### PR TITLE
Removing parsing version argument from webworker runtime

### DIFF
--- a/src/runtimes/webworker.ts
+++ b/src/runtimes/webworker.ts
@@ -11,16 +11,13 @@ import {
 } from "vscode-languageserver/browser";
 import { Logging, Lsp, Telemetry, Workspace } from "../features";
 import { inlineCompletionRequestType } from "../features/lsp/inline-completions/futureProtocol";
-import { Server } from "./server";
 import { Auth } from "../features/auth/auth";
-import { handleVersionArgument } from "../features/versioning";
 import { RuntimeProps } from "./runtime";
 
 declare const self: WindowOrWorkerGlobalScope;
 
 // TODO: testing rig for runtimes
 export const webworker = (props: RuntimeProps) => {
-  handleVersionArgument(props.version);
 
   const lspConnection = createConnection(
     new BrowserMessageReader(self),


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-language-server-runtimes/issues/13
*Description of changes:*
Removing parsing of version argument from webworker runtime

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
