### PR TITLE
Provide `Server` interface for providers to implement their language servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,55 @@
+{
+  "name": "@aws-placeholder/aws-language-server-runtimes",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@aws-placeholder/aws-language-server-runtimes",
+      "version": "0.1.0",
+      "dependencies": {
+        "vscode-languageserver": "^8.0.1",
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
+      "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.3"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "dependencies": {
+        "vscode-jsonrpc": "8.1.0",
+        "vscode-languageserver-types": "3.17.3"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@aws-placeholder/aws-language-server-runtimes",
+  "version": "0.1.0",
+  "description": "Runtimes to host AWS Language Servers",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "vscode-languageserver": "^8.0.1",
+    "vscode-languageserver-textdocument": "^1.0.8",
+    "vscode-languageserver-types": "^3.17.3"
+  }
+}

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -1,0 +1,21 @@
+export type IamCredentials = {
+    type: "iam",
+    accessKeyId: string,
+    secretAccessKey: string,
+}
+
+export type BearerCredentials = {
+    type: "bearer",
+    token: string,
+}
+
+export type CredentialsType = "iam" | "bearer"
+export type Credentials = IamCredentials | BearerCredentials
+
+/**
+ * The Auth feature interface. Supports IAM and Bearer credentials.
+ */
+export type Auth = {
+    hasCredentials: (type: CredentialsType) => boolean,
+    getCredentials: (type: CredentialsType) => Credentials | undefined
+}

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,0 +1,6 @@
+export { Auth } from "./auth"
+export { Logging } from "./logging"
+export { Lsp } from "./lsp"
+export { Telemetry } from "./telemetry"
+export { Workspace } from "./workspace"
+

--- a/src/features/logging.ts
+++ b/src/features/logging.ts
@@ -1,0 +1,7 @@
+/**
+ * The logging feature interface
+ */
+export type Logging = {
+    // TODO: Implement log levels
+    log: (message: string) => void,
+}

--- a/src/features/lsp/index.ts
+++ b/src/features/lsp/index.ts
@@ -1,0 +1,10 @@
+import { CancellationToken, CompletionParams, } from 'vscode-languageserver'
+
+import { CompletionList } from 'vscode-languageserver-types'
+import { InlineCompletionParams } from "./inline-completions/futureProtocol"
+import { InlineCompletionList } from './inline-completions/futureTypes'
+
+export type Lsp = {
+    onInlineCompletion: (handler: (params: InlineCompletionParams, token: CancellationToken) => Promise<InlineCompletionList | null | undefined>) => void,
+    onCompletion: (handler: (params: CompletionParams, token: CancellationToken) => Promise<CompletionList | null | undefined>) => void,
+}

--- a/src/features/lsp/inline-completions/futureProtocol.ts
+++ b/src/features/lsp/inline-completions/futureProtocol.ts
@@ -1,0 +1,44 @@
+import {
+    ProtocolRequestType,
+    StaticRegistrationOptions,
+    TextDocumentPositionParams,
+    TextDocumentRegistrationOptions,
+    WorkDoneProgressOptions,
+    WorkDoneProgressParams,
+} from 'vscode-languageserver'
+import { InlineCompletionContext, InlineCompletionItem, InlineCompletionList } from './futureTypes'
+
+/**
+ * Inline completion is not a part of the language server protocol.
+ * It is being proposed at this time (https://github.com/microsoft/language-server-protocol/pull/1673).
+ *
+ * This file contains boilerplate code that goes away if that proposal goes mainline, as
+ * it would be a part of the `vscode-languageserver` package.
+ *
+ * The expectation would be that when inline completion becomes part of the
+ * protocol standard, we have a low-friction transition, since there shouldn't be much drift
+ * between these types, and the final standard's types.
+ */
+
+type InlineCompletionOptions = WorkDoneProgressOptions
+
+type InlineCompletionRegistrationOptions = InlineCompletionOptions &
+    TextDocumentRegistrationOptions &
+    StaticRegistrationOptions
+
+export type InlineCompletionParams = WorkDoneProgressParams &
+    TextDocumentPositionParams & {
+        context: InlineCompletionContext
+    }
+
+/**
+ * inlineCompletionRequestType defines the custom method that the language client
+ * requests from the server to provide inline completion recommendations.
+ */
+export const inlineCompletionRequestType = new ProtocolRequestType<
+    InlineCompletionParams,
+    InlineCompletionList | InlineCompletionItem[] | null,
+    InlineCompletionItem[],
+    void,
+    InlineCompletionRegistrationOptions
+>('aws/textDocument/inlineCompletion')

--- a/src/features/lsp/inline-completions/futureTypes.ts
+++ b/src/features/lsp/inline-completions/futureTypes.ts
@@ -1,0 +1,175 @@
+import { Command } from 'vscode-languageserver'
+import { Range } from 'vscode-languageserver-textdocument'
+
+/**
+ * Inline completion is not a part of the language server protocol.
+ * It is being proposed at this time (https://github.com/microsoft/language-server-protocol/pull/1673).
+ *
+ * This file contains boilerplate code that goes away if that proposal goes mainline, as
+ * it would be a part of the `vscode-languageserver` package.
+ *
+ * The expectation would be that when inline completion becomes part of the
+ * protocol standard, we have a low-friction transition, since there shouldn't be much drift
+ * between these types, and the final standard's types.
+ * 
+ * This file contains types defined as part of the proposal.
+ * They have been copied from https://github.com/microsoft/vscode-languageserver-node/pull/1190
+ * Relating to code copied from the proposal PR... (via https://github.com/microsoft/vscode-languageserver-node/blob/main/License.txt)
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * A string value used as a snippet is a template which allows to insert text
+ * and to control the editor cursor when insertion happens.
+ *
+ * A snippet can define tab stops and placeholders with `$1`, `$2`
+ * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+ * the end of the snippet. Variables are defined with `$name` and
+ * `${name:default value}`.
+ */
+export interface StringValue {
+    /**
+     * The kind of string value.
+     */
+    kind: 'snippet'
+    /**
+     * The snippet string.
+     */
+    value: string
+}
+
+export namespace StringValue {
+    export function create(value: string): StringValue {
+        return { value, kind: 'snippet' }
+    }
+}
+
+/**
+ * An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.
+ */
+export interface InlineCompletionItem {
+    /**
+     * The text to replace the range with. Must be set.
+     */
+    insertText: string | StringValue
+
+    /**
+     * A text that is used to decide if this inline completion should be shown. When `falsy` the {@link InlineCompletionItem.insertText} is used.
+     */
+    filterText?: string
+
+    /**
+     * The range to replace. Must begin and end on the same line.
+     */
+    range?: Range
+
+    /**
+     * An optional {@link Command} that is executed *after* inserting this completion.
+     */
+    command?: Command
+}
+
+export namespace InlineCompletionItem {
+    export function create(
+        insertText: string | StringValue,
+        filterText?: string,
+        range?: Range,
+        command?: Command
+    ): InlineCompletionItem {
+        return { insertText, filterText, range, command }
+    }
+}
+
+/**
+ * Represents a collection of {@link InlineCompletionItem inline completion items} to be presented in the editor.
+ */
+export interface InlineCompletionList {
+    /**
+     * The inline completion items
+     */
+    items: InlineCompletionItem[]
+}
+
+export namespace InlineCompletionList {
+    export function create(items: InlineCompletionItem[]): InlineCompletionList {
+        return { items }
+    }
+}
+
+/**
+ * Describes how an {@link InlineCompletionItemProvider inline completion provider} was triggered.
+ */
+export namespace InlineCompletionTriggerKind {
+    /**
+     * Completion was triggered explicitly by a user gesture.
+     */
+    export const Invoked: 0 = 0
+
+    /**
+     * Completion was triggered automatically while editing.
+     */
+    export const Automatic: 1 = 1
+}
+
+export type InlineCompletionTriggerKind = 0 | 1
+
+/**
+ * Describes the currently selected completion item.
+ */
+export interface SelectedCompletionInfo {
+    /**
+     * The range that will be replaced if this completion item is accepted.
+     */
+    range: Range
+
+    /**
+     * The text the range will be replaced with if this completion is accepted.
+     */
+    text: string
+}
+
+export namespace SelectedCompletionInfo {
+    export function create(range: Range, text: string): SelectedCompletionInfo {
+        return { range, text }
+    }
+}
+
+/**
+ * Provides information about the context in which an inline completion was requested.
+ */
+export interface InlineCompletionContext {
+    /**
+     * Describes how the inline completion was triggered.
+     */
+    triggerKind: InlineCompletionTriggerKind
+
+    /**
+     * Provides information about the currently selected item in the autocomplete widget if it is visible.
+     */
+    selectedCompletionInfo?: SelectedCompletionInfo
+}
+
+export namespace InlineCompletionContext {
+    export function create(
+        triggerKind: InlineCompletionTriggerKind,
+        selectedCompletionInfo?: SelectedCompletionInfo
+    ): InlineCompletionContext {
+        return { triggerKind, selectedCompletionInfo }
+    }
+}

--- a/src/features/telemetry.ts
+++ b/src/features/telemetry.ts
@@ -1,0 +1,16 @@
+// TODO: implement the richer Metric type to support more complex values and dimensions
+export type Metric = {
+    name: string,
+    value: number,
+}
+
+export const metric = (name: string, value: number): Metric => ({ name, value })
+
+/**
+ * The telemetry feature interface.
+ * 
+ * TODO: define the {Metric} type.
+ */
+export type Telemetry = {
+    emit: (metric: Metric) => void
+}

--- a/src/features/workspace.ts
+++ b/src/features/workspace.ts
@@ -1,0 +1,11 @@
+import { TextDocument } from 'vscode-languageserver-textdocument'
+
+/**
+ * The Workspace feature interface. Provides access to currently
+ * open files in the workspace. May not provide full filesystem
+ * access to files that are not currently open or outside the 
+ * workspace root.
+ */
+export type Workspace = {
+    getTextDocument: (uri: string) => Promise<TextDocument | undefined>
+}

--- a/src/runtimes/index.ts
+++ b/src/runtimes/index.ts
@@ -1,0 +1,3 @@
+export { Server } from './server'
+export { standalone } from './standalone'
+

--- a/src/runtimes/server.ts
+++ b/src/runtimes/server.ts
@@ -1,0 +1,18 @@
+import { Auth, Logging, Lsp, Telemetry, Workspace } from '../features'
+
+/**
+ * Servers are used to provide features to the client.
+ * 
+ * Servers can make use of the {Auth}, {Lsp}, {Workspace}, {Logging} and {Telemetry} features
+ * to implement their functionality. Servers are notexpected to perform actions when their method
+ * is called, but instead to set up listeners, event handlers, etc to handle.
+ * 
+ * {Auth}}, {Lsp}, and {Workspace} features may be initialized asynchronously, and can be empty until initialization
+ * is completed and the client or user provides the necessary information. It's up to Server implementations to
+ * either wait for the content to become available, or to gracefully handle cases where content is not yet available.
+ * 
+ * The main use case for Servers is to listen to {Lsp} events and respond to these appropriately.
+ * 
+ * @returns A function that will be called when the client exits, used to dispose of any held resources. 
+ */
+export type Server = (features: { auth: Auth, lsp: Lsp, workspace: Workspace, logging: Logging, telemetry: Telemetry }) => () => void

--- a/src/runtimes/standalone.ts
+++ b/src/runtimes/standalone.ts
@@ -1,0 +1,136 @@
+import { InitializeParams, TextDocumentSyncKind, TextDocuments } from "vscode-languageserver"
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
+import { Auth, Logging, Lsp, Telemetry, Workspace } from '../features'
+import { inlineCompletionRequestType } from "../features/lsp/inline-completions/futureProtocol"
+import { metric } from '../features/telemetry'
+import { Server } from './server'
+
+type Handler<A = any[], B = any> = (...args: A extends any[] ? A : [A]) => B
+type HandlerWrapper<H extends Handler, A extends Parameters<H>, B extends ReturnType<H>> = (name: string, handler: H) => (...args: A) => B
+
+// Instruments a handler to emit telemetry without changing its signature. Supports async handlers.
+// Tracks timing between invocation and completion of the handler, and emits a failure count (either 0 or 1)
+// depending on whether the handler threw an error or not.
+const withTelemetry = <H extends Handler, A extends Parameters<H>, B extends ReturnType<H>>(telemetry: Telemetry) => (name: string, handler: H) => (...args: A): B => {
+    const startTime = new Date().valueOf()
+    const result = handler(...args)
+    Promise.resolve(result)
+        .finally(() => telemetry.emit(metric(`${name}Time`, new Date().valueOf() - startTime)))
+        .then(() => telemetry.emit(metric(`${name}Error`, 0)))
+        .catch(() => telemetry.emit(metric(`${name}Error`, 1)))
+    return result
+}
+
+// Instruments a handler to emit logging on invocation without changing its signature.
+const withLogging = <H extends Handler, A extends Parameters<H>, B extends ReturnType<H>>(logging: Logging) => (name: string, handler: H) => (...args: A): B => {
+    logging.log(`[${name}] was called`)
+    return handler(...args)
+}
+
+/**
+ * The runtime for standalone LSP-based servers.
+ * 
+ * Initializes one or more Servers with the following features:
+ * - Auth: No-op auth
+ * - LSP: Initializes a connection based on STDIN / STDOUT
+ * - Logging: logs messages through the LSP connection
+ * - Telemetry: emits telemetry through the LSP connection
+ * - Workspace: tracks open and closed files from the LSP connection
+ * 
+ * By instantiating features inside the runtime we can tree-shake features or
+ * variants of features in cases where they are not used.
+ * 
+ * E.g., we can have separate implementations for a standalone and web
+ * without increasing the bundle size for either. We can also depend on
+ * platform specific features like STDIN/STDOUT that might not be available
+ * in other runtimes.
+ * 
+ * As features are implemented, e.g., Auth or Telemetry, they will be supported
+ * by each runtime.
+ * 
+ * @param servers The list of servers to initialize and run
+ * @returns 
+ */
+export const standalone = (...servers: Server[]) => {
+    const lspConnection = createConnection(ProposedFeatures.all)
+    const documents = new TextDocuments(TextDocument)
+
+    // Initialize the LSP connection based on the supported LSP capabilities
+    // TODO: make this dependent on the actual requirements of the
+    // servers parameter.
+    lspConnection.onInitialize((params: InitializeParams) => {
+        return {
+            serverInfo: {
+                // TODO: make this configurable
+                name: "AWS LSP Standalone",
+                // This indicates the standalone server version and is updated
+                // every time the standalone or any of the servers update.
+                // Major version updates only happen when the supported LSP
+                // protocol version changes and is not backwards compatible.
+                // TODO: Set this at build time to match the above description
+                version: "0.1",
+            },
+            capabilities: {
+                textDocumentSync: {
+                    openClose: true,
+                    change: TextDocumentSyncKind.Incremental,
+                },
+                completionProvider: {
+                    resolveProvider: true,
+                    completionItem: {
+                        labelDetailsSupport: true,
+                    },
+                },
+            },
+        }
+    })
+
+    // Set up logigng over LSP
+    // TODO: set up Logging once implemented
+    const logging: Logging = {
+        log: message => lspConnection.console.info(`[${new Date().toISOString()}] ${message}`)
+    }
+
+    // Set up telemetry over LSP
+    // TODO: set up Telemetry once implemented
+    const telemetry: Telemetry = {
+        emit: metric => lspConnection.telemetry.logEvent(metric)
+    }
+
+    // TODO: This can probably be cleaned up a bit more.
+    // This type ensures that the signature of the handler function does not change, even if we instrument it with telemetry or logging
+    const withLspTelemetry: <H extends Handler, A extends Parameters<H>, B extends ReturnType<H>>(name: string, handler: H) => (...args: A) => B = withTelemetry(telemetry)
+    const withLspLogging: <H extends Handler, A extends Parameters<H>, B extends ReturnType<H>>(name: string, handler: H) => (...args: A) => B = withLogging(logging)
+    const instrument: <H extends Handler, A extends Parameters<H>, B extends ReturnType<H>>(name: string, handler: H) => (...args: A) => B = (name: string, handler: any) => withLspLogging(name, withLspTelemetry(name, handler))
+
+    // Set up the workspace sync to use the LSP Text Document Sync capability
+    const workspace: Workspace = {
+        getTextDocument: instrument("getTextDocument", async uri => documents.get(uri))
+    }
+
+    // Map the instrumented LSP client to the LSP feature.
+    const lsp: Lsp = {
+        onCompletion: handler => lspConnection.onCompletion(instrument("onCompletion", handler)),
+        onInlineCompletion: handler => lspConnection.onRequest(inlineCompletionRequestType, instrument("onInlineCompletion", handler))
+    }
+
+    // Set up no-op Auth
+    // TODO: set up Auth once implemented
+    const auth: Auth = {
+        hasCredentials: () => false,
+        getCredentials: () => undefined,
+    }
+
+    // Initialize every Server
+    const disposables = servers.map(s => s({ auth, lsp, workspace, telemetry, logging }))
+
+    // Free up any resources or threads used by Servers
+    lspConnection.onExit(() => {
+        disposables.forEach(d => d())
+    })
+
+    // Initialize the documents listener and start the LSP connection
+    documents.listen(lspConnection)
+    lspConnection.listen()
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change provides the `Server` interface through which language server providers can host their language server in one or more runtimes. The `Server` interface exposes a numbe of features, including `LSP` and `Auth`, to be used in language servers. This allows a portable, reusable interface for common operations and interactions that can be hosted in a number of different runtimes, tools, and environments.

The `standalone` runtime is provided as an initial and incomplete implementation. It will be expanded on as future features become available. Likewise, some features like LSP and Telemetry will be expand in future revisions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
