### PR TITLE
refactor: update LSP types to use `vscode-languageserver-protocol`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "jose": "^4.14.4",
         "prettier": "^3.0.3",
         "vscode-languageserver": "^8.0.1",
+        "vscode-languageserver-protocol": "^3.17.3",
         "vscode-languageserver-textdocument": "^1.0.8",
         "vscode-languageserver-types": "^3.17.3"
       },
@@ -1638,9 +1639,9 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1657,12 +1658,12 @@
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "dependencies": {
-        "vscode-jsonrpc": "8.1.0",
-        "vscode-languageserver-types": "3.17.3"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -1671,6 +1672,28 @@
       "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
     },
     "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "dependencies": {
+        "vscode-jsonrpc": "8.1.0",
+        "vscode-languageserver-types": "3.17.3"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-types": {
       "version": "3.17.3",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
       "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prettier": "^3.0.3",
     "vscode-languageserver": "^8.0.1",
     "vscode-languageserver-textdocument": "^1.0.8",
-    "vscode-languageserver-types": "^3.17.3"
+    "vscode-languageserver-types": "^3.17.3",
+    "vscode-languageserver-protocol": "^3.17.3"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",

--- a/src/features/lsp/index.ts
+++ b/src/features/lsp/index.ts
@@ -1,20 +1,16 @@
-import { CancellationToken, CompletionParams } from "vscode-languageserver";
-
-import { CompletionList } from "vscode-languageserver-types";
+import { CompletionParams, CompletionList, RequestHandler, CompletionItem } from "vscode-languageserver-protocol";
 import { InlineCompletionParams } from "./inline-completions/futureProtocol";
-import { InlineCompletionList } from "./inline-completions/futureTypes";
+import { InlineCompletionItem, InlineCompletionList } from "./inline-completions/futureTypes";
 
+// Using `RequestHandler` here from `vscode-languageserver-protocol` which doesn't support partial progress.
+// If we want to support partial progress, we'll need to use `ServerRequestHandler` from `vscode-languageserver` instead.
+// but if we can avoid exposing multiple different `vscode-languageserver-*` packages and package versions to
+// implementors that would prevent potentially very hard to debug type mismatch errors (even on minor versions).
 export type Lsp = {
   onInlineCompletion: (
-    handler: (
-      params: InlineCompletionParams,
-      token: CancellationToken,
-    ) => Promise<InlineCompletionList | null | undefined>,
+    handler: RequestHandler<InlineCompletionParams, InlineCompletionItem[] | InlineCompletionList | undefined | null, void>,
   ) => void;
   onCompletion: (
-    handler: (
-      params: CompletionParams,
-      token: CancellationToken,
-    ) => Promise<CompletionList | null | undefined>,
+    handler: RequestHandler<CompletionParams, CompletionItem[] | CompletionList | undefined | null, void>
   ) => void;
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
