### PR TITLE
Configure server name on LSP init flow

### DIFF
--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -12,4 +12,8 @@ export type RuntimeProps = {
    *  The list of servers to initialize and run
    */
   servers: Server[];
+  /**
+   * Name of the server used inside the runtime
+   */
+  name: string;
 };

--- a/src/runtimes/standalone.ts
+++ b/src/runtimes/standalone.ts
@@ -108,8 +108,7 @@ export const standalone = (props: RuntimeProps) => {
       clientInitializeParams = params;
       return {
         serverInfo: {
-          // TODO: make this configurable
-          name: "AWS LSP Standalone",
+          name: props.name,
           // This indicates the standalone server version and is updated
           // every time the standalone or any of the servers update.
           // Major version updates only happen for backwards incompatible changes.

--- a/src/runtimes/webworker.ts
+++ b/src/runtimes/webworker.ts
@@ -41,8 +41,7 @@ export const webworker = (props: RuntimeProps) => {
     clientInitializeParams = params;
     return {
       serverInfo: {
-        // TODO: make this configurable
-        name: "AWS LSP Web Worker",
+        name: props.name,
         // This indicates the webworker server version and is updated
         // every time the runtime or any of the servers update.
         // Major version updates only happen for backwards incompatible changes.


### PR DESCRIPTION
## Problem
Currently we hardcode the server name, making it unclear what server is included inside the runtime

## Solution
Add `name` to the RuntimeProps and pass it on to the LSP initialization result.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
