### PR TITLE
Fix method name mix-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The server runtime implementation acts as a proxy for LSP methods, which means i
 ##### LSP Extensions
 | Method Name | Method | Params | Method Type | Response Type | Notes |
 | ------------| ------ | ------ | ----------- | ------------- | ----- |
-| onInlineCompletionWithReferences | `$/aws/logInlineCompelitionSessionResults` | `InlineCompletionWithReferencesParams` | [Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage) | `InlineCompletionListWithReferences` | Provides list of inline completion suggestions from the Server with references for each of its suggestion |
-| onLogInlineCompelitionSessionResults | `$/aws/textDocument/inlineCompletionWithReferences` | `LogInlineCompelitionSessionResultsParams` | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) | n/a | Logs the results from inline completion suggestions from the Server |
+| onInlineCompletionWithReferences | `aws/textDocument/inlineCompletionWithReferences` | `InlineCompletionWithReferencesParams` | [Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage) | `InlineCompletionListWithReferences` | Provides list of inline completion suggestions from the Server with references for each of its suggestion |
+| onLogInlineCompelitionSessionResults | `aws/logInlineCompelitionSessionResults` | `LogInlineCompelitionSessionResultsParams` | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) | n/a | Logs the results from inline completion suggestions from the Server |
 
 ### Auth
 


### PR DESCRIPTION
*Description of changes:*
Fix mix-ups in the readme for extension methods

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
