### PR TITLE
Pin prettier to 3.0.3 and move to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "jose": "^4.14.4",
-        "prettier": "^3.0.3",
         "rxjs": "^7.8.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11"
@@ -18,6 +17,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^20.5.9",
         "assert": "^2.0.0",
+        "prettier": "3.0.3",
         "sinon": "^15.1.0",
         "ts-mocha": "^10.0.0",
         "ts-sinon": "^2.0.2",
@@ -1258,6 +1258,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
       "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "jose": "^4.14.4",
-    "prettier": "^3.0.3",
     "rxjs": "^7.8.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.11"
@@ -22,6 +21,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.5.9",
     "assert": "^2.0.0",
+    "prettier": "3.0.3",
     "sinon": "^15.1.0",
     "ts-mocha": "^10.0.0",
     "ts-sinon": "^2.0.2",


### PR DESCRIPTION
*Description of changes:*
Temporarily pinned prettier dependency to 3.0.3 and moved to dev dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
