### PR TITLE
Extend LogInlineCompletionSessionResult method

### DIFF
--- a/src/features/lsp/inline-completions/protocolExtensions.ts
+++ b/src/features/lsp/inline-completions/protocolExtensions.ts
@@ -94,6 +94,10 @@ export interface LogInlineCompletionSessionResultsParams {
    * Total time when items from this completion session were visible in UI
    */
   totalSessionDisplayTime?: number;
+  /**
+   * Length of additional characters inputed by user from when the trigger happens to when the user decision was made
+   */
+  typeaheadLength?: number;
 }
 
 export const logInlineCompletionSessionResultsNotificationType =


### PR DESCRIPTION
*Description of changes:*
Extend the method to include `typeaheadLength` parameter 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
