### PR TITLE
Move security reporting instructions to separate file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,6 @@ For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 
-## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
-
-
 ## Licensing
 
 See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,2 @@
+## Security issue notifications
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.


### PR DESCRIPTION
## Problem
It is recommended to move instructions on how to report security issues to SECURITY.md file

## Solution

Created the file


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
