### PR TITLE
Add Telemetry LSP specification in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,18 +82,20 @@ Changelog:
 The runtimes by default supports the telemetry feature, allowing servers to send metrics to destinations. Additional option to disable this feature during initialization as well as during an ongoing session is currently in plan.
 
 #### Feature Specification
-The shape of the data in metrics is arbitrary allowing servers to provide any information inside the `data` field. All fields and the `name` value are expected to be written in `camelCase`.
+The telemetry notification is sent from the server to the client to ask the client to log a telemetry event. AWS Runtimes using Telemetry feature will send metric events with default LSP telemetry notification with specified payload interface. Telemetry notifications are specified as follow:
+
+| Description |	Method | Params | Method type | Response Type |
+| ----------- | ------ | ------ | ----------- | ------------- |
+| Send telemetry event | `telemetry/event` | `MetricEvent` | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) | n/a |
 
 ```ts
-export const metric = (
-  name: string,
-  data?: any,
-): MetricEvent => ({
-  name,
-  data,
-});
+export type MetricEvent = {
+    name: string;
+    data?: any;
+    result?: ResultType;
+    errorData?: ErrorData;
+};
 ```
-
 
 ### Logging
 


### PR DESCRIPTION
Updated Telemetry features LSP specification in README


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
