### PR TITLE
feat: add multi-listener document events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "jose": "^4.14.4",
         "prettier": "^3.0.3",
+        "rxjs": "^7.8.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11"
       },
@@ -1300,6 +1301,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1649,6 +1658,11 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "jose": "^4.14.4",
     "prettier": "^3.0.3",
+    "rxjs": "^7.8.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.11"
   },

--- a/src/features/lsp/index.ts
+++ b/src/features/lsp/index.ts
@@ -3,6 +3,8 @@ import {
   CompletionList,
   CompletionParams,
   DidChangeConfigurationParams,
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
   InitializedParams,
   InlineCompletionItem,
   InlineCompletionList,
@@ -15,6 +17,8 @@ import {
   InlineCompletionListWithReferences,
   LogInlineCompelitionSessionResultsParams,
 } from "./inline-completions/protocolExtensions";
+
+export { observe } from "./textDocuments/textDocumentConnection";
 
 // Using `RequestHandler` here from `vscode-languageserver-protocol` which doesn't support partial progress.
 // If we want to support partial progress, we'll need to use `ServerRequestHandler` from `vscode-languageserver` instead.
@@ -38,6 +42,12 @@ export type Lsp = {
   ) => void;
   didChangeConfiguration: (
     handler: NotificationHandler<DidChangeConfigurationParams>,
+  ) => void;
+  onDidChangeTextDocument: (
+    handler: NotificationHandler<DidChangeTextDocumentParams>,
+  ) => void;
+  onDidCloseTextDocument: (
+    handler: NotificationHandler<DidCloseTextDocumentParams>,
   ) => void;
   workspace: {
     getConfiguration: (section: string) => Promise<any>;

--- a/src/features/lsp/textDocuments/textDocumentConnection.test.ts
+++ b/src/features/lsp/textDocuments/textDocumentConnection.test.ts
@@ -1,0 +1,157 @@
+import assert from "assert";
+import {
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenTextDocumentParams,
+  DidSaveTextDocumentParams,
+  NotificationHandler,
+  WillSaveTextDocumentParams,
+} from "vscode-languageserver";
+import { TextDocumentConnection } from "vscode-languageserver/lib/common/textDocuments";
+import { observe } from "./textDocumentConnection";
+
+const handlers = {
+  onDidOpenTextDocument: undefined as NotificationHandler<any> | undefined,
+  onDidChangeTextDocument: undefined as NotificationHandler<any> | undefined,
+  onDidCloseTextDocument: undefined as NotificationHandler<any> | undefined,
+  onWillSaveTextDocument: undefined as NotificationHandler<any> | undefined,
+  onDidSaveTextDocument: undefined as NotificationHandler<any> | undefined,
+};
+
+const testConnection: TextDocumentConnection = {
+  onDidOpenTextDocument: (
+    handler: NotificationHandler<DidOpenTextDocumentParams>,
+  ) => {
+    handlers.onDidOpenTextDocument = handler;
+    return { dispose: () => {} };
+  },
+  onDidChangeTextDocument: (
+    handler: NotificationHandler<DidChangeTextDocumentParams>,
+  ) => {
+    handlers.onDidChangeTextDocument = handler;
+    return { dispose: () => {} };
+  },
+  onDidCloseTextDocument: (
+    handler: NotificationHandler<DidCloseTextDocumentParams>,
+  ) => {
+    handlers.onDidCloseTextDocument = handler;
+    return { dispose: () => {} };
+  },
+  onWillSaveTextDocument: (
+    handler: NotificationHandler<WillSaveTextDocumentParams>,
+  ) => {
+    handlers.onWillSaveTextDocument = handler;
+    return { dispose: () => {} };
+  },
+  onDidSaveTextDocument: (
+    handler: NotificationHandler<DidSaveTextDocumentParams>,
+  ) => {
+    handlers.onDidSaveTextDocument = handler;
+    return { dispose: () => {} };
+  },
+  onWillSaveTextDocumentWaitUntil: () => ({ dispose: () => {} }),
+};
+
+describe("TextDocumentConnection", () => {
+  let calledFirst = false;
+  let calledSecond = false;
+  beforeEach(() => {
+    calledFirst = false;
+    calledSecond = false;
+
+    Object.keys(handlers).forEach(
+      (k) => (handlers[k as keyof typeof handlers] = undefined),
+    );
+  });
+
+  describe("without observable (baseline)", () => {
+    Object.keys(handlers).forEach((key) => {
+      it(key + " only supports the last callback", () => {
+        testConnection[key as keyof typeof handlers](() => {
+          calledFirst = true;
+        });
+        testConnection[key as keyof typeof handlers](
+          () => (calledSecond = true),
+        );
+
+        handlers[key as keyof typeof handlers]!({});
+
+        assert.equal(calledFirst, false);
+        assert.equal(calledSecond, true);
+      });
+    });
+  });
+
+  describe("with observable", () => {
+    Object.keys(handlers).forEach((key) => {
+      let observableConnection: ReturnType<typeof observe>;
+
+      beforeEach(async () => {
+        observableConnection = observe(testConnection);
+      });
+
+      it(key + " supports multiple subscriptions", () => {
+        observableConnection[key as keyof typeof handlers].subscribe(() => {
+          calledFirst = true;
+        });
+        observableConnection[key as keyof typeof handlers].subscribe(
+          () => (calledSecond = true),
+        );
+
+        handlers[key as keyof typeof handlers]!({});
+
+        assert.equal(calledFirst, true);
+        assert.equal(calledSecond, true);
+      });
+
+      it(key + " supports unsubscribe and resubscribe", () => {
+        const sub = observableConnection[
+          key as keyof typeof handlers
+        ].subscribe(() => {
+          calledFirst = true;
+        });
+        sub.unsubscribe();
+        observableConnection[key as keyof typeof handlers].subscribe(
+          () => (calledSecond = true),
+        );
+
+        handlers[key as keyof typeof handlers]!({});
+
+        assert.equal(calledFirst, false);
+        assert.equal(calledSecond, true);
+      });
+
+      it(key + " supports callbacks", () => {
+        observableConnection.callbacks[key as keyof typeof handlers](() => {
+          calledFirst = true;
+        });
+        observableConnection.callbacks[key as keyof typeof handlers](() => {
+          calledSecond = true;
+        });
+
+        handlers[key as keyof typeof handlers]!({});
+
+        assert.equal(calledFirst, true);
+        assert.equal(calledSecond, true);
+      });
+
+      it(key + " supports callback dispose", () => {
+        const disposable = observableConnection.callbacks[
+          key as keyof typeof handlers
+        ](() => {
+          calledFirst = true;
+        });
+        observableConnection.callbacks[key as keyof typeof handlers](() => {
+          calledSecond = true;
+        });
+
+        disposable.dispose();
+
+        handlers[key as keyof typeof handlers]!({});
+
+        assert.equal(calledFirst, false);
+        assert.equal(calledSecond, true);
+      });
+    });
+  });
+});

--- a/src/features/lsp/textDocuments/textDocumentConnection.ts
+++ b/src/features/lsp/textDocuments/textDocumentConnection.ts
@@ -1,0 +1,114 @@
+import { Observable, fromEventPattern, share } from "rxjs";
+import {
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenTextDocumentParams,
+  DidSaveTextDocumentParams,
+  NotificationHandler,
+  RequestHandler,
+  TextEdit,
+  WillSaveTextDocumentParams,
+} from "vscode-languageserver";
+import { TextDocumentConnection } from "vscode-languageserver/lib/common/textDocuments";
+
+// Filter out only the handlers that return void to avoid the request/response format,
+// which would not support multiple handlers since it requires disambiguating the handler
+// responsible for responding.
+type TextDocumentNotifications = {
+  [key in keyof TextDocumentConnection]: ReturnType<
+    Parameters<TextDocumentConnection[key]>[0]
+  > extends void
+    ? key
+    : never;
+}[keyof TextDocumentConnection];
+
+type TextDocumentObservable = {
+  [key in TextDocumentNotifications]: Observable<
+    Parameters<Parameters<TextDocumentConnection[key]>[0]>[0]
+  >;
+};
+
+/**
+ * Wrap a standard LSP {TextDocumentConnection}, that only supports a single callback for each operation,
+ * with observables for each operation.
+ *
+ * This is useful for integrating mutliple Servers that each want to handle events one or more times. The {Observable}
+ * interface allows for low-level control of subscrive, resubscribe, and notification handling. The callback interface
+ * mimics the {TextDocumentConnection}, but does not overwrite each callback with the next.
+ *
+ * **Note:** {onWillSaveTextDocumentWaitUntil} will NOT support multiple handlers. The last registrered is the one
+ * providing the return value. This is due to multiple handlers would have to disabiguate which one gets to
+ * return the actual response, without some sort of smart merging of the desired edits.
+ *
+ * @param connection A {TextDocumentConnection} to wrap with observables
+ * @returns A wrapper around the {TextDocumentConnection} providing both a callback and an observable interface
+ */
+export const observe = (
+  connection: TextDocumentConnection,
+): { callbacks: TextDocumentConnection } & TextDocumentObservable => {
+  const onDidChangeTextDocument = fromEventPattern<DidChangeTextDocumentParams>(
+    connection.onDidChangeTextDocument,
+  ).pipe(share());
+  const onDidOpenTextDocument = fromEventPattern<DidOpenTextDocumentParams>(
+    connection.onDidOpenTextDocument,
+  ).pipe(share());
+  const onDidCloseTextDocument = fromEventPattern<DidCloseTextDocumentParams>(
+    connection.onDidCloseTextDocument,
+  ).pipe(share());
+  const onWillSaveTextDocument = fromEventPattern<WillSaveTextDocumentParams>(
+    connection.onWillSaveTextDocument,
+  ).pipe(share());
+  const onDidSaveTextDocument = fromEventPattern<DidSaveTextDocumentParams>(
+    connection.onDidSaveTextDocument,
+  ).pipe(share());
+
+  return {
+    callbacks: {
+      onDidChangeTextDocument: (
+        handler: NotificationHandler<DidChangeTextDocumentParams>,
+      ) => {
+        const subscription = onDidChangeTextDocument.subscribe(handler);
+        return { dispose: () => subscription.unsubscribe() };
+      },
+      onDidOpenTextDocument: (
+        handler: NotificationHandler<DidOpenTextDocumentParams>,
+      ) => {
+        const subscription = onDidOpenTextDocument.subscribe(handler);
+        return { dispose: () => subscription.unsubscribe() };
+      },
+      onDidCloseTextDocument: (
+        handler: NotificationHandler<DidCloseTextDocumentParams>,
+      ) => {
+        const subscription = onDidCloseTextDocument.subscribe(handler);
+        return { dispose: () => subscription.unsubscribe() };
+      },
+      onWillSaveTextDocument: (
+        handler: NotificationHandler<WillSaveTextDocumentParams>,
+      ) => {
+        const subscription = onWillSaveTextDocument.subscribe(handler);
+        return { dispose: () => subscription.unsubscribe() };
+      },
+      onDidSaveTextDocument: (
+        handler: NotificationHandler<DidSaveTextDocumentParams>,
+      ) => {
+        const subscription = onDidSaveTextDocument.subscribe(handler);
+        return { dispose: () => subscription.unsubscribe() };
+      },
+      onWillSaveTextDocumentWaitUntil: (
+        handler: RequestHandler<
+          WillSaveTextDocumentParams,
+          TextEdit[] | undefined | null,
+          void
+        >,
+      ) => {
+        return connection.onWillSaveTextDocumentWaitUntil(handler);
+      },
+    },
+
+    onDidChangeTextDocument,
+    onDidOpenTextDocument,
+    onDidCloseTextDocument,
+    onWillSaveTextDocument,
+    onDidSaveTextDocument,
+  };
+};


### PR DESCRIPTION
Adding a callback to the LSP Connection overwrites the previous one. This change replaces the callbacks with subscribers, allowing multiple listeners to attach and detach without influencing each other.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
