### PR TITLE
Remove completion capability from init response

### DIFF
--- a/src/runtimes/standalone.ts
+++ b/src/runtimes/standalone.ts
@@ -147,12 +147,6 @@ export const standalone = (props: RuntimeProps) => {
             openClose: true,
             change: TextDocumentSyncKind.Incremental,
           },
-          completionProvider: {
-            resolveProvider: true,
-            completionItem: {
-              labelDetailsSupport: true,
-            },
-          },
         },
       };
     });

--- a/src/runtimes/webworker.ts
+++ b/src/runtimes/webworker.ts
@@ -47,12 +47,6 @@ export const webworker = (props: RuntimeProps) => {
           openClose: true,
           change: TextDocumentSyncKind.Incremental,
         },
-        completionProvider: {
-          resolveProvider: true,
-          completionItem: {
-            labelDetailsSupport: true,
-          },
-        },
       },
     };
   });


### PR DESCRIPTION
*Description of changes:*
Neither runtimes nor existing capabilities support onCompletion lsp method. 
Removing it from the initialisation response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
