### PR TITLE
Extend server interface

### DIFF
--- a/src/runtimes/server.ts
+++ b/src/runtimes/server.ts
@@ -21,10 +21,14 @@ import {
  *
  * @returns A function that will be called when the client exits, used to dispose of any held resources.
  */
-export type Server = (features: {
-  credentialsProvider: CredentialsProvider;
-  lsp: Lsp;
-  workspace: Workspace;
-  logging: Logging;
-  telemetry: Telemetry;
-}) => () => void;
+export type Server = {
+  serverName: string;
+  customCapabilities: object;
+  (features: {
+    credentialsProvider: CredentialsProvider;
+    lsp: Lsp;
+    workspace: Workspace;
+    logging: Logging;
+    telemetry: Telemetry;
+  }): () => void;
+};

--- a/src/runtimes/webworker.ts
+++ b/src/runtimes/webworker.ts
@@ -37,6 +37,13 @@ export const webworker = (props: RuntimeProps) => {
   // Initialize the LSP connection based on the supported LSP capabilities
   // TODO: make this dependent on the actual requirements of the
   // servers parameter.
+
+  const names = props.servers.map((s) => s.serverName);
+  const capabilities = Object.assign(
+    {},
+    ...props.servers.map((s) => s.customCapabilities),
+  );
+
   lspConnection.onInitialize((params: InitializeParams) => {
     clientInitializeParams = params;
     return {
@@ -53,6 +60,10 @@ export const webworker = (props: RuntimeProps) => {
           openClose: true,
           change: TextDocumentSyncKind.Incremental,
         },
+      },
+      awsCapabilities: {
+        awsLanguageServersNames: names,
+        ...capabilities,
       },
     };
   });


### PR DESCRIPTION
## Problem
We want servers to be able to announce their name and custom LSP capabilities on LSP initilization. The current Server interface does not support these properties.

## Solution
- Add `serverName` and `customCapabilities` properties to Server interface
- Expose properties in LSP initialization result

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
