### PR TITLE
fix: Prevent TestFeatures from failing when methods are not registered in the server

### DIFF
--- a/src/testing/TestFeatures.ts
+++ b/src/testing/TestFeatures.ts
@@ -64,7 +64,7 @@ export class TestFeatures {
   async start(server: Server) {
     this.disposables.push(server(this));
     return Promise.resolve(this).then((f) => {
-      this.lsp.onInitialized.args[0][0]({});
+      this.lsp.onInitialized.args[0]?.[0]({});
       return f;
     });
   }
@@ -73,11 +73,11 @@ export class TestFeatures {
     params: InlineCompletionParams,
     token: CancellationToken,
   ) {
-    return this.lsp.onInlineCompletion.args[0][0](params, token);
+    return this.lsp.onInlineCompletion.args[0]?.[0](params, token);
   }
 
   async doCompletion(params: CompletionParams, token: CancellationToken) {
-    return this.lsp.onCompletion.args[0][0](params, token);
+    return this.lsp.onCompletion.args[0]?.[0](params, token);
   }
 
   async doInlineCompletionWithReferences(
@@ -85,7 +85,7 @@ export class TestFeatures {
       Parameters<Lsp["extensions"]["onInlineCompletionWithReferences"]>[0]
     >
   ) {
-    return this.lsp.extensions.onInlineCompletionWithReferences.args[0][0](
+    return this.lsp.extensions.onInlineCompletionWithReferences.args[0]?.[0](
       ...args,
     );
   }
@@ -95,7 +95,7 @@ export class TestFeatures {
       Parameters<Lsp["extensions"]["onLogInlineCompletionSessionResults"]>[0]
     >
   ) {
-    return this.lsp.extensions.onLogInlineCompletionSessionResults.args[0][0](
+    return this.lsp.extensions.onLogInlineCompletionSessionResults.args[0]?.[0](
       ...args,
     );
   }
@@ -108,14 +108,14 @@ export class TestFeatures {
   async doChangeConfiguration() {
     // Force the call to handle after the current task completes
     await undefined;
-    this.lsp.didChangeConfiguration.args[0][0]({ settings: undefined });
+    this.lsp.didChangeConfiguration.args[0]?.[0]({ settings: undefined });
     return this;
   }
 
   async doChangeTextDocument(params: DidChangeTextDocumentParams) {
     // Force the call to handle after the current task completes
     await undefined;
-    this.lsp.onDidChangeTextDocument.args[0][0](params);
+    this.lsp.onDidChangeTextDocument.args[0]?.[0](params);
     return this;
   }
 
@@ -123,10 +123,7 @@ export class TestFeatures {
     params: ExecuteCommandParams,
     token: CancellationToken,
   ) {
-    // Force the call to handle after the current task completes
-    await undefined;
-    this.lsp.onExecuteCommand.args[0][0](params, token);
-    return this;
+    return this.lsp.onExecuteCommand.args[0]?.[0](params, token);
   }
 
   async simulateTyping(uri: string, text: string) {
@@ -152,7 +149,7 @@ export class TestFeatures {
 
       // Force the call to handle after the current task completes
       await undefined;
-      this.lsp.onDidChangeTextDocument.args[0][0]({
+      this.lsp.onDidChangeTextDocument.args[0]?.[0]({
         textDocument: {
           uri,
           version: document.version,


### PR DESCRIPTION


Also, doExecuteCommand is a request, not a notification, so we need to return the result

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
