### PR TITLE
Remove custom command naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The server runtime implementation acts as a proxy for LSP methods, which means i
 | Method | Support | Notes | 
 | ------ | ------- | ----- |
 | onInlineCompletion | Yes | Provide list of inline completion suggestions from the Server |
-| onExecuteCommand | Yes | Executes a custom command provided by the Server. Servers are advised to document custom commands they support in the package README. For a consistent experience, naming of the commands should consist of the main Server name and purpose of the command combined with `/` (forward slash) and written in camelCase format. Eg. `/helloWorld/logError` |
+| onExecuteCommand | Yes | Executes a custom command provided by the Server. Servers are advised to document custom commands they support in the package README. |
 
 ##### LSP Extensions
 | Method Name | Method | Params | Method Type | Response Type | Notes |


### PR DESCRIPTION
## Problem
Unconfirmed naming convention guide for custom commands

## Solution
Remove documentation on naming

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
