### PR TITLE
Make server version optional

### DIFF
--- a/src/features/versioning.ts
+++ b/src/features/versioning.ts
@@ -1,4 +1,4 @@
-export function handleVersionArgument(version: string) {
+export function handleVersionArgument(version?: string) {
   if (process.argv.some((arg) => arg === "--version" || arg === "-v")) {
     console.log(version);
     process.exit(0);

--- a/src/runtimes/initialize.test.ts
+++ b/src/runtimes/initialize.test.ts
@@ -13,7 +13,7 @@ describe("InitializeHandler", () => {
   let initializeHandler: InitializeHandler;
 
   beforeEach(() => {
-    initializeHandler = new InitializeHandler("1.0.0", "AWS LSP Standalone");
+    initializeHandler = new InitializeHandler("AWS LSP Standalone", "1.0.0");
   });
 
   it("should store InitializeParam in a field", () => {

--- a/src/runtimes/initialize.ts
+++ b/src/runtimes/initialize.ts
@@ -18,8 +18,8 @@ export class InitializeHandler {
   public clientInitializeParams?: InitializeParams;
 
   constructor(
-    private version: string,
     private name: string,
+    private version?: string,
   ) {}
 
   public onInitialize = async (

--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -7,7 +7,7 @@ export type RuntimeProps = {
   /**
    * Version of the build artifact resulting from initialising the runtime with the list of servers
    */
-  version: string;
+  version?: string;
   /**
    *  The list of servers to initialize and run
    */

--- a/src/runtimes/standalone.ts
+++ b/src/runtimes/standalone.ts
@@ -103,7 +103,7 @@ export const standalone = (props: RuntimeProps) => {
   function initializeRuntime() {
     const documents = new TextDocuments(TextDocument);
 
-    let initializeHandler = new InitializeHandler(props.version, props.name);
+    let initializeHandler = new InitializeHandler(props.name, props.version);
     lspConnection.onInitialize(initializeHandler.onInitialize);
 
     // Set up logging over LSP

--- a/src/runtimes/webworker.ts
+++ b/src/runtimes/webworker.ts
@@ -33,7 +33,7 @@ export const webworker = (props: RuntimeProps) => {
   const documentsObserver = observe(lspConnection);
   const documents = new TextDocuments(TextDocument);
 
-  let initializeHandler = new InitializeHandler(props.version, props.name);
+  let initializeHandler = new InitializeHandler(props.name, props.version);
   lspConnection.onInitialize(initializeHandler.onInitialize);
 
   // Set up logigng over LSP


### PR DESCRIPTION
## Problem
For webworker runtimes, the integrators will initialize the runtime with the server themselves. This makes the server version not meaningful in that case. We want to make it optional. Also this would match the serverInfo shape in [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/) 

## Solution
Make server version optional
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
