### PR TITLE
Add git secrets scan as pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+git secrets --register-aws || (echo 'Please install git-secrets https://github.com/awslabs/git-secrets to check for accidentally commited secrets!' && exit 1)
+git secrets --scan

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^20.5.9",
         "assert": "^2.0.0",
+        "husky": "^8.0.3",
         "prettier": "3.0.3",
         "sinon": "^15.1.0",
         "ts-mocha": "^10.0.0",
@@ -755,6 +756,21 @@
       "peer": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/inflight": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test:unit": "ts-mocha -b 'src/**/*.test.ts'",
     "test:prettier": "prettier . --check",
     "test": "npm run test:prettier && npm run test:unit",
-    "fix:prettier": "prettier . --write"
+    "fix:prettier": "prettier . --write",
+    "prepare": "husky install"
   },
   "dependencies": {
     "jose": "^4.14.4",
@@ -21,6 +22,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.5.9",
     "assert": "^2.0.0",
+    "husky": "^8.0.3",
     "prettier": "3.0.3",
     "sinon": "^15.1.0",
     "ts-mocha": "^10.0.0",


### PR DESCRIPTION
## Problem
We have no mechanism to protect ourselves from leaking secrets 

## Solution
Install git secrets as pre-commit hook

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
