### PR TITLE
Allow capabilities to define responses for onInitialize

### DIFF
--- a/src/features/lsp/index.ts
+++ b/src/features/lsp/index.ts
@@ -8,14 +8,18 @@ import {
   ExecuteCommandParams,
   Hover,
   HoverParams,
+  InitializeError,
+  InitializeParams,
   InitializedParams,
   InlineCompletionItem,
   InlineCompletionList,
   InlineCompletionParams,
+  LSPAny,
   NotificationHandler,
   PublishDiagnosticsParams,
   RequestHandler,
   ServerRequestHandler,
+  ServerCapabilities,
 } from "vscode-languageserver";
 import {
   InlineCompletionItemWithReferences,
@@ -25,11 +29,33 @@ import {
 
 export { observe } from "./textDocuments/textDocumentConnection";
 
+export type PartialServerCapabilities<T = any> = Pick<
+  ServerCapabilities<T>,
+  "completionProvider" | "hoverProvider"
+>;
+export type PartialInitializeResult<T = any> = {
+  capabilities: PartialServerCapabilities<T>;
+};
+
 // Using `RequestHandler` here from `vscode-languageserver-protocol` which doesn't support partial progress.
 // If we want to support partial progress, we'll need to use `ServerRequestHandler` from `vscode-languageserver` instead.
 // but if we can avoid exposing multiple different `vscode-languageserver-*` packages and package versions to
 // implementors that would prevent potentially very hard to debug type mismatch errors (even on minor versions).
 export type Lsp = {
+  /**
+   * Lsp#addInitializer allows servers to register handlers for the initilaze LSP request.
+   * The handlers respond with PartialInitializeResult which includes a subset of InitializeResult's properties
+   * as not all original properties are expected to be defined by servers.
+   * Then the runtime will use the regiestered handlers and merge their responses when responding to initialize LSP request.
+   *
+   */
+  addInitializer: (
+    handler: RequestHandler<
+      InitializeParams,
+      PartialInitializeResult,
+      InitializeError
+    >,
+  ) => void;
   onInitialized: (handler: NotificationHandler<InitializedParams>) => void;
   onInlineCompletion: (
     handler: RequestHandler<

--- a/src/runtimes/initialize.test.ts
+++ b/src/runtimes/initialize.test.ts
@@ -1,0 +1,156 @@
+import {
+  CancellationToken,
+  InitializeError,
+  InitializeParams,
+  InitializeResult,
+  ResponseError,
+  TextDocumentSyncKind,
+} from "vscode-languageserver";
+import { InitializeHandler } from "./initialize";
+import assert from "assert";
+
+describe("InitializeHandler", () => {
+  let initializeHandler: InitializeHandler;
+
+  beforeEach(() => {
+    initializeHandler = new InitializeHandler("1.0.0", "AWS LSP Standalone");
+  });
+
+  it("should store InitializeParam in a field", () => {
+    const initParam = {} as InitializeParams;
+    initializeHandler.onInitialize(initParam, {} as CancellationToken);
+    assert(initializeHandler.clientInitializeParams === initParam);
+  });
+
+  it("should return the default response when no handlers are registered", async () => {
+    const result = await initializeHandler.onInitialize(
+      {} as InitializeParams,
+      {} as CancellationToken,
+    );
+
+    const expected = {
+      serverInfo: {
+        name: "AWS LSP Standalone",
+        version: "1.0.0",
+      },
+      capabilities: {
+        textDocumentSync: {
+          openClose: true,
+          change: TextDocumentSyncKind.Incremental,
+        },
+        hoverProvider: true,
+      },
+    };
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it("should merge handler results with the default response", async () => {
+    const handler1 = () => {
+      return {
+        capabilities: {
+          completionProvider: { resolveProvider: true },
+        },
+      };
+    };
+    const handler2 = () => {
+      return Promise.resolve({
+        capabilities: {
+          hoverProvider: true,
+        },
+        extraField: "extraValue",
+      });
+    };
+
+    initializeHandler.addHandler(handler1);
+    initializeHandler.addHandler(handler2);
+
+    const result = await initializeHandler.onInitialize(
+      {} as InitializeParams,
+      {} as CancellationToken,
+    );
+
+    const expected: InitializeResult = {
+      serverInfo: {
+        name: "AWS LSP Standalone",
+        version: "1.0.0",
+      },
+      capabilities: {
+        textDocumentSync: {
+          openClose: true,
+          change: TextDocumentSyncKind.Incremental,
+        },
+        completionProvider: { resolveProvider: true },
+        hoverProvider: true,
+      },
+      extraField: "extraValue",
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it("should prioritize the response of the handler that comes first", async () => {
+    const handler1 = () => {
+      return {
+        capabilities: {
+          completionProvider: { resolveProvider: true },
+        },
+      };
+    };
+    const handler2 = () => {
+      return Promise.resolve({
+        capabilities: {
+          completionProvider: { resolveProvider: false },
+        },
+      });
+    };
+
+    initializeHandler.addHandler(handler1);
+    initializeHandler.addHandler(handler2);
+
+    const result = await initializeHandler.onInitialize(
+      {} as InitializeParams,
+      {} as CancellationToken,
+    );
+
+    const expected: InitializeResult = {
+      serverInfo: {
+        name: "AWS LSP Standalone",
+        version: "1.0.0",
+      },
+      capabilities: {
+        textDocumentSync: {
+          openClose: true,
+          change: TextDocumentSyncKind.Incremental,
+        },
+        completionProvider: { resolveProvider: true },
+        hoverProvider: true,
+      },
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it("should return error if any of the handlers failed", async () => {
+    const handler1 = () => {
+      return {
+        capabilities: {
+          completionProvider: { resolveProvider: true },
+        },
+      };
+    };
+    const error = new ResponseError(111, "failed", { retry: false });
+    const handler2 = (): Promise<ResponseError<InitializeError>> => {
+      return Promise.resolve(error);
+    };
+
+    initializeHandler.addHandler(handler1);
+    initializeHandler.addHandler(handler2);
+
+    const result = await initializeHandler.onInitialize(
+      {} as InitializeParams,
+      {} as CancellationToken,
+    );
+
+    assert.deepStrictEqual(result, error);
+  });
+});

--- a/src/runtimes/initialize.ts
+++ b/src/runtimes/initialize.ts
@@ -1,0 +1,118 @@
+import {
+  RequestHandler,
+  InitializeParams,
+  InitializeError,
+  CancellationToken,
+  InitializeResult,
+  TextDocumentSyncKind,
+  ResponseError,
+} from "vscode-languageserver";
+import { PartialInitializeResult } from "../features/lsp";
+
+export class InitializeHandler {
+  private handlers: RequestHandler<
+    InitializeParams,
+    PartialInitializeResult,
+    InitializeError
+  >[] = [];
+  public clientInitializeParams?: InitializeParams;
+
+  constructor(
+    private version: string,
+    private name: string,
+  ) {}
+
+  public onInitialize = async (
+    params: InitializeParams,
+    token: CancellationToken,
+  ): Promise<InitializeResult | ResponseError<InitializeError>> => {
+    this.clientInitializeParams = params;
+    const defaultResponse: InitializeResult = {
+      serverInfo: {
+        name: this.name,
+        version: this.version,
+      },
+      capabilities: {
+        textDocumentSync: {
+          openClose: true,
+          change: TextDocumentSyncKind.Incremental,
+        },
+        hoverProvider: true,
+      },
+    };
+
+    const responsesList = await Promise.all(
+      this.handlers.map((f) => asPromise(f(params, token))),
+    );
+    if (responsesList.some((el) => el instanceof ResponseError)) {
+      return responsesList.find(
+        (el) => el instanceof ResponseError,
+      ) as ResponseError<InitializeError>;
+    }
+    const resultList = responsesList as InitializeResult[];
+    resultList.unshift(defaultResponse);
+    return resultList.reduceRight((acc, curr) => {
+      return mergeObjects(acc, curr);
+    });
+  };
+
+  public addHandler = (
+    handler: RequestHandler<
+      InitializeParams,
+      PartialInitializeResult,
+      InitializeError
+    >,
+  ): void => {
+    this.handlers.push(handler);
+  };
+}
+
+function mergeObjects(obj1: any, obj2: any) {
+  const merged: any = {};
+
+  for (let key in obj1) {
+    if (obj1.hasOwnProperty(key)) {
+      if (typeof obj1[key] === "object" && typeof obj2[key] === "object") {
+        merged[key] = mergeObjects(obj1[key], obj2[key]);
+      } else {
+        merged[key] = obj1[key];
+        if (obj2.hasOwnProperty(key)) {
+          merged[key] = obj2[key];
+        }
+      }
+    }
+  }
+
+  for (let key in obj2) {
+    if (obj2.hasOwnProperty(key) && !obj1.hasOwnProperty(key)) {
+      merged[key] = obj2[key];
+    }
+  }
+  return merged;
+}
+
+function func(value: any): value is Function {
+  return typeof value === "function";
+}
+
+function thenable<T>(value: any): value is Thenable<T> {
+  return value && func(value.then);
+}
+
+function asPromise<T>(value: Promise<T>): Promise<T>;
+function asPromise<T>(value: Thenable<T>): Promise<T>;
+function asPromise<T>(value: T): Promise<T>;
+function asPromise(value: any): Promise<any> {
+  if (value instanceof Promise) {
+    return value;
+  } else if (thenable(value)) {
+    return new Promise((resolve, reject) => {
+      value.then(
+        (resolved) => resolve(resolved),
+        (error) => reject(error),
+      );
+    });
+  } else {
+    return Promise.resolve(value);
+  }
+}

--- a/src/runtimes/standalone.ts
+++ b/src/runtimes/standalone.ts
@@ -30,6 +30,7 @@ import { access, mkdirSync, existsSync } from "fs";
 import { readdir, readFile, rm, stat, copyFile } from "fs/promises";
 import * as os from "os";
 import * as path from "path";
+import { InitializeHandler } from "./initialize";
 
 /**
  * The runtime for standalone LSP-based servers.
@@ -103,28 +104,9 @@ export const standalone = (props: RuntimeProps) => {
 
   function initializeRuntime() {
     const documents = new TextDocuments(TextDocument);
-    let clientInitializeParams: InitializeParams;
 
-    lspConnection.onInitialize((params: InitializeParams) => {
-      clientInitializeParams = params;
-      return {
-        serverInfo: {
-          name: props.name,
-          // This indicates the standalone server version and is updated
-          // every time the standalone or any of the servers update.
-          // Major version updates only happen for backwards incompatible changes.
-          version: props.version,
-        },
-        capabilities: {
-          textDocumentSync: {
-            openClose: true,
-            change: TextDocumentSyncKind.Incremental,
-          },
-          hoverProvider: true,
-          diagnosticsProvider: true,
-        },
-      };
-    });
+    let initializeHandler = new InitializeHandler(props.version, props.name);
+    lspConnection.onInitialize(initializeHandler.onInitialize);
 
     // Set up logging over LSP
     // TODO: set up Logging once implemented
@@ -147,7 +129,8 @@ export const standalone = (props: RuntimeProps) => {
         const fileUrl = new URL(uri);
         const normalizedFileUri = fileUrl.pathname || "";
 
-        const folders = clientInitializeParams.workspaceFolders;
+        const folders =
+          initializeHandler.clientInitializeParams!.workspaceFolders;
         if (!folders) return undefined;
 
         for (const folder of folders) {
@@ -188,10 +171,11 @@ export const standalone = (props: RuntimeProps) => {
 
     // Map the LSP client to the LSP feature.
     const lsp: Lsp = {
+      addInitializer: initializeHandler.addHandler,
       onInitialized: (handler) =>
         lspConnection.onInitialized((p) => {
           const workspaceCapabilities =
-            clientInitializeParams?.capabilities.workspace;
+            initializeHandler.clientInitializeParams?.capabilities.workspace;
           if (
             workspaceCapabilities?.didChangeConfiguration?.dynamicRegistration
           ) {


### PR DESCRIPTION
## Problem
`InitializeResult` is currently hardcoded in the runtimes and cannot be delegated to the capabilities.

## Solution
Extended the LSP feature to allow registering handlers for `onInitialize` requests. If more than one capability registers the handler the handlers get stored in an order of precedence. 
Later, when responding on the request all handlers get called and their results merged. If 2 responses contain different values for the same key - the priority goes to the value provided by the handler that was registered first. 

In the PR I kept the response that was defined in the `standalone` runtime and gave it the highest priority but we can remove it altogether and rely on the capability-provided values. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
