### PR TITLE
Fix typos for logInlineCompletionSessionResults method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The server runtime implementation acts as a proxy for LSP methods, which means i
 | Method Name | Method | Params | Method Type | Response Type | Notes |
 | ------------| ------ | ------ | ----------- | ------------- | ----- |
 | onInlineCompletionWithReferences | `aws/textDocument/inlineCompletionWithReferences` | `InlineCompletionWithReferencesParams` | [Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage) | `InlineCompletionListWithReferences` | Provides list of inline completion suggestions from the Server with references for each of its suggestion |
-| onLogInlineCompelitionSessionResults | `aws/logInlineCompelitionSessionResults` | `LogInlineCompelitionSessionResultsParams` | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) | n/a | Logs the results from inline completion suggestions from the Server |
+| onLogInlineCompletionSessionResults | `aws/logInlineCompletionSessionResults` | `LogInlineCompletionSessionResultsParams` | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) | n/a | Logs the results from inline completion suggestions from the Server |
 
 ### Auth
 

--- a/src/features/lsp/index.ts
+++ b/src/features/lsp/index.ts
@@ -15,7 +15,7 @@ import {
 import {
   InlineCompletionItemWithReferences,
   InlineCompletionListWithReferences,
-  LogInlineCompelitionSessionResultsParams,
+  LogInlineCompletionSessionResultsParams,
 } from "./inline-completions/protocolExtensions";
 
 export { observe } from "./textDocuments/textDocumentConnection";
@@ -63,8 +63,8 @@ export type Lsp = {
         void
       >,
     ) => void;
-    onLogInlineCompelitionSessionResults: (
-      handler: NotificationHandler<LogInlineCompelitionSessionResultsParams>,
+    onLogInlineCompletionSessionResults: (
+      handler: NotificationHandler<LogInlineCompletionSessionResultsParams>,
     ) => void;
   };
 };

--- a/src/features/lsp/inline-completions/protocolExtensions.ts
+++ b/src/features/lsp/inline-completions/protocolExtensions.ts
@@ -73,7 +73,7 @@ export interface InlineCompletionStates {
   discarded: boolean;
 }
 
-export interface LogInlineCompelitionSessionResultsParams {
+export interface LogInlineCompletionSessionResultsParams {
   /**
    * Session Id attached to get completion items response.
    * This value must match to the one that server returned in InlineCompletionListWithReferences response.
@@ -96,7 +96,7 @@ export interface LogInlineCompelitionSessionResultsParams {
   totalSessionDisplayTime?: number;
 }
 
-export const logInlineCompelitionSessionResultsNotificationType =
-  new ProtocolNotificationType<LogInlineCompelitionSessionResultsParams, void>(
-    "aws/logInlineCompelitionSessionResults",
+export const logInlineCompletionSessionResultsNotificationType =
+  new ProtocolNotificationType<LogInlineCompletionSessionResultsParams, void>(
+    "aws/logInlineCompletionSessionResults",
   );

--- a/src/runtimes/standalone.ts
+++ b/src/runtimes/standalone.ts
@@ -22,7 +22,7 @@ import { RuntimeProps } from "./runtime";
 
 import {
   inlineCompletionWithReferencesRequestType,
-  logInlineCompelitionSessionResultsNotificationType,
+  logInlineCompletionSessionResultsNotificationType,
 } from "../features/lsp/inline-completions/protocolExtensions";
 import { observe } from "../features/lsp/textDocuments/textDocumentConnection";
 
@@ -252,10 +252,10 @@ export const standalone = (props: RuntimeProps) => {
             inlineCompletionWithReferencesRequestType,
             instrument("onInlineCompletionWithReferences", handler),
           ),
-        onLogInlineCompelitionSessionResults: (handler) => {
+        onLogInlineCompletionSessionResults: (handler) => {
           lspConnection.onNotification(
-            logInlineCompelitionSessionResultsNotificationType,
-            instrument("onLogInlineCompelitionSessionResults", handler),
+            logInlineCompletionSessionResultsNotificationType,
+            instrument("onLogInlineCompletionSessionResults", handler),
           );
         },
       },

--- a/src/runtimes/webworker.ts
+++ b/src/runtimes/webworker.ts
@@ -17,7 +17,7 @@ import { Auth } from "../features/auth/auth";
 import { RuntimeProps } from "./runtime";
 import {
   inlineCompletionWithReferencesRequestType,
-  logInlineCompelitionSessionResultsNotificationType,
+  logInlineCompletionSessionResultsNotificationType,
 } from "../features/lsp/inline-completions/protocolExtensions";
 import { observe } from "../features/lsp";
 
@@ -109,9 +109,9 @@ export const webworker = (props: RuntimeProps) => {
           inlineCompletionWithReferencesRequestType,
           handler,
         ),
-      onLogInlineCompelitionSessionResults: (handler) => {
+      onLogInlineCompletionSessionResults: (handler) => {
         lspConnection.onNotification(
-          logInlineCompelitionSessionResultsNotificationType,
+          logInlineCompletionSessionResultsNotificationType,
           handler,
         );
       },


### PR DESCRIPTION
*Description of changes:*
Fix typos for logInlineCompletionSessionResults method
- Method name
- Parameter name
- README

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
