### PR TITLE
Add prettier rules and reformat source code

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'

--- a/.github/workflows/runtimes-ci.yaml
+++ b/.github/workflows/runtimes-ci.yaml
@@ -1,25 +1,25 @@
 name: Language Server Runtime CI
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Sync Code
-        uses: actions/checkout@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - name: Build
-        run: |
-          npm install
-          npm run compile
-      - name: Test
-        run: |
-          npm run test
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Sync Code
+              uses: actions/checkout@v4
+            - name: Set up Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+            - name: Build
+              run: |
+                  npm install
+                  npm run compile
+            - name: Test
+              run: |
+                  npm run test

--- a/package.json
+++ b/package.json
@@ -1,48 +1,58 @@
 {
-  "name": "@aws/language-server-runtimes",
-  "version": "0.1.1",
-  "description": "Runtimes to host Language Servers for AWS",
-  "main": "out/runtimes/index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/aws/language-server-runtimes"
-  },
-  "author": "Amazon Web Services",
-  "license": "Apache-2.0",
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "scripts": {
-    "compile": "tsc --build",
-    "prepack": "npm run compile",
-    "test:unit": "ts-mocha -b 'src/**/*.test.ts'",
-    "test:prettier": "prettier . --check",
-    "test": "npm run test:prettier && npm run test:unit",
-    "fix:prettier": "prettier . --write",
-    "prepare": "husky install"
-  },
-  "dependencies": {
-    "jose": "^5.2.3",
-    "rxjs": "^7.8.1",
-    "vscode-languageserver": "^9.0.1",
-    "vscode-languageserver-textdocument": "^1.0.11"
-  },
-  "devDependencies": {
-    "@types/mocha": "^10.0.1",
-    "@types/node": "^20.5.9",
-    "assert": "^2.0.0",
-    "husky": "^8.0.3",
-    "prettier": "3.2.5",
-    "sinon": "^17.0.1",
-    "ts-mocha": "^10.0.0",
-    "ts-sinon": "^2.0.2",
-    "typescript": "^5.2.2"
-  },
-  "typesVersions": {
-    "*": {
-      "browser": [
-        "./out/runtimes/webworker.d.ts"
-      ]
+    "name": "@aws/language-server-runtimes",
+    "version": "0.1.1",
+    "description": "Runtimes to host Language Servers for AWS",
+    "main": "out/runtimes/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/aws/language-server-runtimes"
+    },
+    "author": "Amazon Web Services",
+    "license": "Apache-2.0",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "scripts": {
+        "compile": "tsc --build",
+        "prepack": "npm run compile",
+        "test:unit": "ts-mocha -b 'src/**/*.test.ts'",
+        "test:prettier": "prettier . --check",
+        "test": "npm run test:prettier && npm run test:unit",
+        "fix:prettier": "prettier . --write",
+        "prepare": "husky install"
+    },
+    "dependencies": {
+        "jose": "^5.2.3",
+        "rxjs": "^7.8.1",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.11"
+    },
+    "devDependencies": {
+        "@types/mocha": "^10.0.1",
+        "@types/node": "^20.5.9",
+        "assert": "^2.0.0",
+        "husky": "^8.0.3",
+        "prettier": "3.2.5",
+        "sinon": "^17.0.1",
+        "ts-mocha": "^10.0.0",
+        "ts-sinon": "^2.0.2",
+        "typescript": "^5.2.2"
+    },
+    "typesVersions": {
+        "*": {
+            "browser": [
+                "./out/runtimes/webworker.d.ts"
+            ]
+        }
+    },
+    "prettier": {
+        "printWidth": 120,
+        "trailingComma": "es5",
+        "tabWidth": 4,
+        "singleQuote": true,
+        "semi": false,
+        "bracketSpacing": true,
+        "arrowParens": "avoid",
+        "endOfLine": "lf"
     }
-  }
 }

--- a/src/features/auth/auth.test.ts
+++ b/src/features/auth/auth.test.ts
@@ -1,470 +1,368 @@
-import assert from "assert";
-import { randomBytes } from "node:crypto";
-import * as jose from "jose";
-import { Duplex } from "stream";
-import { Connection, createConnection } from "vscode-languageserver/node";
+import assert from 'assert'
+import { randomBytes } from 'node:crypto'
+import * as jose from 'jose'
+import { Duplex } from 'stream'
+import { Connection, createConnection } from 'vscode-languageserver/node'
 import {
-  Auth,
-  BearerCredentials,
-  CredentialsProvider,
-  CredentialsType,
-  IamCredentials,
-  UpdateCredentialsRequest,
-  credentialsProtocolMethodNames,
-} from "./auth";
+    Auth,
+    BearerCredentials,
+    CredentialsProvider,
+    CredentialsType,
+    IamCredentials,
+    UpdateCredentialsRequest,
+    credentialsProtocolMethodNames,
+} from './auth'
 
 class TestStream extends Duplex {
-  _write(chunk: string, _encoding: string, done: () => void) {
-    this.emit("data", chunk);
-    done();
-  }
+    _write(chunk: string, _encoding: string, done: () => void) {
+        this.emit('data', chunk)
+        done()
+    }
 
-  _read(_size: number) {}
+    _read(_size: number) {}
 }
 
 const authHandlers = {
-  iamUpdateHandler: async (
-    request: UpdateCredentialsRequest,
-  ): Promise<void | Error> => {},
-  iamDeleteHandler: () => {},
-  bearerUpdateHandler: async (
-    request: UpdateCredentialsRequest,
-  ): Promise<void | Error> => {},
-  bearerDeleteHandler: () => {},
-};
+    iamUpdateHandler: async (request: UpdateCredentialsRequest): Promise<void | Error> => {},
+    iamDeleteHandler: () => {},
+    bearerUpdateHandler: async (request: UpdateCredentialsRequest): Promise<void | Error> => {},
+    bearerDeleteHandler: () => {},
+}
 
 function clearHandlers() {
-  authHandlers.iamUpdateHandler = async (
-    request: UpdateCredentialsRequest,
-  ): Promise<void | Error> => {};
-  authHandlers.iamDeleteHandler = () => {};
-  authHandlers.bearerUpdateHandler = async (
-    request: UpdateCredentialsRequest,
-  ): Promise<void | Error> => {};
-  authHandlers.bearerDeleteHandler = () => {};
+    authHandlers.iamUpdateHandler = async (request: UpdateCredentialsRequest): Promise<void | Error> => {}
+    authHandlers.iamDeleteHandler = () => {}
+    authHandlers.bearerUpdateHandler = async (request: UpdateCredentialsRequest): Promise<void | Error> => {}
+    authHandlers.bearerDeleteHandler = () => {}
 }
 
 const serverLspConnectionMock = <Connection>{
-  onRequest: (method: string, handler: any) => {
-    if (method === credentialsProtocolMethodNames.iamCredentialsUpdate) {
-      authHandlers.iamUpdateHandler = handler;
-    }
-    if (method === credentialsProtocolMethodNames.bearerCredentialsUpdate) {
-      authHandlers.bearerUpdateHandler = handler;
-    }
-  },
-  onNotification: (method: string, handler: any) => {
-    if (method === credentialsProtocolMethodNames.iamCredentialsDelete) {
-      authHandlers.iamDeleteHandler = handler;
-    }
-    if (method === credentialsProtocolMethodNames.bearerCredentialsDelete) {
-      authHandlers.bearerDeleteHandler = handler;
-    }
-  },
-  console: {
-    info: (str: string) => {
-      console.log(str);
+    onRequest: (method: string, handler: any) => {
+        if (method === credentialsProtocolMethodNames.iamCredentialsUpdate) {
+            authHandlers.iamUpdateHandler = handler
+        }
+        if (method === credentialsProtocolMethodNames.bearerCredentialsUpdate) {
+            authHandlers.bearerUpdateHandler = handler
+        }
     },
-    log: (str: string) => {
-      console.log(str);
+    onNotification: (method: string, handler: any) => {
+        if (method === credentialsProtocolMethodNames.iamCredentialsDelete) {
+            authHandlers.iamDeleteHandler = handler
+        }
+        if (method === credentialsProtocolMethodNames.bearerCredentialsDelete) {
+            authHandlers.bearerDeleteHandler = handler
+        }
     },
-    error: (str: string) => {
-      console.log(str);
+    console: {
+        info: (str: string) => {
+            console.log(str)
+        },
+        log: (str: string) => {
+            console.log(str)
+        },
+        error: (str: string) => {
+            console.log(str)
+        },
     },
-  },
-};
+}
 
 const bearerCredentials: BearerCredentials = {
-  token: "testToken",
-};
+    token: 'testToken',
+}
 const iamCredentials: IamCredentials = {
-  accessKeyId: "testKey",
-  secretAccessKey: "testSecret",
-  sessionToken: "testSession",
-};
+    accessKeyId: 'testKey',
+    secretAccessKey: 'testSecret',
+    sessionToken: 'testSession',
+}
 
-const encryptionKey = randomBytes(32);
+const encryptionKey = randomBytes(32)
 
-describe("Auth", () => {
-  let serverConnection: Connection;
-  let clientConnection: Connection;
+describe('Auth', () => {
+    let serverConnection: Connection
+    let clientConnection: Connection
 
-  beforeEach(() => {
-    const up = new TestStream();
-    const down = new TestStream();
-    serverConnection = createConnection(up, down);
-    clientConnection = createConnection(down, up);
-    serverConnection.listen();
-    clientConnection.listen();
+    beforeEach(() => {
+        const up = new TestStream()
+        const down = new TestStream()
+        serverConnection = createConnection(up, down)
+        clientConnection = createConnection(down, up)
+        serverConnection.listen()
+        clientConnection.listen()
 
-    clearHandlers();
-  });
+        clearHandlers()
+    })
 
-  it("Handles IAM credentials", async () => {
-    const updateRequest: UpdateCredentialsRequest = {
-      data: iamCredentials,
-      encrypted: false,
-    };
-    const auth = new Auth(serverLspConnectionMock);
-    const credentialsProvider: CredentialsProvider =
-      auth.getCredentialsProvider();
+    it('Handles IAM credentials', async () => {
+        const updateRequest: UpdateCredentialsRequest = {
+            data: iamCredentials,
+            encrypted: false,
+        }
+        const auth = new Auth(serverLspConnectionMock)
+        const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-    assert(!credentialsProvider.hasCredentials("iam"));
-    await authHandlers.iamUpdateHandler(updateRequest);
+        assert(!credentialsProvider.hasCredentials('iam'))
+        await authHandlers.iamUpdateHandler(updateRequest)
 
-    assert(credentialsProvider.hasCredentials("iam"));
-    assert.deepEqual(credentialsProvider.getCredentials("iam"), iamCredentials);
+        assert(credentialsProvider.hasCredentials('iam'))
+        assert.deepEqual(credentialsProvider.getCredentials('iam'), iamCredentials)
 
-    authHandlers.iamDeleteHandler();
-    assert(!credentialsProvider.hasCredentials("iam"));
-    assert(credentialsProvider.getCredentials("iam") === undefined);
-  });
+        authHandlers.iamDeleteHandler()
+        assert(!credentialsProvider.hasCredentials('iam'))
+        assert(credentialsProvider.getCredentials('iam') === undefined)
+    })
 
-  it("Handles Set Bearer credentials request", async () => {
-    const updateRequest: UpdateCredentialsRequest = {
-      data: bearerCredentials,
-      encrypted: false,
-    };
-    const auth = new Auth(serverConnection);
-    const credentialsProvider: CredentialsProvider =
-      auth.getCredentialsProvider();
+    it('Handles Set Bearer credentials request', async () => {
+        const updateRequest: UpdateCredentialsRequest = {
+            data: bearerCredentials,
+            encrypted: false,
+        }
+        const auth = new Auth(serverConnection)
+        const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-    assert(!credentialsProvider.hasCredentials("bearer"));
+        assert(!credentialsProvider.hasCredentials('bearer'))
 
-    await clientConnection.sendRequest(
-      credentialsProtocolMethodNames.bearerCredentialsUpdate,
-      updateRequest,
-    );
+        await clientConnection.sendRequest(credentialsProtocolMethodNames.bearerCredentialsUpdate, updateRequest)
 
-    assert(credentialsProvider.hasCredentials("bearer"));
-    assert.deepEqual(
-      credentialsProvider.getCredentials("bearer"),
-      bearerCredentials,
-    );
-  });
+        assert(credentialsProvider.hasCredentials('bearer'))
+        assert.deepEqual(credentialsProvider.getCredentials('bearer'), bearerCredentials)
+    })
 
-  it("Updates connection metadata on receiving Set Bearer credentials request", async () => {
-    const CONNECTION_METADATA = {
-      sso: {
-        startUrl: "testStartUrl",
-      },
-    };
-    clientConnection.onRequest(
-      credentialsProtocolMethodNames.getConnectionMetadata,
-      () => {
-        return CONNECTION_METADATA;
-      },
-    );
+    it('Updates connection metadata on receiving Set Bearer credentials request', async () => {
+        const CONNECTION_METADATA = {
+            sso: {
+                startUrl: 'testStartUrl',
+            },
+        }
+        clientConnection.onRequest(credentialsProtocolMethodNames.getConnectionMetadata, () => {
+            return CONNECTION_METADATA
+        })
 
-    const updateRequest: UpdateCredentialsRequest = {
-      data: bearerCredentials,
-      encrypted: false,
-    };
-    const auth = new Auth(serverConnection);
-    const credentialsProvider: CredentialsProvider =
-      auth.getCredentialsProvider();
+        const updateRequest: UpdateCredentialsRequest = {
+            data: bearerCredentials,
+            encrypted: false,
+        }
+        const auth = new Auth(serverConnection)
+        const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-    assert(!credentialsProvider.getConnectionMetadata());
+        assert(!credentialsProvider.getConnectionMetadata())
 
-    await clientConnection.sendRequest(
-      credentialsProtocolMethodNames.bearerCredentialsUpdate,
-      updateRequest,
-    );
+        await clientConnection.sendRequest(credentialsProtocolMethodNames.bearerCredentialsUpdate, updateRequest)
 
-    assert.deepEqual(
-      credentialsProvider.getConnectionMetadata(),
-      CONNECTION_METADATA,
-    );
-  });
+        assert.deepEqual(credentialsProvider.getConnectionMetadata(), CONNECTION_METADATA)
+    })
 
-  it("Updates Bearer credentials on failed get connection metadata request", async () => {
-    clientConnection.onRequest(
-      credentialsProtocolMethodNames.getConnectionMetadata,
-      () => {
-        console.log("FAILING GET METADATA REQUEST");
-        throw new Error("TEST ERROR");
-      },
-    );
+    it('Updates Bearer credentials on failed get connection metadata request', async () => {
+        clientConnection.onRequest(credentialsProtocolMethodNames.getConnectionMetadata, () => {
+            console.log('FAILING GET METADATA REQUEST')
+            throw new Error('TEST ERROR')
+        })
 
-    const updateRequest: UpdateCredentialsRequest = {
-      data: bearerCredentials,
-      encrypted: false,
-    };
-    const auth = new Auth(serverConnection);
-    const credentialsProvider: CredentialsProvider =
-      auth.getCredentialsProvider();
+        const updateRequest: UpdateCredentialsRequest = {
+            data: bearerCredentials,
+            encrypted: false,
+        }
+        const auth = new Auth(serverConnection)
+        const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-    await clientConnection.sendRequest(
-      credentialsProtocolMethodNames.bearerCredentialsUpdate,
-      updateRequest,
-    );
+        await clientConnection.sendRequest(credentialsProtocolMethodNames.bearerCredentialsUpdate, updateRequest)
 
-    assert.deepEqual(credentialsProvider.getConnectionMetadata(), undefined);
-    assert.deepEqual(
-      credentialsProvider.getCredentials("bearer"),
-      bearerCredentials,
-    );
-  });
+        assert.deepEqual(credentialsProvider.getConnectionMetadata(), undefined)
+        assert.deepEqual(credentialsProvider.getCredentials('bearer'), bearerCredentials)
+    })
 
-  it("Handles Bearer credentials delete request", (done) => {
-    const updateRequest: UpdateCredentialsRequest = {
-      data: bearerCredentials,
-      encrypted: false,
-    };
-    const auth = new Auth(serverConnection);
-    const credentialsProvider: CredentialsProvider =
-      auth.getCredentialsProvider();
+    it('Handles Bearer credentials delete request', done => {
+        const updateRequest: UpdateCredentialsRequest = {
+            data: bearerCredentials,
+            encrypted: false,
+        }
+        const auth = new Auth(serverConnection)
+        const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-    assert(!credentialsProvider.hasCredentials("bearer"));
+        assert(!credentialsProvider.hasCredentials('bearer'))
 
-    serverConnection.onNotification(
-      credentialsProtocolMethodNames.bearerCredentialsDelete,
-      () => {
-        assert(!credentialsProvider.hasCredentials("bearer"));
-        assert(credentialsProvider.getCredentials("bearer") === undefined);
-        done();
-      },
-    );
-    clientConnection.sendNotification(
-      credentialsProtocolMethodNames.bearerCredentialsDelete,
-      updateRequest,
-    );
-  });
+        serverConnection.onNotification(credentialsProtocolMethodNames.bearerCredentialsDelete, () => {
+            assert(!credentialsProvider.hasCredentials('bearer'))
+            assert(credentialsProvider.getCredentials('bearer') === undefined)
+            done()
+        })
+        clientConnection.sendNotification(credentialsProtocolMethodNames.bearerCredentialsDelete, updateRequest)
+    })
 
-  it("Rejects when IAM credentials are invalid", async () => {
-    const malformedIamCredentials = {
-      accessKeyId: "testKey",
-      sessionToken: "testSession",
-    };
-    const updateIamRequest: UpdateCredentialsRequest = {
-      data: malformedIamCredentials as IamCredentials,
-      encrypted: false,
-    };
-    const auth = new Auth(serverLspConnectionMock);
-    const credentialsProvider: CredentialsProvider =
-      auth.getCredentialsProvider();
+    it('Rejects when IAM credentials are invalid', async () => {
+        const malformedIamCredentials = {
+            accessKeyId: 'testKey',
+            sessionToken: 'testSession',
+        }
+        const updateIamRequest: UpdateCredentialsRequest = {
+            data: malformedIamCredentials as IamCredentials,
+            encrypted: false,
+        }
+        const auth = new Auth(serverLspConnectionMock)
+        const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-    await assert.rejects(
-      authHandlers.iamUpdateHandler(updateIamRequest),
-      /Invalid IAM credentials/,
-    );
-    assert(!credentialsProvider.getCredentials("iam"));
-  });
+        await assert.rejects(authHandlers.iamUpdateHandler(updateIamRequest), /Invalid IAM credentials/)
+        assert(!credentialsProvider.getCredentials('iam'))
+    })
 
-  it("Rejects when bearer credentials are invalid", async () => {
-    const malformedBearerCredentials = {
-      token: undefined as unknown,
-    };
-    const updateBearerRequest: UpdateCredentialsRequest = {
-      data: malformedBearerCredentials as BearerCredentials,
-      encrypted: false,
-    };
-    const auth = new Auth(serverLspConnectionMock);
-    const credentialsProvider: CredentialsProvider =
-      auth.getCredentialsProvider();
+    it('Rejects when bearer credentials are invalid', async () => {
+        const malformedBearerCredentials = {
+            token: undefined as unknown,
+        }
+        const updateBearerRequest: UpdateCredentialsRequest = {
+            data: malformedBearerCredentials as BearerCredentials,
+            encrypted: false,
+        }
+        const auth = new Auth(serverLspConnectionMock)
+        const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-    await assert.rejects(
-      authHandlers.bearerUpdateHandler(updateBearerRequest),
-      /Invalid bearer credentials/,
-    );
-    assert(!credentialsProvider.getCredentials("bearer"));
-  });
+        await assert.rejects(authHandlers.bearerUpdateHandler(updateBearerRequest), /Invalid bearer credentials/)
+        assert(!credentialsProvider.getCredentials('bearer'))
+    })
 
-  describe("Credentials provider", () => {
-    it("Prevents modifying IAM credentials object", async () => {
-      const updateIamRequest: UpdateCredentialsRequest = {
-        data: iamCredentials,
-        encrypted: false,
-      };
-      const auth = new Auth(serverLspConnectionMock);
-      const credentialsProvider: CredentialsProvider =
-        auth.getCredentialsProvider();
+    describe('Credentials provider', () => {
+        it('Prevents modifying IAM credentials object', async () => {
+            const updateIamRequest: UpdateCredentialsRequest = {
+                data: iamCredentials,
+                encrypted: false,
+            }
+            const auth = new Auth(serverLspConnectionMock)
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-      await authHandlers.iamUpdateHandler(updateIamRequest);
+            await authHandlers.iamUpdateHandler(updateIamRequest)
 
-      let creds: any = credentialsProvider.getCredentials("iam");
-      const initialAccessKey = creds.accessKeyId;
+            let creds: any = credentialsProvider.getCredentials('iam')
+            const initialAccessKey = creds.accessKeyId
 
-      assert.throws(
-        () => (creds.accessKeyId = "anotherKey"),
-        /Cannot assign to read only property/,
-      );
-      creds = {};
-      assert(
-        (credentialsProvider.getCredentials("iam") as IamCredentials)
-          .accessKeyId === initialAccessKey,
-      );
-    });
+            assert.throws(() => (creds.accessKeyId = 'anotherKey'), /Cannot assign to read only property/)
+            creds = {}
+            assert((credentialsProvider.getCredentials('iam') as IamCredentials).accessKeyId === initialAccessKey)
+        })
 
-    it("Prevents modifying Bearer credentials object", async () => {
-      const updateBearerRequest: UpdateCredentialsRequest = {
-        data: bearerCredentials,
-        encrypted: false,
-      };
+        it('Prevents modifying Bearer credentials object', async () => {
+            const updateBearerRequest: UpdateCredentialsRequest = {
+                data: bearerCredentials,
+                encrypted: false,
+            }
 
-      const auth = new Auth(serverLspConnectionMock);
-      const credentialsProvider: CredentialsProvider =
-        auth.getCredentialsProvider();
+            const auth = new Auth(serverLspConnectionMock)
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-      await authHandlers.bearerUpdateHandler(updateBearerRequest);
+            await authHandlers.bearerUpdateHandler(updateBearerRequest)
 
-      let creds: any = credentialsProvider.getCredentials("bearer");
-      const initialToken = creds.token;
-      assert.throws(
-        () => (creds.token = "anotherToken"),
-        /Cannot assign to read only property/,
-      );
-      creds = {};
-      assert(
-        (credentialsProvider.getCredentials("bearer") as BearerCredentials)
-          .token === initialToken,
-      );
-    });
+            let creds: any = credentialsProvider.getCredentials('bearer')
+            const initialToken = creds.token
+            assert.throws(() => (creds.token = 'anotherToken'), /Cannot assign to read only property/)
+            creds = {}
+            assert((credentialsProvider.getCredentials('bearer') as BearerCredentials).token === initialToken)
+        })
 
-    it("Throws on unsupported type", async () => {
-      const auth = new Auth(serverLspConnectionMock);
-      const credentialsProvider: CredentialsProvider =
-        auth.getCredentialsProvider();
+        it('Throws on unsupported type', async () => {
+            const auth = new Auth(serverLspConnectionMock)
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-      assert.throws(
-        () =>
-          credentialsProvider.hasCredentials(
-            "unsupported_type" as CredentialsType,
-          ),
-        /Unsupported credentials type/,
-      );
-      assert.throws(
-        () =>
-          credentialsProvider.getCredentials(
-            "unsupported_type" as CredentialsType,
-          ),
-        /Unsupported credentials type/,
-      );
-    });
-  });
+            assert.throws(
+                () => credentialsProvider.hasCredentials('unsupported_type' as CredentialsType),
+                /Unsupported credentials type/
+            )
+            assert.throws(
+                () => credentialsProvider.getCredentials('unsupported_type' as CredentialsType),
+                /Unsupported credentials type/
+            )
+        })
+    })
 
-  describe("Encrypted credentials", () => {
-    it("Rejects when encrypted flag is set wrong", async () => {
-      const updateIamRequest: UpdateCredentialsRequest = {
-        data: iamCredentials as IamCredentials,
-        encrypted: true,
-      };
-      const auth = new Auth(serverLspConnectionMock);
-      const credentialsProvider: CredentialsProvider =
-        auth.getCredentialsProvider();
+    describe('Encrypted credentials', () => {
+        it('Rejects when encrypted flag is set wrong', async () => {
+            const updateIamRequest: UpdateCredentialsRequest = {
+                data: iamCredentials as IamCredentials,
+                encrypted: true,
+            }
+            const auth = new Auth(serverLspConnectionMock)
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-      await assert.rejects(
-        authHandlers.iamUpdateHandler(updateIamRequest),
-        /No encryption key/,
-      );
+            await assert.rejects(authHandlers.iamUpdateHandler(updateIamRequest), /No encryption key/)
 
-      assert(!credentialsProvider.getCredentials("iam"));
-    });
+            assert(!credentialsProvider.getCredentials('iam'))
+        })
 
-    it("Handles encrypted IAM credentials", async () => {
-      const auth = new Auth(
-        serverLspConnectionMock,
-        encryptionKey.toString("base64"),
-        "JWT",
-      );
-      const credentialsProvider: CredentialsProvider =
-        auth.getCredentialsProvider();
+        it('Handles encrypted IAM credentials', async () => {
+            const auth = new Auth(serverLspConnectionMock, encryptionKey.toString('base64'), 'JWT')
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-      const payload = { data: iamCredentials };
+            const payload = { data: iamCredentials }
 
-      const jwt = await new jose.EncryptJWT(payload)
-        .setProtectedHeader({ alg: "dir", enc: "A256GCM" })
-        .encrypt(encryptionKey);
+            const jwt = await new jose.EncryptJWT(payload)
+                .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+                .encrypt(encryptionKey)
 
-      const updateIamRequest: UpdateCredentialsRequest = {
-        data: jwt,
-        encrypted: true,
-      };
-      await authHandlers.iamUpdateHandler(updateIamRequest);
-      assert.deepEqual(
-        credentialsProvider.getCredentials("iam"),
-        iamCredentials,
-      );
-    });
+            const updateIamRequest: UpdateCredentialsRequest = {
+                data: jwt,
+                encrypted: true,
+            }
+            await authHandlers.iamUpdateHandler(updateIamRequest)
+            assert.deepEqual(credentialsProvider.getCredentials('iam'), iamCredentials)
+        })
 
-    it("Handles encrypted bearer credentials", async () => {
-      const auth = new Auth(
-        serverLspConnectionMock,
-        encryptionKey.toString("base64"),
-        "JWT",
-      );
-      const credentialsProvider: CredentialsProvider =
-        auth.getCredentialsProvider();
+        it('Handles encrypted bearer credentials', async () => {
+            const auth = new Auth(serverLspConnectionMock, encryptionKey.toString('base64'), 'JWT')
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-      const payload = { data: bearerCredentials };
+            const payload = { data: bearerCredentials }
 
-      const jwt = await new jose.EncryptJWT(payload)
-        .setProtectedHeader({ alg: "dir", enc: "A256GCM" })
-        .encrypt(encryptionKey);
+            const jwt = await new jose.EncryptJWT(payload)
+                .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+                .encrypt(encryptionKey)
 
-      const updateBearerRequest: UpdateCredentialsRequest = {
-        data: jwt,
-        encrypted: true,
-      };
-      await authHandlers.bearerUpdateHandler(updateBearerRequest);
-      assert.deepEqual(
-        credentialsProvider.getCredentials("bearer"),
-        bearerCredentials,
-      );
-    });
+            const updateBearerRequest: UpdateCredentialsRequest = {
+                data: jwt,
+                encrypted: true,
+            }
+            await authHandlers.bearerUpdateHandler(updateBearerRequest)
+            assert.deepEqual(credentialsProvider.getCredentials('bearer'), bearerCredentials)
+        })
 
-    it("Rejects if encryption algorithm is not direct A256GCM", async () => {
-      const auth = new Auth(
-        serverLspConnectionMock,
-        encryptionKey.toString("base64"),
-        "JWT",
-      );
-      const credentialsProvider: CredentialsProvider =
-        auth.getCredentialsProvider();
+        it('Rejects if encryption algorithm is not direct A256GCM', async () => {
+            const auth = new Auth(serverLspConnectionMock, encryptionKey.toString('base64'), 'JWT')
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-      const payload = { data: bearerCredentials };
+            const payload = { data: bearerCredentials }
 
-      const jwt = await new jose.EncryptJWT(payload)
-        .setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256" })
-        .encrypt(encryptionKey);
+            const jwt = await new jose.EncryptJWT(payload)
+                .setProtectedHeader({ alg: 'dir', enc: 'A128CBC-HS256' })
+                .encrypt(encryptionKey)
 
-      const updateBearerRequest: UpdateCredentialsRequest = {
-        data: jwt,
-        encrypted: true,
-      };
-      await assert.rejects(
-        authHandlers.bearerUpdateHandler(updateBearerRequest),
-        /Header Parameter value not allowed/,
-      );
-      assert(!credentialsProvider.getCredentials("bearer"));
-    });
+            const updateBearerRequest: UpdateCredentialsRequest = {
+                data: jwt,
+                encrypted: true,
+            }
+            await assert.rejects(
+                authHandlers.bearerUpdateHandler(updateBearerRequest),
+                /Header Parameter value not allowed/
+            )
+            assert(!credentialsProvider.getCredentials('bearer'))
+        })
 
-    it("Verifies JWT claims", async () => {
-      const auth = new Auth(
-        serverLspConnectionMock,
-        encryptionKey.toString("base64"),
-        "JWT",
-      );
-      const credentialsProvider: CredentialsProvider =
-        auth.getCredentialsProvider();
+        it('Verifies JWT claims', async () => {
+            const auth = new Auth(serverLspConnectionMock, encryptionKey.toString('base64'), 'JWT')
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
-      const payload = { data: bearerCredentials };
+            const payload = { data: bearerCredentials }
 
-      const jwt = await new jose.EncryptJWT(payload)
-        .setProtectedHeader({ alg: "dir", enc: "A256GCM" })
-        .setNotBefore(new Date().getTime() / 1000 + 50) //allows up to 60s clockTolerance
-        .setExpirationTime(new Date().getTime() / 1000 - 70) //not allowed
-        .encrypt(encryptionKey);
+            const jwt = await new jose.EncryptJWT(payload)
+                .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+                .setNotBefore(new Date().getTime() / 1000 + 50) //allows up to 60s clockTolerance
+                .setExpirationTime(new Date().getTime() / 1000 - 70) //not allowed
+                .encrypt(encryptionKey)
 
-      const updateBearerRequest: UpdateCredentialsRequest = {
-        data: jwt,
-        encrypted: true,
-      };
-      await assert.rejects(
-        authHandlers.bearerUpdateHandler(updateBearerRequest),
-        /"exp" claim timestamp check failed/,
-      );
-      assert(!credentialsProvider.getCredentials("bearer"));
-    });
-  });
-});
+            const updateBearerRequest: UpdateCredentialsRequest = {
+                data: jwt,
+                encrypted: true,
+            }
+            await assert.rejects(
+                authHandlers.bearerUpdateHandler(updateBearerRequest),
+                /"exp" claim timestamp check failed/
+            )
+            assert(!credentialsProvider.getCredentials('bearer'))
+        })
+    })
+})

--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -1,250 +1,222 @@
-import { jwtDecrypt } from "jose";
-import { Connection } from "vscode-languageserver";
-import { CredentialsEncoding } from "./standalone/encryption";
+import { jwtDecrypt } from 'jose'
+import { Connection } from 'vscode-languageserver'
+import { CredentialsEncoding } from './standalone/encryption'
 
 export type IamCredentials = {
-  readonly accessKeyId: string;
-  readonly secretAccessKey: string;
-  readonly sessionToken?: string;
-};
-
-export type BearerCredentials = {
-  readonly token: string;
-};
-
-export type CredentialsType = "iam" | "bearer";
-export type Credentials = IamCredentials | BearerCredentials;
-
-export function isIamCredentials(
-  credentials: Credentials,
-): credentials is IamCredentials {
-  const iamCredentials = credentials as IamCredentials;
-  return (
-    iamCredentials?.accessKeyId !== undefined &&
-    iamCredentials?.secretAccessKey !== undefined
-  );
+    readonly accessKeyId: string
+    readonly secretAccessKey: string
+    readonly sessionToken?: string
 }
 
-export function isBearerCredentials(
-  credentials: Credentials,
-): credentials is BearerCredentials {
-  return (credentials as BearerCredentials)?.token !== undefined;
+export type BearerCredentials = {
+    readonly token: string
+}
+
+export type CredentialsType = 'iam' | 'bearer'
+export type Credentials = IamCredentials | BearerCredentials
+
+export function isIamCredentials(credentials: Credentials): credentials is IamCredentials {
+    const iamCredentials = credentials as IamCredentials
+    return iamCredentials?.accessKeyId !== undefined && iamCredentials?.secretAccessKey !== undefined
+}
+
+export function isBearerCredentials(credentials: Credentials): credentials is BearerCredentials {
+    return (credentials as BearerCredentials)?.token !== undefined
 }
 
 export interface SsoProfileData {
-  startUrl?: string;
+    startUrl?: string
 }
 
 export interface ConnectionMetadata {
-  sso?: SsoProfileData;
+    sso?: SsoProfileData
 }
 
 export interface CredentialsProvider {
-  hasCredentials: (type: CredentialsType) => boolean;
-  getCredentials: (type: CredentialsType) => Credentials | undefined;
-  getConnectionMetadata: () => ConnectionMetadata | undefined;
+    hasCredentials: (type: CredentialsType) => boolean
+    getCredentials: (type: CredentialsType) => Credentials | undefined
+    getConnectionMetadata: () => ConnectionMetadata | undefined
 }
 
 export const credentialsProtocolMethodNames = {
-  iamCredentialsUpdate: "aws/credentials/iam/update",
-  iamCredentialsDelete: "aws/credentials/iam/delete",
-  bearerCredentialsUpdate: "aws/credentials/token/update",
-  bearerCredentialsDelete: "aws/credentials/token/delete",
-  getConnectionMetadata: "aws/credentials/getConnectionMetadata",
-};
+    iamCredentialsUpdate: 'aws/credentials/iam/update',
+    iamCredentialsDelete: 'aws/credentials/iam/delete',
+    bearerCredentialsUpdate: 'aws/credentials/token/update',
+    bearerCredentialsDelete: 'aws/credentials/token/delete',
+    getConnectionMetadata: 'aws/credentials/getConnectionMetadata',
+}
 
 export interface UpdateCredentialsRequest {
-  // Plaintext Credentials (for browser based environments) or encrypted JWT token
-  data: string | Credentials;
-  // If the payload is encrypted
-  // Defaults to false if undefined or null
-  encrypted?: boolean;
+    // Plaintext Credentials (for browser based environments) or encrypted JWT token
+    data: string | Credentials
+    // If the payload is encrypted
+    // Defaults to false if undefined or null
+    encrypted?: boolean
 }
 
 export class Auth {
-  private iamCredentials: IamCredentials | undefined;
-  private bearerCredentials: BearerCredentials | undefined;
-  private credentialsProvider: CredentialsProvider;
-  private connectionMetadata: ConnectionMetadata | undefined;
+    private iamCredentials: IamCredentials | undefined
+    private bearerCredentials: BearerCredentials | undefined
+    private credentialsProvider: CredentialsProvider
+    private connectionMetadata: ConnectionMetadata | undefined
 
-  private key: Buffer | undefined;
-  private credentialsEncoding: CredentialsEncoding | undefined;
+    private key: Buffer | undefined
+    private credentialsEncoding: CredentialsEncoding | undefined
 
-  constructor(
-    private readonly connection: Connection,
-    key?: string,
-    encoding?: CredentialsEncoding,
-  ) {
-    if (key) {
-      this.key = Buffer.from(key, "base64");
-      this.credentialsEncoding = encoding;
+    constructor(
+        private readonly connection: Connection,
+        key?: string,
+        encoding?: CredentialsEncoding
+    ) {
+        if (key) {
+            this.key = Buffer.from(key, 'base64')
+            this.credentialsEncoding = encoding
+        }
+
+        this.credentialsProvider = {
+            getCredentials: (type: CredentialsType): Credentials | undefined => {
+                if (type === 'iam') {
+                    return this.iamCredentials
+                }
+                if (type === 'bearer') {
+                    return this.bearerCredentials
+                }
+                throw new Error(`Unsupported credentials type: ${type}`)
+            },
+
+            hasCredentials: (type: CredentialsType): boolean => {
+                if (type === 'iam') {
+                    return this.iamCredentials !== undefined
+                }
+                if (type === 'bearer') {
+                    return this.bearerCredentials !== undefined
+                }
+                throw new Error(`Unsupported credentials type: ${type}`)
+            },
+
+            getConnectionMetadata: () => {
+                return this.connectionMetadata
+            },
+        }
+
+        this.registerLspCredentialsUpdateHandlers()
     }
 
-    this.credentialsProvider = {
-      getCredentials: (type: CredentialsType): Credentials | undefined => {
-        if (type === "iam") {
-          return this.iamCredentials;
-        }
-        if (type === "bearer") {
-          return this.bearerCredentials;
-        }
-        throw new Error(`Unsupported credentials type: ${type}`);
-      },
-
-      hasCredentials: (type: CredentialsType): boolean => {
-        if (type === "iam") {
-          return this.iamCredentials !== undefined;
-        }
-        if (type === "bearer") {
-          return this.bearerCredentials !== undefined;
-        }
-        throw new Error(`Unsupported credentials type: ${type}`);
-      },
-
-      getConnectionMetadata: () => {
-        return this.connectionMetadata;
-      },
-    };
-
-    this.registerLspCredentialsUpdateHandlers();
-  }
-
-  public getCredentialsProvider(): CredentialsProvider {
-    return this.credentialsProvider;
-  }
-
-  private areValidCredentials(creds: Credentials): boolean {
-    return creds && (isIamCredentials(creds) || isBearerCredentials(creds));
-  }
-
-  private async registerLspCredentialsUpdateHandlers() {
-    this.registerIamCredentialsUpdateHandlers();
-    this.registerBearerCredentialsUpdateHandlers();
-  }
-
-  private registerIamCredentialsUpdateHandlers(): void {
-    this.connection.console.info(
-      "Runtime: Registering IAM credentials update handler",
-    );
-
-    this.connection.onRequest(
-      credentialsProtocolMethodNames.iamCredentialsUpdate,
-      async (request: UpdateCredentialsRequest) => {
-        const iamCredentials = request.encrypted
-          ? await this.decodeCredentialsRequestToken<IamCredentials>(request)
-          : (request.data as IamCredentials);
-
-        if (isIamCredentials(iamCredentials)) {
-          this.setCredentials(iamCredentials);
-          this.connection.console.info(
-            "Runtime: Successfully saved IAM credentials",
-          );
-        } else {
-          this.iamCredentials = undefined;
-          throw new Error("Invalid IAM credentials");
-        }
-      },
-    );
-
-    this.connection.onNotification(
-      credentialsProtocolMethodNames.iamCredentialsDelete,
-      () => {
-        this.iamCredentials = undefined;
-        this.connection.console.info("Runtime: Deleted IAM credentials");
-      },
-    );
-  }
-
-  private registerBearerCredentialsUpdateHandlers(): void {
-    this.connection.console.info(
-      "Runtime: Registering bearer credentials update handler",
-    );
-
-    this.connection.onRequest(
-      credentialsProtocolMethodNames.bearerCredentialsUpdate,
-      async (request: UpdateCredentialsRequest) => {
-        const bearerCredentials = request.encrypted
-          ? await this.decodeCredentialsRequestToken<BearerCredentials>(request)
-          : (request.data as BearerCredentials);
-
-        if (isBearerCredentials(bearerCredentials)) {
-          this.setCredentials(bearerCredentials);
-          this.connection.console.info(
-            "Runtime: Successfully saved bearer credentials",
-          );
-
-          await this.requestConnectionMetadata();
-        } else {
-          this.bearerCredentials = undefined;
-          throw new Error("Invalid bearer credentials");
-        }
-      },
-    );
-
-    this.connection.onNotification(
-      credentialsProtocolMethodNames.bearerCredentialsDelete,
-      () => {
-        this.bearerCredentials = undefined;
-        this.connectionMetadata = undefined;
-        this.connection.console.info("Runtime: Deleted bearer credentials");
-      },
-    );
-  }
-
-  private setCredentials(creds: Credentials) {
-    if (this.areValidCredentials(creds)) {
-      if (isIamCredentials(creds)) {
-        this.iamCredentials = creds as IamCredentials;
-        // Prevent modifying credentials by implementors
-        Object.freeze(this.iamCredentials);
-      } else {
-        this.bearerCredentials = creds as BearerCredentials;
-        Object.freeze(this.bearerCredentials);
-      }
-    }
-  }
-
-  private async decodeCredentialsRequestToken<T>(
-    request: UpdateCredentialsRequest,
-  ): Promise<T> {
-    this.connection.console.info(
-      "Runtime: Decoding encrypted credentials token",
-    );
-    if (!this.key) {
-      throw new Error("No encryption key");
+    public getCredentialsProvider(): CredentialsProvider {
+        return this.credentialsProvider
     }
 
-    if (this.credentialsEncoding === "JWT") {
-      this.connection.console.info("Decoding JWT token");
-      const result = await jwtDecrypt(request.data as string, this.key, {
-        clockTolerance: 60, // Allow up to 60 seconds to account for clock differences
-        contentEncryptionAlgorithms: ["A256GCM"],
-        keyManagementAlgorithms: ["dir"],
-      });
-      if (!result.payload.data) {
-        throw new Error("JWT payload not found");
-      }
-      return result.payload.data as T;
+    private areValidCredentials(creds: Credentials): boolean {
+        return creds && (isIamCredentials(creds) || isBearerCredentials(creds))
     }
-    throw new Error("Encoding mode not implemented");
-  }
 
-  private async requestConnectionMetadata() {
-    try {
-      const connectionMetadata =
-        await this.connection.sendRequest<ConnectionMetadata>(
-          credentialsProtocolMethodNames.getConnectionMetadata,
-        );
-
-      this.connectionMetadata = connectionMetadata;
-      this.connection.console.info("Runtime: Connection metadata updated");
-    } catch (error: any) {
-      this.connectionMetadata = undefined;
-      this.connection.console.info(
-        `Runtime: Failed to update Connection metadata with error: ${
-          error?.message || "unknown"
-        }`,
-      );
+    private async registerLspCredentialsUpdateHandlers() {
+        this.registerIamCredentialsUpdateHandlers()
+        this.registerBearerCredentialsUpdateHandlers()
     }
-  }
+
+    private registerIamCredentialsUpdateHandlers(): void {
+        this.connection.console.info('Runtime: Registering IAM credentials update handler')
+
+        this.connection.onRequest(
+            credentialsProtocolMethodNames.iamCredentialsUpdate,
+            async (request: UpdateCredentialsRequest) => {
+                const iamCredentials = request.encrypted
+                    ? await this.decodeCredentialsRequestToken<IamCredentials>(request)
+                    : (request.data as IamCredentials)
+
+                if (isIamCredentials(iamCredentials)) {
+                    this.setCredentials(iamCredentials)
+                    this.connection.console.info('Runtime: Successfully saved IAM credentials')
+                } else {
+                    this.iamCredentials = undefined
+                    throw new Error('Invalid IAM credentials')
+                }
+            }
+        )
+
+        this.connection.onNotification(credentialsProtocolMethodNames.iamCredentialsDelete, () => {
+            this.iamCredentials = undefined
+            this.connection.console.info('Runtime: Deleted IAM credentials')
+        })
+    }
+
+    private registerBearerCredentialsUpdateHandlers(): void {
+        this.connection.console.info('Runtime: Registering bearer credentials update handler')
+
+        this.connection.onRequest(
+            credentialsProtocolMethodNames.bearerCredentialsUpdate,
+            async (request: UpdateCredentialsRequest) => {
+                const bearerCredentials = request.encrypted
+                    ? await this.decodeCredentialsRequestToken<BearerCredentials>(request)
+                    : (request.data as BearerCredentials)
+
+                if (isBearerCredentials(bearerCredentials)) {
+                    this.setCredentials(bearerCredentials)
+                    this.connection.console.info('Runtime: Successfully saved bearer credentials')
+
+                    await this.requestConnectionMetadata()
+                } else {
+                    this.bearerCredentials = undefined
+                    throw new Error('Invalid bearer credentials')
+                }
+            }
+        )
+
+        this.connection.onNotification(credentialsProtocolMethodNames.bearerCredentialsDelete, () => {
+            this.bearerCredentials = undefined
+            this.connectionMetadata = undefined
+            this.connection.console.info('Runtime: Deleted bearer credentials')
+        })
+    }
+
+    private setCredentials(creds: Credentials) {
+        if (this.areValidCredentials(creds)) {
+            if (isIamCredentials(creds)) {
+                this.iamCredentials = creds as IamCredentials
+                // Prevent modifying credentials by implementors
+                Object.freeze(this.iamCredentials)
+            } else {
+                this.bearerCredentials = creds as BearerCredentials
+                Object.freeze(this.bearerCredentials)
+            }
+        }
+    }
+
+    private async decodeCredentialsRequestToken<T>(request: UpdateCredentialsRequest): Promise<T> {
+        this.connection.console.info('Runtime: Decoding encrypted credentials token')
+        if (!this.key) {
+            throw new Error('No encryption key')
+        }
+
+        if (this.credentialsEncoding === 'JWT') {
+            this.connection.console.info('Decoding JWT token')
+            const result = await jwtDecrypt(request.data as string, this.key, {
+                clockTolerance: 60, // Allow up to 60 seconds to account for clock differences
+                contentEncryptionAlgorithms: ['A256GCM'],
+                keyManagementAlgorithms: ['dir'],
+            })
+            if (!result.payload.data) {
+                throw new Error('JWT payload not found')
+            }
+            return result.payload.data as T
+        }
+        throw new Error('Encoding mode not implemented')
+    }
+
+    private async requestConnectionMetadata() {
+        try {
+            const connectionMetadata = await this.connection.sendRequest<ConnectionMetadata>(
+                credentialsProtocolMethodNames.getConnectionMetadata
+            )
+
+            this.connectionMetadata = connectionMetadata
+            this.connection.console.info('Runtime: Connection metadata updated')
+        } catch (error: any) {
+            this.connectionMetadata = undefined
+            this.connection.console.info(
+                `Runtime: Failed to update Connection metadata with error: ${error?.message || 'unknown'}`
+            )
+        }
+    }
 }

--- a/src/features/auth/standalone/encryption.test.ts
+++ b/src/features/auth/standalone/encryption.test.ts
@@ -1,135 +1,127 @@
-import { Readable } from "stream";
-import assert from "assert";
+import { Readable } from 'stream'
+import assert from 'assert'
 import {
-  EncryptionInitialization,
-  readEncryptionDetails,
-  shouldWaitForEncryptionKey,
-  validateEncryptionDetails,
-} from "./encryption";
-import sinon from "sinon";
+    EncryptionInitialization,
+    readEncryptionDetails,
+    shouldWaitForEncryptionKey,
+    validateEncryptionDetails,
+} from './encryption'
+import sinon from 'sinon'
 
 function createReadableStream(): Readable {
-  const stream = new Readable();
-  // throws error if not implemented
-  stream._read = function () {};
-  return stream;
+    const stream = new Readable()
+    // throws error if not implemented
+    stream._read = function () {}
+    return stream
 }
 
-describe("readEncryptionDetails", () => {
-  it("resolves with the parsed encryption details", async () => {
-    const request: EncryptionInitialization = {
-      version: "1.0",
-      mode: "JWT",
-      key: "encryption_key",
-    };
+describe('readEncryptionDetails', () => {
+    it('resolves with the parsed encryption details', async () => {
+        const request: EncryptionInitialization = {
+            version: '1.0',
+            mode: 'JWT',
+            key: 'encryption_key',
+        }
 
-    const stream = createReadableStream();
-    stream.push(JSON.stringify(request));
-    stream.push("\n");
+        const stream = createReadableStream()
+        stream.push(JSON.stringify(request))
+        stream.push('\n')
 
-    const result = await readEncryptionDetails(stream);
-    assert.deepEqual(result, request);
-  });
+        const result = await readEncryptionDetails(stream)
+        assert.deepEqual(result, request)
+    })
 
-  it("rejects if no newline is encountered within the timeout", async () => {
-    const clock = sinon.useFakeTimers();
-    const stream = createReadableStream();
-    const timeoutMs = 5000;
+    it('rejects if no newline is encountered within the timeout', async () => {
+        const clock = sinon.useFakeTimers()
+        const stream = createReadableStream()
+        const timeoutMs = 5000
 
-    await assert.rejects(async () => {
-      const promise = readEncryptionDetails(stream);
-      clock.tick(timeoutMs);
-      await promise;
-    }, /Encryption details followed by newline must be sent during first/);
+        await assert.rejects(async () => {
+            const promise = readEncryptionDetails(stream)
+            clock.tick(timeoutMs)
+            await promise
+        }, /Encryption details followed by newline must be sent during first/)
 
-    clock.restore();
-  });
+        clock.restore()
+    })
 
-  it("rejects if bad JSON is sent", async () => {
-    const stream = createReadableStream();
+    it('rejects if bad JSON is sent', async () => {
+        const stream = createReadableStream()
 
-    stream.push("badJSON");
-    stream.push("\n");
+        stream.push('badJSON')
+        stream.push('\n')
 
-    await assert.rejects(readEncryptionDetails(stream), /SyntaxError/);
-  });
-});
+        await assert.rejects(readEncryptionDetails(stream), /SyntaxError/)
+    })
+})
 
-describe("validateEncryptionDetails", () => {
-  it("does not throw for valid encryption details", () => {
-    const validEncryptionDetails: EncryptionInitialization = {
-      version: "1.0",
-      key: "secret_key",
-      mode: "JWT",
-    };
+describe('validateEncryptionDetails', () => {
+    it('does not throw for valid encryption details', () => {
+        const validEncryptionDetails: EncryptionInitialization = {
+            version: '1.0',
+            key: 'secret_key',
+            mode: 'JWT',
+        }
 
-    assert.doesNotThrow(() =>
-      validateEncryptionDetails(validEncryptionDetails),
-    );
-  });
+        assert.doesNotThrow(() => validateEncryptionDetails(validEncryptionDetails))
+    })
 
-  it("throws for unsupported initialization version", () => {
-    const invalidVersionEncryptionDetails: EncryptionInitialization = {
-      version: "2.0", // Unsupported version
-      key: "secret_key",
-      mode: "JWT",
-    };
+    it('throws for unsupported initialization version', () => {
+        const invalidVersionEncryptionDetails: EncryptionInitialization = {
+            version: '2.0', // Unsupported version
+            key: 'secret_key',
+            mode: 'JWT',
+        }
 
-    assert.throws(
-      () => validateEncryptionDetails(invalidVersionEncryptionDetails),
-      /Unsupported initialization version: 2.0/,
-    );
-  });
+        assert.throws(
+            () => validateEncryptionDetails(invalidVersionEncryptionDetails),
+            /Unsupported initialization version: 2.0/
+        )
+    })
 
-  it("throws for missing encryption key", () => {
-    const missingKeyEncryptionDetails = {
-      version: "1.0",
-      // Missing key
-      mode: "JWT",
-    };
+    it('throws for missing encryption key', () => {
+        const missingKeyEncryptionDetails = {
+            version: '1.0',
+            // Missing key
+            mode: 'JWT',
+        }
 
-    assert.throws(
-      () =>
-        validateEncryptionDetails(
-          missingKeyEncryptionDetails as EncryptionInitialization,
-        ),
-      /Encryption key is missing/,
-    );
-  });
+        assert.throws(
+            () => validateEncryptionDetails(missingKeyEncryptionDetails as EncryptionInitialization),
+            /Encryption key is missing/
+        )
+    })
 
-  it("throws for unsupported encoding mode", () => {
-    const invalidModeEncryptionDetails = {
-      version: "1.0",
-      key: "secret_key",
-      mode: "AES", // Unsupported mode
-    };
+    it('throws for unsupported encoding mode', () => {
+        const invalidModeEncryptionDetails = {
+            version: '1.0',
+            key: 'secret_key',
+            mode: 'AES', // Unsupported mode
+        }
 
-    assert.throws(
-      () =>
-        validateEncryptionDetails(
-          invalidModeEncryptionDetails as EncryptionInitialization,
-        ),
-      /Unsupported encoding mode: AES/,
-    );
-  });
-});
+        assert.throws(
+            () => validateEncryptionDetails(invalidModeEncryptionDetails as EncryptionInitialization),
+            /Unsupported encoding mode: AES/
+        )
+    })
+})
 
-describe("shouldWaitForEncryptionKey", () => {
-  it("should return true when --set-credentials-encryption-key is in process.argv", () => {
-    const originalArgv = process.argv;
-    process.argv = ["--set-credentials-encryption-key"];
+describe('shouldWaitForEncryptionKey', () => {
+    it('should return true when --set-credentials-encryption-key is in process.argv', () => {
+        const originalArgv = process.argv
+        process.argv = ['--set-credentials-encryption-key']
 
-    assert.strictEqual(shouldWaitForEncryptionKey(), true);
+        assert.strictEqual(shouldWaitForEncryptionKey(), true)
 
-    process.argv = originalArgv;
-  });
+        process.argv = originalArgv
+    })
 
-  it("should return false when --set-credentials-encryption-key is not in process.argv", () => {
-    const originalArgv = process.argv;
-    process.argv = ["--some-other-arg"];
+    it('should return false when --set-credentials-encryption-key is not in process.argv', () => {
+        const originalArgv = process.argv
+        process.argv = ['--some-other-arg']
 
-    assert.strictEqual(shouldWaitForEncryptionKey(), false);
+        assert.strictEqual(shouldWaitForEncryptionKey(), false)
 
-    process.argv = originalArgv;
-  });
-});
+        process.argv = originalArgv
+    })
+})

--- a/src/features/auth/standalone/encryption.ts
+++ b/src/features/auth/standalone/encryption.ts
@@ -1,97 +1,87 @@
-import { Readable } from "stream";
+import { Readable } from 'stream'
 
 export function shouldWaitForEncryptionKey(): boolean {
-  return process.argv.some((arg) => arg === "--set-credentials-encryption-key");
+    return process.argv.some(arg => arg === '--set-credentials-encryption-key')
 }
 
-export type CredentialsEncoding = "JWT";
+export type CredentialsEncoding = 'JWT'
 
 /**
  * Runtimes expect destinations to provide this payload as part of the startup sequence
  * if encrypted credentials are required
  */
 export type EncryptionInitialization = {
-  /**
-   * The version of this payload.
-   * If the property is set to a value that the server has not implemented, or
-   * does not support, a fatal exception is thrown.
-   */
-  version: string;
-  /**
-   * Indicates how credentials tokens will be encoded for this session.
-   */
-  mode: CredentialsEncoding;
-  /**
-   * Base64 encoding of the encryption key to be used for the duration of this session.
-   */
-  key: string;
-};
+    /**
+     * The version of this payload.
+     * If the property is set to a value that the server has not implemented, or
+     * does not support, a fatal exception is thrown.
+     */
+    version: string
+    /**
+     * Indicates how credentials tokens will be encoded for this session.
+     */
+    mode: CredentialsEncoding
+    /**
+     * Base64 encoding of the encryption key to be used for the duration of this session.
+     */
+    key: string
+}
 
-export function validateEncryptionDetails(
-  encryptionDetails: EncryptionInitialization,
-) {
-  if (encryptionDetails.version !== "1.0") {
-    throw new Error(
-      `Unsupported initialization version: ${encryptionDetails.version}`,
-    );
-  }
+export function validateEncryptionDetails(encryptionDetails: EncryptionInitialization) {
+    if (encryptionDetails.version !== '1.0') {
+        throw new Error(`Unsupported initialization version: ${encryptionDetails.version}`)
+    }
 
-  if (!encryptionDetails.key) {
-    throw new Error(`Encryption key is missing`);
-  }
+    if (!encryptionDetails.key) {
+        throw new Error(`Encryption key is missing`)
+    }
 
-  if (encryptionDetails.mode !== "JWT") {
-    throw new Error(`Unsupported encoding mode: ${encryptionDetails.mode}`);
-  }
+    if (encryptionDetails.mode !== 'JWT') {
+        throw new Error(`Unsupported encoding mode: ${encryptionDetails.mode}`)
+    }
 }
 
 /**
  * Read from the given stream, stopping after the first newline (\n).
  * Return the string consumed from the stream.
  */
-export function readEncryptionDetails(
-  stream: Readable,
-): Promise<EncryptionInitialization> {
-  return new Promise<EncryptionInitialization>((resolve, reject) => {
-    let buffer = Buffer.alloc(0);
-    const TIMEOUT_INTERVAL_MS = 5000;
+export function readEncryptionDetails(stream: Readable): Promise<EncryptionInitialization> {
+    return new Promise<EncryptionInitialization>((resolve, reject) => {
+        let buffer = Buffer.alloc(0)
+        const TIMEOUT_INTERVAL_MS = 5000
 
-    const timer: NodeJS.Timeout = setTimeout(() => {
-      clearTimer();
-      stream.removeListener("readable", onStreamIsReadable);
-      reject(
-        `Encryption details followed by newline must be sent during first ${TIMEOUT_INTERVAL_MS}ms`,
-      );
-    }, TIMEOUT_INTERVAL_MS);
+        const timer: NodeJS.Timeout = setTimeout(() => {
+            clearTimer()
+            stream.removeListener('readable', onStreamIsReadable)
+            reject(`Encryption details followed by newline must be sent during first ${TIMEOUT_INTERVAL_MS}ms`)
+        }, TIMEOUT_INTERVAL_MS)
 
-    const clearTimer = () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-    };
-
-    // Fires when the stream has contents that can be read
-    const onStreamIsReadable = () => {
-      let byteRead;
-      while ((byteRead = stream.read(1)) !== null) {
-        if (byteRead.toString("utf-8") == "\n") {
-          clearTimer();
-          // Stop reading this stream, we have read a line from it
-          stream.removeListener("readable", onStreamIsReadable);
-          try {
-            resolve(
-              JSON.parse(buffer.toString("utf-8")) as EncryptionInitialization,
-            );
-          } catch (error) {
-            reject(error);
-          }
-          break;
-        } else {
-          buffer = Buffer.concat([buffer, byteRead]);
+        const clearTimer = () => {
+            if (timer) {
+                clearTimeout(timer)
+            }
         }
-      }
-    };
 
-    stream.on("readable", onStreamIsReadable);
-  });
+        // Fires when the stream has contents that can be read
+        const onStreamIsReadable = () => {
+            let byteRead
+            while ((byteRead = stream.read(1)) !== null) {
+                if (byteRead.toString('utf-8') == '\n') {
+                    clearTimer()
+                    // Stop reading this stream, we have read a line from it
+                    stream.removeListener('readable', onStreamIsReadable)
+                    try {
+                        resolve(JSON.parse(buffer.toString('utf-8')) as EncryptionInitialization)
+                    } catch (error) {
+                        reject(error)
+                    }
+                    break
+                } else {
+                    buffer = Buffer.concat([buffer, byteRead])
+                }
+            }
+        }
+
+        stream.on('readable', onStreamIsReadable)
+    })
 }

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,5 +1,5 @@
-export { CredentialsProvider } from "./auth/auth";
-export { Logging } from "./logging";
-export { Lsp } from "./lsp";
-export { Telemetry } from "./telemetry/telemetry";
-export { Workspace } from "./workspace";
+export { CredentialsProvider } from './auth/auth'
+export { Logging } from './logging'
+export { Lsp } from './lsp'
+export { Telemetry } from './telemetry/telemetry'
+export { Workspace } from './workspace'

--- a/src/features/logging.ts
+++ b/src/features/logging.ts
@@ -2,6 +2,6 @@
  * The logging feature interface
  */
 export type Logging = {
-  // TODO: Implement log levels
-  log: (message: string) => void;
-};
+    // TODO: Implement log levels
+    log: (message: string) => void
+}

--- a/src/features/lsp/index.ts
+++ b/src/features/lsp/index.ts
@@ -1,108 +1,82 @@
 import {
-  CompletionItem,
-  CompletionList,
-  CompletionParams,
-  DidChangeConfigurationParams,
-  DidChangeTextDocumentParams,
-  DidCloseTextDocumentParams,
-  ExecuteCommandParams,
-  Hover,
-  HoverParams,
-  InitializeError,
-  InitializeParams,
-  InitializedParams,
-  InlineCompletionItem,
-  InlineCompletionList,
-  InlineCompletionParams,
-  LSPAny,
-  NotificationHandler,
-  PublishDiagnosticsParams,
-  RequestHandler,
-  ServerRequestHandler,
-  ServerCapabilities,
-} from "vscode-languageserver";
+    CompletionItem,
+    CompletionList,
+    CompletionParams,
+    DidChangeConfigurationParams,
+    DidChangeTextDocumentParams,
+    DidCloseTextDocumentParams,
+    ExecuteCommandParams,
+    Hover,
+    HoverParams,
+    InitializeError,
+    InitializeParams,
+    InitializedParams,
+    InlineCompletionItem,
+    InlineCompletionList,
+    InlineCompletionParams,
+    LSPAny,
+    NotificationHandler,
+    PublishDiagnosticsParams,
+    RequestHandler,
+    ServerRequestHandler,
+    ServerCapabilities,
+} from 'vscode-languageserver'
 import {
-  InlineCompletionItemWithReferences,
-  InlineCompletionListWithReferences,
-  LogInlineCompletionSessionResultsParams,
-} from "./inline-completions/protocolExtensions";
+    InlineCompletionItemWithReferences,
+    InlineCompletionListWithReferences,
+    LogInlineCompletionSessionResultsParams,
+} from './inline-completions/protocolExtensions'
 
-export { observe } from "./textDocuments/textDocumentConnection";
+export { observe } from './textDocuments/textDocumentConnection'
 
-export type PartialServerCapabilities<T = any> = Pick<
-  ServerCapabilities<T>,
-  "completionProvider" | "hoverProvider"
->;
+export type PartialServerCapabilities<T = any> = Pick<ServerCapabilities<T>, 'completionProvider' | 'hoverProvider'>
 export type PartialInitializeResult<T = any> = {
-  capabilities: PartialServerCapabilities<T>;
-};
+    capabilities: PartialServerCapabilities<T>
+}
 
 // Using `RequestHandler` here from `vscode-languageserver-protocol` which doesn't support partial progress.
 // If we want to support partial progress, we'll need to use `ServerRequestHandler` from `vscode-languageserver` instead.
 // but if we can avoid exposing multiple different `vscode-languageserver-*` packages and package versions to
 // implementors that would prevent potentially very hard to debug type mismatch errors (even on minor versions).
 export type Lsp = {
-  /**
-   * Lsp#addInitializer allows servers to register handlers for the initilaze LSP request.
-   * The handlers respond with PartialInitializeResult which includes a subset of InitializeResult's properties
-   * as not all original properties are expected to be defined by servers.
-   * Then the runtime will use the regiestered handlers and merge their responses when responding to initialize LSP request.
-   *
-   */
-  addInitializer: (
-    handler: RequestHandler<
-      InitializeParams,
-      PartialInitializeResult,
-      InitializeError
-    >,
-  ) => void;
-  onInitialized: (handler: NotificationHandler<InitializedParams>) => void;
-  onInlineCompletion: (
-    handler: RequestHandler<
-      InlineCompletionParams,
-      InlineCompletionItem[] | InlineCompletionList | undefined | null,
-      void
-    >,
-  ) => void;
-  onCompletion: (
-    handler: RequestHandler<
-      CompletionParams,
-      CompletionItem[] | CompletionList | undefined | null,
-      void
-    >,
-  ) => void;
-  didChangeConfiguration: (
-    handler: NotificationHandler<DidChangeConfigurationParams>,
-  ) => void;
-  onDidChangeTextDocument: (
-    handler: NotificationHandler<DidChangeTextDocumentParams>,
-  ) => void;
-  onDidCloseTextDocument: (
-    handler: NotificationHandler<DidCloseTextDocumentParams>,
-  ) => void;
-  publishDiagnostics: (params: PublishDiagnosticsParams) => Promise<void>;
-  onHover: (
-    handler: RequestHandler<HoverParams, Hover | null | undefined, void>,
-  ) => void;
-  onExecuteCommand: (
-    handler: RequestHandler<ExecuteCommandParams, any | undefined | null, void>,
-  ) => void;
-  workspace: {
-    getConfiguration: (section: string) => Promise<any>;
-  };
-  extensions: {
-    onInlineCompletionWithReferences: (
-      handler: RequestHandler<
-        InlineCompletionParams,
-        | InlineCompletionItemWithReferences[]
-        | InlineCompletionListWithReferences
-        | undefined
-        | null,
-        void
-      >,
-    ) => void;
-    onLogInlineCompletionSessionResults: (
-      handler: NotificationHandler<LogInlineCompletionSessionResultsParams>,
-    ) => void;
-  };
-};
+    /**
+     * Lsp#addInitializer allows servers to register handlers for the initilaze LSP request.
+     * The handlers respond with PartialInitializeResult which includes a subset of InitializeResult's properties
+     * as not all original properties are expected to be defined by servers.
+     * Then the runtime will use the regiestered handlers and merge their responses when responding to initialize LSP request.
+     *
+     */
+    addInitializer: (handler: RequestHandler<InitializeParams, PartialInitializeResult, InitializeError>) => void
+    onInitialized: (handler: NotificationHandler<InitializedParams>) => void
+    onInlineCompletion: (
+        handler: RequestHandler<
+            InlineCompletionParams,
+            InlineCompletionItem[] | InlineCompletionList | undefined | null,
+            void
+        >
+    ) => void
+    onCompletion: (
+        handler: RequestHandler<CompletionParams, CompletionItem[] | CompletionList | undefined | null, void>
+    ) => void
+    didChangeConfiguration: (handler: NotificationHandler<DidChangeConfigurationParams>) => void
+    onDidChangeTextDocument: (handler: NotificationHandler<DidChangeTextDocumentParams>) => void
+    onDidCloseTextDocument: (handler: NotificationHandler<DidCloseTextDocumentParams>) => void
+    publishDiagnostics: (params: PublishDiagnosticsParams) => Promise<void>
+    onHover: (handler: RequestHandler<HoverParams, Hover | null | undefined, void>) => void
+    onExecuteCommand: (handler: RequestHandler<ExecuteCommandParams, any | undefined | null, void>) => void
+    workspace: {
+        getConfiguration: (section: string) => Promise<any>
+    }
+    extensions: {
+        onInlineCompletionWithReferences: (
+            handler: RequestHandler<
+                InlineCompletionParams,
+                InlineCompletionItemWithReferences[] | InlineCompletionListWithReferences | undefined | null,
+                void
+            >
+        ) => void
+        onLogInlineCompletionSessionResults: (
+            handler: NotificationHandler<LogInlineCompletionSessionResultsParams>
+        ) => void
+    }
+}

--- a/src/features/lsp/inline-completions/futureProtocol.ts
+++ b/src/features/lsp/inline-completions/futureProtocol.ts
@@ -1,19 +1,19 @@
 import {
-  InlineCompletionItem,
-  InlineCompletionList,
-  InlineCompletionParams,
-  InlineCompletionRegistrationOptions,
-  ProtocolRequestType,
-} from "vscode-languageserver";
+    InlineCompletionItem,
+    InlineCompletionList,
+    InlineCompletionParams,
+    InlineCompletionRegistrationOptions,
+    ProtocolRequestType,
+} from 'vscode-languageserver'
 
 /**
  * inlineCompletionRequestType defines the custom method that the language client
  * requests from the server to provide inline completion recommendations.
  */
 export const inlineCompletionRequestType = new ProtocolRequestType<
-  InlineCompletionParams,
-  InlineCompletionList | InlineCompletionItem[] | null,
-  InlineCompletionItem[],
-  void,
-  InlineCompletionRegistrationOptions
->("aws/textDocument/inlineCompletion");
+    InlineCompletionParams,
+    InlineCompletionList | InlineCompletionItem[] | null,
+    InlineCompletionItem[],
+    void,
+    InlineCompletionRegistrationOptions
+>('aws/textDocument/inlineCompletion')

--- a/src/features/lsp/inline-completions/protocolExtensions.ts
+++ b/src/features/lsp/inline-completions/protocolExtensions.ts
@@ -1,106 +1,103 @@
 import {
-  InlineCompletionItem,
-  InlineCompletionParams,
-  InlineCompletionRegistrationOptions,
-  ProtocolNotificationType,
-  ProtocolRequestType,
-} from "vscode-languageserver";
+    InlineCompletionItem,
+    InlineCompletionParams,
+    InlineCompletionRegistrationOptions,
+    ProtocolNotificationType,
+    ProtocolRequestType,
+} from 'vscode-languageserver'
 
 export type InlineCompletionWithReferencesParams = InlineCompletionParams & {
-  // No added parameters
-};
+    // No added parameters
+}
 
 /**
  * Extend InlineCompletionItem to include optional references.
  */
 export type InlineCompletionItemWithReferences = InlineCompletionItem & {
-  /**
-   * Identifier for the the recommendation returned by server.
-   */
-  itemId: string;
+    /**
+     * Identifier for the the recommendation returned by server.
+     */
+    itemId: string
 
-  references?: {
-    referenceName?: string;
-    referenceUrl?: string;
-    licenseName?: string;
-    position?: {
-      startCharacter?: number;
-      endCharacter?: number;
-    };
-  }[];
-};
+    references?: {
+        referenceName?: string
+        referenceUrl?: string
+        licenseName?: string
+        position?: {
+            startCharacter?: number
+            endCharacter?: number
+        }
+    }[]
+}
 
 /**
  * Extend InlineCompletionList to include optional references. This is not inheriting from `InlineCompletionList`
  * since the `items` arrays are incompatible.
  */
 export type InlineCompletionListWithReferences = {
-  /**
-   * Server returns a session ID for current recommendation session.
-   * Client need to attach this session ID in the request when sending
-   * a completion session results.
-   */
-  sessionId: string;
-  /**
-   * The inline completion items with optional references
-   */
-  items: InlineCompletionItemWithReferences[];
-};
+    /**
+     * Server returns a session ID for current recommendation session.
+     * Client need to attach this session ID in the request when sending
+     * a completion session results.
+     */
+    sessionId: string
+    /**
+     * The inline completion items with optional references
+     */
+    items: InlineCompletionItemWithReferences[]
+}
 
-export const inlineCompletionWithReferencesRequestType =
-  new ProtocolRequestType<
+export const inlineCompletionWithReferencesRequestType = new ProtocolRequestType<
     InlineCompletionWithReferencesParams,
-    | InlineCompletionListWithReferences
-    | InlineCompletionItemWithReferences[]
-    | null,
+    InlineCompletionListWithReferences | InlineCompletionItemWithReferences[] | null,
     InlineCompletionItemWithReferences[],
     void,
     InlineCompletionRegistrationOptions
-  >("aws/textDocument/inlineCompletionWithReferences");
+>('aws/textDocument/inlineCompletionWithReferences')
 
 export interface InlineCompletionStates {
-  /**
-   * Completion item was displayed in the client application UI.
-   */
-  seen: boolean;
-  /**
-   * Completion item was accepted.
-   */
-  accepted: boolean;
-  /**
-   * Recommendation was filtered out on the client-side and marked as discarded.
-   */
-  discarded: boolean;
+    /**
+     * Completion item was displayed in the client application UI.
+     */
+    seen: boolean
+    /**
+     * Completion item was accepted.
+     */
+    accepted: boolean
+    /**
+     * Recommendation was filtered out on the client-side and marked as discarded.
+     */
+    discarded: boolean
 }
 
 export interface LogInlineCompletionSessionResultsParams {
-  /**
-   * Session Id attached to get completion items response.
-   * This value must match to the one that server returned in InlineCompletionListWithReferences response.
-   */
-  sessionId: string;
-  /**
-   * Map with results of interaction with completion items in the client UI.
-   * This list contain a state of each recommendation items from the recommendation session.
-   */
-  completionSessionResult: {
-    [itemId: string /* Completion itemId */]: InlineCompletionStates;
-  };
-  /**
-   * Time from completion request invocation start to rendering of the first recommendation in the UI.
-   */
-  firstCompletionDisplayLatency?: number;
-  /**
-   * Total time when items from this completion session were visible in UI
-   */
-  totalSessionDisplayTime?: number;
-  /**
-   * Length of additional characters inputed by user from when the trigger happens to when the user decision was made
-   */
-  typeaheadLength?: number;
+    /**
+     * Session Id attached to get completion items response.
+     * This value must match to the one that server returned in InlineCompletionListWithReferences response.
+     */
+    sessionId: string
+    /**
+     * Map with results of interaction with completion items in the client UI.
+     * This list contain a state of each recommendation items from the recommendation session.
+     */
+    completionSessionResult: {
+        [itemId: string /* Completion itemId */]: InlineCompletionStates
+    }
+    /**
+     * Time from completion request invocation start to rendering of the first recommendation in the UI.
+     */
+    firstCompletionDisplayLatency?: number
+    /**
+     * Total time when items from this completion session were visible in UI
+     */
+    totalSessionDisplayTime?: number
+    /**
+     * Length of additional characters inputed by user from when the trigger happens to when the user decision was made
+     */
+    typeaheadLength?: number
 }
 
-export const logInlineCompletionSessionResultsNotificationType =
-  new ProtocolNotificationType<LogInlineCompletionSessionResultsParams, void>(
-    "aws/logInlineCompletionSessionResults",
-  );
+export const logInlineCompletionSessionResultsNotificationType = new ProtocolNotificationType<
+    LogInlineCompletionSessionResultsParams,
+    void
+>('aws/logInlineCompletionSessionResults')

--- a/src/features/lsp/textDocuments/textDocumentConnection.test.ts
+++ b/src/features/lsp/textDocuments/textDocumentConnection.test.ts
@@ -1,210 +1,169 @@
-import assert from "assert";
+import assert from 'assert'
 import {
-  CancellationToken,
-  DidChangeTextDocumentParams,
-  DidCloseTextDocumentParams,
-  DidOpenTextDocumentParams,
-  DidSaveTextDocumentParams,
-  NotificationHandler,
-  RequestHandler,
-  TextEdit,
-  WillSaveTextDocumentParams,
-} from "vscode-languageserver";
-import { TextDocumentConnection } from "vscode-languageserver/lib/common/textDocuments";
-import { observe } from "./textDocumentConnection";
+    CancellationToken,
+    DidChangeTextDocumentParams,
+    DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams,
+    NotificationHandler,
+    RequestHandler,
+    TextEdit,
+    WillSaveTextDocumentParams,
+} from 'vscode-languageserver'
+import { TextDocumentConnection } from 'vscode-languageserver/lib/common/textDocuments'
+import { observe } from './textDocumentConnection'
 
 const notificationHandlers = {
-  onDidOpenTextDocument: undefined as NotificationHandler<any> | undefined,
-  onDidChangeTextDocument: undefined as NotificationHandler<any> | undefined,
-  onDidCloseTextDocument: undefined as NotificationHandler<any> | undefined,
-  onWillSaveTextDocument: undefined as NotificationHandler<any> | undefined,
-  onDidSaveTextDocument: undefined as NotificationHandler<any> | undefined,
-};
+    onDidOpenTextDocument: undefined as NotificationHandler<any> | undefined,
+    onDidChangeTextDocument: undefined as NotificationHandler<any> | undefined,
+    onDidCloseTextDocument: undefined as NotificationHandler<any> | undefined,
+    onWillSaveTextDocument: undefined as NotificationHandler<any> | undefined,
+    onDidSaveTextDocument: undefined as NotificationHandler<any> | undefined,
+}
 
 let onWillSaveTextDocumentWaitUntilHandler:
-  | RequestHandler<
-      WillSaveTextDocumentParams,
-      TextEdit[] | undefined | null,
-      void
-    >
-  | undefined = undefined;
+    | RequestHandler<WillSaveTextDocumentParams, TextEdit[] | undefined | null, void>
+    | undefined = undefined
 
 const testConnection: TextDocumentConnection = {
-  onDidOpenTextDocument: (
-    handler: NotificationHandler<DidOpenTextDocumentParams>,
-  ) => {
-    notificationHandlers.onDidOpenTextDocument = handler;
-    return { dispose: () => {} };
-  },
-  onDidChangeTextDocument: (
-    handler: NotificationHandler<DidChangeTextDocumentParams>,
-  ) => {
-    notificationHandlers.onDidChangeTextDocument = handler;
-    return { dispose: () => {} };
-  },
-  onDidCloseTextDocument: (
-    handler: NotificationHandler<DidCloseTextDocumentParams>,
-  ) => {
-    notificationHandlers.onDidCloseTextDocument = handler;
-    return { dispose: () => {} };
-  },
-  onWillSaveTextDocument: (
-    handler: NotificationHandler<WillSaveTextDocumentParams>,
-  ) => {
-    notificationHandlers.onWillSaveTextDocument = handler;
-    return { dispose: () => {} };
-  },
-  onDidSaveTextDocument: (
-    handler: NotificationHandler<DidSaveTextDocumentParams>,
-  ) => {
-    notificationHandlers.onDidSaveTextDocument = handler;
-    return { dispose: () => {} };
-  },
-  onWillSaveTextDocumentWaitUntil: (
-    handler: RequestHandler<
-      WillSaveTextDocumentParams,
-      TextEdit[] | undefined | null,
-      void
-    >,
-  ) => {
-    onWillSaveTextDocumentWaitUntilHandler = handler;
-    return { dispose: () => {} };
-  },
-};
+    onDidOpenTextDocument: (handler: NotificationHandler<DidOpenTextDocumentParams>) => {
+        notificationHandlers.onDidOpenTextDocument = handler
+        return { dispose: () => {} }
+    },
+    onDidChangeTextDocument: (handler: NotificationHandler<DidChangeTextDocumentParams>) => {
+        notificationHandlers.onDidChangeTextDocument = handler
+        return { dispose: () => {} }
+    },
+    onDidCloseTextDocument: (handler: NotificationHandler<DidCloseTextDocumentParams>) => {
+        notificationHandlers.onDidCloseTextDocument = handler
+        return { dispose: () => {} }
+    },
+    onWillSaveTextDocument: (handler: NotificationHandler<WillSaveTextDocumentParams>) => {
+        notificationHandlers.onWillSaveTextDocument = handler
+        return { dispose: () => {} }
+    },
+    onDidSaveTextDocument: (handler: NotificationHandler<DidSaveTextDocumentParams>) => {
+        notificationHandlers.onDidSaveTextDocument = handler
+        return { dispose: () => {} }
+    },
+    onWillSaveTextDocumentWaitUntil: (
+        handler: RequestHandler<WillSaveTextDocumentParams, TextEdit[] | undefined | null, void>
+    ) => {
+        onWillSaveTextDocumentWaitUntilHandler = handler
+        return { dispose: () => {} }
+    },
+}
 
-describe("TextDocumentConnection", () => {
-  let calledFirst = false;
-  let calledSecond = false;
-  beforeEach(() => {
-    calledFirst = false;
-    calledSecond = false;
+describe('TextDocumentConnection', () => {
+    let calledFirst = false
+    let calledSecond = false
+    beforeEach(() => {
+        calledFirst = false
+        calledSecond = false
 
-    Object.keys(notificationHandlers).forEach(
-      (k) =>
-        (notificationHandlers[k as keyof typeof notificationHandlers] =
-          undefined),
-    );
-  });
+        Object.keys(notificationHandlers).forEach(
+            k => (notificationHandlers[k as keyof typeof notificationHandlers] = undefined)
+        )
+    })
 
-  describe("without observable (baseline)", () => {
-    Object.keys(notificationHandlers).forEach((key) => {
-      it(key + " only supports the last callback", () => {
-        testConnection[key as keyof typeof notificationHandlers](() => {
-          calledFirst = true;
-        });
-        testConnection[key as keyof typeof notificationHandlers](
-          () => (calledSecond = true),
-        );
+    describe('without observable (baseline)', () => {
+        Object.keys(notificationHandlers).forEach(key => {
+            it(key + ' only supports the last callback', () => {
+                testConnection[key as keyof typeof notificationHandlers](() => {
+                    calledFirst = true
+                })
+                testConnection[key as keyof typeof notificationHandlers](() => (calledSecond = true))
 
-        notificationHandlers[key as keyof typeof notificationHandlers]!({});
+                notificationHandlers[key as keyof typeof notificationHandlers]!({})
 
-        assert.equal(calledFirst, false);
-        assert.equal(calledSecond, true);
-      });
-    });
-  });
+                assert.equal(calledFirst, false)
+                assert.equal(calledSecond, true)
+            })
+        })
+    })
 
-  describe("with observable", () => {
-    Object.keys(notificationHandlers).forEach((key) => {
-      let observableConnection: ReturnType<typeof observe>;
+    describe('with observable', () => {
+        Object.keys(notificationHandlers).forEach(key => {
+            let observableConnection: ReturnType<typeof observe>
 
-      beforeEach(async () => {
-        observableConnection = observe(testConnection);
-      });
+            beforeEach(async () => {
+                observableConnection = observe(testConnection)
+            })
 
-      it(key + " supports multiple subscriptions", () => {
-        observableConnection[
-          key as keyof typeof notificationHandlers
-        ].subscribe(() => {
-          calledFirst = true;
-        });
-        observableConnection[
-          key as keyof typeof notificationHandlers
-        ].subscribe(() => (calledSecond = true));
+            it(key + ' supports multiple subscriptions', () => {
+                observableConnection[key as keyof typeof notificationHandlers].subscribe(() => {
+                    calledFirst = true
+                })
+                observableConnection[key as keyof typeof notificationHandlers].subscribe(() => (calledSecond = true))
 
-        notificationHandlers[key as keyof typeof notificationHandlers]!({});
+                notificationHandlers[key as keyof typeof notificationHandlers]!({})
 
-        assert.equal(calledFirst, true);
-        assert.equal(calledSecond, true);
-      });
+                assert.equal(calledFirst, true)
+                assert.equal(calledSecond, true)
+            })
 
-      it(key + " supports unsubscribe and resubscribe", () => {
-        const sub = observableConnection[
-          key as keyof typeof notificationHandlers
-        ].subscribe(() => {
-          calledFirst = true;
-        });
-        sub.unsubscribe();
-        observableConnection[
-          key as keyof typeof notificationHandlers
-        ].subscribe(() => (calledSecond = true));
+            it(key + ' supports unsubscribe and resubscribe', () => {
+                const sub = observableConnection[key as keyof typeof notificationHandlers].subscribe(() => {
+                    calledFirst = true
+                })
+                sub.unsubscribe()
+                observableConnection[key as keyof typeof notificationHandlers].subscribe(() => (calledSecond = true))
 
-        notificationHandlers[key as keyof typeof notificationHandlers]!({});
+                notificationHandlers[key as keyof typeof notificationHandlers]!({})
 
-        assert.equal(calledFirst, false);
-        assert.equal(calledSecond, true);
-      });
+                assert.equal(calledFirst, false)
+                assert.equal(calledSecond, true)
+            })
 
-      it(key + " supports callbacks", () => {
-        observableConnection.callbacks[
-          key as keyof typeof notificationHandlers
-        ](() => {
-          calledFirst = true;
-        });
-        observableConnection.callbacks[
-          key as keyof typeof notificationHandlers
-        ](() => {
-          calledSecond = true;
-        });
+            it(key + ' supports callbacks', () => {
+                observableConnection.callbacks[key as keyof typeof notificationHandlers](() => {
+                    calledFirst = true
+                })
+                observableConnection.callbacks[key as keyof typeof notificationHandlers](() => {
+                    calledSecond = true
+                })
 
-        notificationHandlers[key as keyof typeof notificationHandlers]!({});
+                notificationHandlers[key as keyof typeof notificationHandlers]!({})
 
-        assert.equal(calledFirst, true);
-        assert.equal(calledSecond, true);
-      });
+                assert.equal(calledFirst, true)
+                assert.equal(calledSecond, true)
+            })
 
-      it(key + " supports callback dispose", () => {
-        const disposable = observableConnection.callbacks[
-          key as keyof typeof notificationHandlers
-        ](() => {
-          calledFirst = true;
-        });
-        observableConnection.callbacks[
-          key as keyof typeof notificationHandlers
-        ](() => {
-          calledSecond = true;
-        });
+            it(key + ' supports callback dispose', () => {
+                const disposable = observableConnection.callbacks[key as keyof typeof notificationHandlers](() => {
+                    calledFirst = true
+                })
+                observableConnection.callbacks[key as keyof typeof notificationHandlers](() => {
+                    calledSecond = true
+                })
 
-        disposable.dispose();
+                disposable.dispose()
 
-        notificationHandlers[key as keyof typeof notificationHandlers]!({});
+                notificationHandlers[key as keyof typeof notificationHandlers]!({})
 
-        assert.equal(calledFirst, false);
-        assert.equal(calledSecond, true);
-      });
-    });
-  });
+                assert.equal(calledFirst, false)
+                assert.equal(calledSecond, true)
+            })
+        })
+    })
 
-  describe("onWillSaeTextDocumentWaitUntil", () => {
-    it("supports only last handler", () => {
-      const connection = observe(testConnection);
-      connection.callbacks.onWillSaveTextDocumentWaitUntil((p) => {
-        calledFirst = true;
-        return [];
-      });
+    describe('onWillSaeTextDocumentWaitUntil', () => {
+        it('supports only last handler', () => {
+            const connection = observe(testConnection)
+            connection.callbacks.onWillSaveTextDocumentWaitUntil(p => {
+                calledFirst = true
+                return []
+            })
 
-      connection.callbacks.onWillSaveTextDocumentWaitUntil((p) => {
-        calledSecond = true;
-        return [];
-      });
+            connection.callbacks.onWillSaveTextDocumentWaitUntil(p => {
+                calledSecond = true
+                return []
+            })
 
-      onWillSaveTextDocumentWaitUntilHandler!(
-        {} as WillSaveTextDocumentParams,
-        CancellationToken.None,
-      );
+            onWillSaveTextDocumentWaitUntilHandler!({} as WillSaveTextDocumentParams, CancellationToken.None)
 
-      assert.equal(calledFirst, false);
-      assert.equal(calledSecond, true);
-    });
-  });
-});
+            assert.equal(calledFirst, false)
+            assert.equal(calledSecond, true)
+        })
+    })
+})

--- a/src/features/lsp/textDocuments/textDocumentConnection.ts
+++ b/src/features/lsp/textDocuments/textDocumentConnection.ts
@@ -1,32 +1,28 @@
-import { Observable, fromEventPattern, share } from "rxjs";
+import { Observable, fromEventPattern, share } from 'rxjs'
 import {
-  DidChangeTextDocumentParams,
-  DidCloseTextDocumentParams,
-  DidOpenTextDocumentParams,
-  DidSaveTextDocumentParams,
-  NotificationHandler,
-  RequestHandler,
-  TextEdit,
-  WillSaveTextDocumentParams,
-} from "vscode-languageserver";
-import { TextDocumentConnection } from "vscode-languageserver/lib/common/textDocuments";
+    DidChangeTextDocumentParams,
+    DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams,
+    NotificationHandler,
+    RequestHandler,
+    TextEdit,
+    WillSaveTextDocumentParams,
+} from 'vscode-languageserver'
+import { TextDocumentConnection } from 'vscode-languageserver/lib/common/textDocuments'
 
 // Filter out only the handlers that return void to avoid the request/response format,
 // which would not support multiple handlers since it requires disambiguating the handler
 // responsible for responding.
 type TextDocumentNotifications = {
-  [key in keyof TextDocumentConnection]: ReturnType<
-    Parameters<TextDocumentConnection[key]>[0]
-  > extends void
-    ? key
-    : never;
-}[keyof TextDocumentConnection];
+    [key in keyof TextDocumentConnection]: ReturnType<Parameters<TextDocumentConnection[key]>[0]> extends void
+        ? key
+        : never
+}[keyof TextDocumentConnection]
 
 type TextDocumentObservable = {
-  [key in TextDocumentNotifications]: Observable<
-    Parameters<Parameters<TextDocumentConnection[key]>[0]>[0]
-  >;
-};
+    [key in TextDocumentNotifications]: Observable<Parameters<Parameters<TextDocumentConnection[key]>[0]>[0]>
+}
 
 /**
  * Wrap a standard LSP {TextDocumentConnection}, that only supports a single callback for each operation,
@@ -44,71 +40,57 @@ type TextDocumentObservable = {
  * @returns A wrapper around the {TextDocumentConnection} providing both a callback and an observable interface
  */
 export const observe = (
-  connection: TextDocumentConnection,
+    connection: TextDocumentConnection
 ): { callbacks: TextDocumentConnection } & TextDocumentObservable => {
-  const onDidChangeTextDocument = fromEventPattern<DidChangeTextDocumentParams>(
-    connection.onDidChangeTextDocument,
-  ).pipe(share());
-  const onDidOpenTextDocument = fromEventPattern<DidOpenTextDocumentParams>(
-    connection.onDidOpenTextDocument,
-  ).pipe(share());
-  const onDidCloseTextDocument = fromEventPattern<DidCloseTextDocumentParams>(
-    connection.onDidCloseTextDocument,
-  ).pipe(share());
-  const onWillSaveTextDocument = fromEventPattern<WillSaveTextDocumentParams>(
-    connection.onWillSaveTextDocument,
-  ).pipe(share());
-  const onDidSaveTextDocument = fromEventPattern<DidSaveTextDocumentParams>(
-    connection.onDidSaveTextDocument,
-  ).pipe(share());
+    const onDidChangeTextDocument = fromEventPattern<DidChangeTextDocumentParams>(
+        connection.onDidChangeTextDocument
+    ).pipe(share())
+    const onDidOpenTextDocument = fromEventPattern<DidOpenTextDocumentParams>(connection.onDidOpenTextDocument).pipe(
+        share()
+    )
+    const onDidCloseTextDocument = fromEventPattern<DidCloseTextDocumentParams>(connection.onDidCloseTextDocument).pipe(
+        share()
+    )
+    const onWillSaveTextDocument = fromEventPattern<WillSaveTextDocumentParams>(connection.onWillSaveTextDocument).pipe(
+        share()
+    )
+    const onDidSaveTextDocument = fromEventPattern<DidSaveTextDocumentParams>(connection.onDidSaveTextDocument).pipe(
+        share()
+    )
 
-  return {
-    callbacks: {
-      onDidChangeTextDocument: (
-        handler: NotificationHandler<DidChangeTextDocumentParams>,
-      ) => {
-        const subscription = onDidChangeTextDocument.subscribe(handler);
-        return { dispose: () => subscription.unsubscribe() };
-      },
-      onDidOpenTextDocument: (
-        handler: NotificationHandler<DidOpenTextDocumentParams>,
-      ) => {
-        const subscription = onDidOpenTextDocument.subscribe(handler);
-        return { dispose: () => subscription.unsubscribe() };
-      },
-      onDidCloseTextDocument: (
-        handler: NotificationHandler<DidCloseTextDocumentParams>,
-      ) => {
-        const subscription = onDidCloseTextDocument.subscribe(handler);
-        return { dispose: () => subscription.unsubscribe() };
-      },
-      onWillSaveTextDocument: (
-        handler: NotificationHandler<WillSaveTextDocumentParams>,
-      ) => {
-        const subscription = onWillSaveTextDocument.subscribe(handler);
-        return { dispose: () => subscription.unsubscribe() };
-      },
-      onDidSaveTextDocument: (
-        handler: NotificationHandler<DidSaveTextDocumentParams>,
-      ) => {
-        const subscription = onDidSaveTextDocument.subscribe(handler);
-        return { dispose: () => subscription.unsubscribe() };
-      },
-      onWillSaveTextDocumentWaitUntil: (
-        handler: RequestHandler<
-          WillSaveTextDocumentParams,
-          TextEdit[] | undefined | null,
-          void
-        >,
-      ) => {
-        return connection.onWillSaveTextDocumentWaitUntil(handler);
-      },
-    },
+    return {
+        callbacks: {
+            onDidChangeTextDocument: (handler: NotificationHandler<DidChangeTextDocumentParams>) => {
+                const subscription = onDidChangeTextDocument.subscribe(handler)
+                return { dispose: () => subscription.unsubscribe() }
+            },
+            onDidOpenTextDocument: (handler: NotificationHandler<DidOpenTextDocumentParams>) => {
+                const subscription = onDidOpenTextDocument.subscribe(handler)
+                return { dispose: () => subscription.unsubscribe() }
+            },
+            onDidCloseTextDocument: (handler: NotificationHandler<DidCloseTextDocumentParams>) => {
+                const subscription = onDidCloseTextDocument.subscribe(handler)
+                return { dispose: () => subscription.unsubscribe() }
+            },
+            onWillSaveTextDocument: (handler: NotificationHandler<WillSaveTextDocumentParams>) => {
+                const subscription = onWillSaveTextDocument.subscribe(handler)
+                return { dispose: () => subscription.unsubscribe() }
+            },
+            onDidSaveTextDocument: (handler: NotificationHandler<DidSaveTextDocumentParams>) => {
+                const subscription = onDidSaveTextDocument.subscribe(handler)
+                return { dispose: () => subscription.unsubscribe() }
+            },
+            onWillSaveTextDocumentWaitUntil: (
+                handler: RequestHandler<WillSaveTextDocumentParams, TextEdit[] | undefined | null, void>
+            ) => {
+                return connection.onWillSaveTextDocumentWaitUntil(handler)
+            },
+        },
 
-    onDidChangeTextDocument,
-    onDidOpenTextDocument,
-    onDidCloseTextDocument,
-    onWillSaveTextDocument,
-    onDidSaveTextDocument,
-  };
-};
+        onDidChangeTextDocument,
+        onDidOpenTextDocument,
+        onDidCloseTextDocument,
+        onWillSaveTextDocument,
+        onDidSaveTextDocument,
+    }
+}

--- a/src/features/telemetry/telemetry.ts
+++ b/src/features/telemetry/telemetry.ts
@@ -1,28 +1,28 @@
 export type Metric = {
-  name: string;
-};
+    name: string
+}
 
 export type MetricEvent = Metric & {
-  data?: any;
-  result?: ResultType;
-  errorData?: ErrorData;
-};
+    data?: any
+    result?: ResultType
+    errorData?: ErrorData
+}
 
 export type BusinessMetricEvent = Metric & {
-  // TODO: define more
-};
+    // TODO: define more
+}
 
-type ResultType = "Succeeded" | "Failed" | "Cancelled";
+type ResultType = 'Succeeded' | 'Failed' | 'Cancelled'
 
 type ErrorData = {
-  reason: string;
-  errorCode?: string;
-  httpStatusCode?: number;
-};
+    reason: string
+    errorCode?: string
+    httpStatusCode?: number
+}
 
 /**
  * The telemetry feature interface.
  */
 export type Telemetry = {
-  emitMetric: (metric: MetricEvent) => void;
-};
+    emitMetric: (metric: MetricEvent) => void
+}

--- a/src/features/versioning.test.ts
+++ b/src/features/versioning.test.ts
@@ -1,46 +1,46 @@
-import assert from "assert";
-import sinon, { SinonStub } from "sinon";
-import { handleVersionArgument } from "./versioning";
+import assert from 'assert'
+import sinon, { SinonStub } from 'sinon'
+import { handleVersionArgument } from './versioning'
 
-describe("handleVersionArgument", () => {
-  let processExitStub: SinonStub;
-  let consoleLogStub: SinonStub;
-  const version = "1.0.0";
+describe('handleVersionArgument', () => {
+    let processExitStub: SinonStub
+    let consoleLogStub: SinonStub
+    const version = '1.0.0'
 
-  beforeEach(() => {
-    processExitStub = sinon.stub(process, "exit");
-    consoleLogStub = sinon.stub(console, "log");
-  });
+    beforeEach(() => {
+        processExitStub = sinon.stub(process, 'exit')
+        consoleLogStub = sinon.stub(console, 'log')
+    })
 
-  afterEach(() => {
-    processExitStub.restore();
-    consoleLogStub.restore();
-  });
+    afterEach(() => {
+        processExitStub.restore()
+        consoleLogStub.restore()
+    })
 
-  it("should log the version and exit when --version is in process.argv", () => {
-    process.argv = ["node", "script.js", "--version"];
+    it('should log the version and exit when --version is in process.argv', () => {
+        process.argv = ['node', 'script.js', '--version']
 
-    handleVersionArgument(version);
+        handleVersionArgument(version)
 
-    assert.strictEqual(consoleLogStub.calledOnceWithExactly(version), true);
-    assert.strictEqual(processExitStub.calledOnceWithExactly(0), true);
-  });
+        assert.strictEqual(consoleLogStub.calledOnceWithExactly(version), true)
+        assert.strictEqual(processExitStub.calledOnceWithExactly(0), true)
+    })
 
-  it("should log the version and exit when -v is in process.argv", () => {
-    process.argv = ["node", "script.js", "-v"];
+    it('should log the version and exit when -v is in process.argv', () => {
+        process.argv = ['node', 'script.js', '-v']
 
-    handleVersionArgument(version);
+        handleVersionArgument(version)
 
-    assert.strictEqual(consoleLogStub.calledOnceWithExactly(version), true);
-    assert.strictEqual(processExitStub.calledOnceWithExactly(0), true);
-  });
+        assert.strictEqual(consoleLogStub.calledOnceWithExactly(version), true)
+        assert.strictEqual(processExitStub.calledOnceWithExactly(0), true)
+    })
 
-  it("should do nothing when neither --version nor -v is in process.argv", () => {
-    process.argv = ["node", "script.js", "--stdio"];
+    it('should do nothing when neither --version nor -v is in process.argv', () => {
+        process.argv = ['node', 'script.js', '--stdio']
 
-    handleVersionArgument(version);
+        handleVersionArgument(version)
 
-    assert.strictEqual(consoleLogStub.called, false);
-    assert.strictEqual(processExitStub.called, false);
-  });
-});
+        assert.strictEqual(consoleLogStub.called, false)
+        assert.strictEqual(processExitStub.called, false)
+    })
+})

--- a/src/features/versioning.ts
+++ b/src/features/versioning.ts
@@ -1,6 +1,6 @@
 export function handleVersionArgument(version?: string) {
-  if (process.argv.some((arg) => arg === "--version" || arg === "-v")) {
-    console.log(version);
-    process.exit(0);
-  }
+    if (process.argv.some(arg => arg === '--version' || arg === '-v')) {
+        console.log(version)
+        process.exit(0)
+    }
 }

--- a/src/features/workspace.ts
+++ b/src/features/workspace.ts
@@ -1,12 +1,12 @@
-import { WorkspaceFolder } from "vscode-languageserver";
-import { TextDocument } from "vscode-languageserver-textdocument";
+import { WorkspaceFolder } from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 
 // Minimal version of fs.Dirent
 interface Dirent {
-  isFile(): boolean;
-  isDirectory(): boolean;
-  name: string;
-  path: string;
+    isFile(): boolean
+    isDirectory(): boolean
+    name: string
+    path: string
 }
 
 /**
@@ -16,16 +16,16 @@ interface Dirent {
  * workspace root.
  */
 export type Workspace = {
-  getTextDocument: (uri: string) => Promise<TextDocument | undefined>;
-  getWorkspaceFolder: (uri: string) => WorkspaceFolder | null | undefined;
-  fs: {
-    copy: (src: string, dest: string) => Promise<void>;
-    exists: (path: string) => Promise<boolean>;
-    getFileSize: (path: string) => Promise<{ size: number }>;
-    getTempDirPath: () => string;
-    readdir: (path: string) => Promise<Dirent[]>;
-    readFile: (path: string) => Promise<string>;
-    isFile: (path: string) => Promise<boolean>;
-    remove: (dir: string) => Promise<void>;
-  };
-};
+    getTextDocument: (uri: string) => Promise<TextDocument | undefined>
+    getWorkspaceFolder: (uri: string) => WorkspaceFolder | null | undefined
+    fs: {
+        copy: (src: string, dest: string) => Promise<void>
+        exists: (path: string) => Promise<boolean>
+        getFileSize: (path: string) => Promise<{ size: number }>
+        getTempDirPath: () => string
+        readdir: (path: string) => Promise<Dirent[]>
+        readFile: (path: string) => Promise<string>
+        isFile: (path: string) => Promise<boolean>
+        remove: (dir: string) => Promise<void>
+    }
+}

--- a/src/runtimes/index.ts
+++ b/src/runtimes/index.ts
@@ -1,2 +1,2 @@
-export { Server } from "./server";
-export { standalone } from "./standalone";
+export { Server } from './server'
+export { standalone } from './standalone'

--- a/src/runtimes/initialize.test.ts
+++ b/src/runtimes/initialize.test.ts
@@ -1,156 +1,144 @@
 import {
-  CancellationToken,
-  InitializeError,
-  InitializeParams,
-  InitializeResult,
-  ResponseError,
-  TextDocumentSyncKind,
-} from "vscode-languageserver";
-import { InitializeHandler } from "./initialize";
-import assert from "assert";
+    CancellationToken,
+    InitializeError,
+    InitializeParams,
+    InitializeResult,
+    ResponseError,
+    TextDocumentSyncKind,
+} from 'vscode-languageserver'
+import { InitializeHandler } from './initialize'
+import assert from 'assert'
 
-describe("InitializeHandler", () => {
-  let initializeHandler: InitializeHandler;
+describe('InitializeHandler', () => {
+    let initializeHandler: InitializeHandler
 
-  beforeEach(() => {
-    initializeHandler = new InitializeHandler("AWS LSP Standalone", "1.0.0");
-  });
+    beforeEach(() => {
+        initializeHandler = new InitializeHandler('AWS LSP Standalone', '1.0.0')
+    })
 
-  it("should store InitializeParam in a field", () => {
-    const initParam = {} as InitializeParams;
-    initializeHandler.onInitialize(initParam, {} as CancellationToken);
-    assert(initializeHandler.clientInitializeParams === initParam);
-  });
+    it('should store InitializeParam in a field', () => {
+        const initParam = {} as InitializeParams
+        initializeHandler.onInitialize(initParam, {} as CancellationToken)
+        assert(initializeHandler.clientInitializeParams === initParam)
+    })
 
-  it("should return the default response when no handlers are registered", async () => {
-    const result = await initializeHandler.onInitialize(
-      {} as InitializeParams,
-      {} as CancellationToken,
-    );
+    it('should return the default response when no handlers are registered', async () => {
+        const result = await initializeHandler.onInitialize({} as InitializeParams, {} as CancellationToken)
 
-    const expected = {
-      serverInfo: {
-        name: "AWS LSP Standalone",
-        version: "1.0.0",
-      },
-      capabilities: {
-        textDocumentSync: {
-          openClose: true,
-          change: TextDocumentSyncKind.Incremental,
-        },
-        hoverProvider: true,
-      },
-    };
-    assert.deepStrictEqual(result, expected);
-  });
+        const expected = {
+            serverInfo: {
+                name: 'AWS LSP Standalone',
+                version: '1.0.0',
+            },
+            capabilities: {
+                textDocumentSync: {
+                    openClose: true,
+                    change: TextDocumentSyncKind.Incremental,
+                },
+                hoverProvider: true,
+            },
+        }
+        assert.deepStrictEqual(result, expected)
+    })
 
-  it("should merge handler results with the default response", async () => {
-    const handler1 = () => {
-      return {
-        capabilities: {
-          completionProvider: { resolveProvider: true },
-        },
-      };
-    };
-    const handler2 = () => {
-      return Promise.resolve({
-        capabilities: {
-          hoverProvider: true,
-        },
-        extraField: "extraValue",
-      });
-    };
+    it('should merge handler results with the default response', async () => {
+        const handler1 = () => {
+            return {
+                capabilities: {
+                    completionProvider: { resolveProvider: true },
+                },
+            }
+        }
+        const handler2 = () => {
+            return Promise.resolve({
+                capabilities: {
+                    hoverProvider: true,
+                },
+                extraField: 'extraValue',
+            })
+        }
 
-    initializeHandler.addHandler(handler1);
-    initializeHandler.addHandler(handler2);
+        initializeHandler.addHandler(handler1)
+        initializeHandler.addHandler(handler2)
 
-    const result = await initializeHandler.onInitialize(
-      {} as InitializeParams,
-      {} as CancellationToken,
-    );
+        const result = await initializeHandler.onInitialize({} as InitializeParams, {} as CancellationToken)
 
-    const expected: InitializeResult = {
-      serverInfo: {
-        name: "AWS LSP Standalone",
-        version: "1.0.0",
-      },
-      capabilities: {
-        textDocumentSync: {
-          openClose: true,
-          change: TextDocumentSyncKind.Incremental,
-        },
-        completionProvider: { resolveProvider: true },
-        hoverProvider: true,
-      },
-      extraField: "extraValue",
-    };
+        const expected: InitializeResult = {
+            serverInfo: {
+                name: 'AWS LSP Standalone',
+                version: '1.0.0',
+            },
+            capabilities: {
+                textDocumentSync: {
+                    openClose: true,
+                    change: TextDocumentSyncKind.Incremental,
+                },
+                completionProvider: { resolveProvider: true },
+                hoverProvider: true,
+            },
+            extraField: 'extraValue',
+        }
 
-    assert.deepStrictEqual(result, expected);
-  });
+        assert.deepStrictEqual(result, expected)
+    })
 
-  it("should prioritize the response of the handler that comes first", async () => {
-    const handler1 = () => {
-      return {
-        capabilities: {
-          completionProvider: { resolveProvider: true },
-        },
-      };
-    };
-    const handler2 = () => {
-      return Promise.resolve({
-        capabilities: {
-          completionProvider: { resolveProvider: false },
-        },
-      });
-    };
+    it('should prioritize the response of the handler that comes first', async () => {
+        const handler1 = () => {
+            return {
+                capabilities: {
+                    completionProvider: { resolveProvider: true },
+                },
+            }
+        }
+        const handler2 = () => {
+            return Promise.resolve({
+                capabilities: {
+                    completionProvider: { resolveProvider: false },
+                },
+            })
+        }
 
-    initializeHandler.addHandler(handler1);
-    initializeHandler.addHandler(handler2);
+        initializeHandler.addHandler(handler1)
+        initializeHandler.addHandler(handler2)
 
-    const result = await initializeHandler.onInitialize(
-      {} as InitializeParams,
-      {} as CancellationToken,
-    );
+        const result = await initializeHandler.onInitialize({} as InitializeParams, {} as CancellationToken)
 
-    const expected: InitializeResult = {
-      serverInfo: {
-        name: "AWS LSP Standalone",
-        version: "1.0.0",
-      },
-      capabilities: {
-        textDocumentSync: {
-          openClose: true,
-          change: TextDocumentSyncKind.Incremental,
-        },
-        completionProvider: { resolveProvider: true },
-        hoverProvider: true,
-      },
-    };
+        const expected: InitializeResult = {
+            serverInfo: {
+                name: 'AWS LSP Standalone',
+                version: '1.0.0',
+            },
+            capabilities: {
+                textDocumentSync: {
+                    openClose: true,
+                    change: TextDocumentSyncKind.Incremental,
+                },
+                completionProvider: { resolveProvider: true },
+                hoverProvider: true,
+            },
+        }
 
-    assert.deepStrictEqual(result, expected);
-  });
+        assert.deepStrictEqual(result, expected)
+    })
 
-  it("should return error if any of the handlers failed", async () => {
-    const handler1 = () => {
-      return {
-        capabilities: {
-          completionProvider: { resolveProvider: true },
-        },
-      };
-    };
-    const error = new ResponseError(111, "failed", { retry: false });
-    const handler2 = (): Promise<ResponseError<InitializeError>> => {
-      return Promise.resolve(error);
-    };
+    it('should return error if any of the handlers failed', async () => {
+        const handler1 = () => {
+            return {
+                capabilities: {
+                    completionProvider: { resolveProvider: true },
+                },
+            }
+        }
+        const error = new ResponseError(111, 'failed', { retry: false })
+        const handler2 = (): Promise<ResponseError<InitializeError>> => {
+            return Promise.resolve(error)
+        }
 
-    initializeHandler.addHandler(handler1);
-    initializeHandler.addHandler(handler2);
+        initializeHandler.addHandler(handler1)
+        initializeHandler.addHandler(handler2)
 
-    const result = await initializeHandler.onInitialize(
-      {} as InitializeParams,
-      {} as CancellationToken,
-    );
+        const result = await initializeHandler.onInitialize({} as InitializeParams, {} as CancellationToken)
 
-    assert.deepStrictEqual(result, error);
-  });
-});
+        assert.deepStrictEqual(result, error)
+    })
+})

--- a/src/runtimes/initialize.ts
+++ b/src/runtimes/initialize.ts
@@ -1,118 +1,104 @@
 import {
-  RequestHandler,
-  InitializeParams,
-  InitializeError,
-  CancellationToken,
-  InitializeResult,
-  TextDocumentSyncKind,
-  ResponseError,
-} from "vscode-languageserver";
-import { PartialInitializeResult } from "../features/lsp";
+    RequestHandler,
+    InitializeParams,
+    InitializeError,
+    CancellationToken,
+    InitializeResult,
+    TextDocumentSyncKind,
+    ResponseError,
+} from 'vscode-languageserver'
+import { PartialInitializeResult } from '../features/lsp'
 
 export class InitializeHandler {
-  private handlers: RequestHandler<
-    InitializeParams,
-    PartialInitializeResult,
-    InitializeError
-  >[] = [];
-  public clientInitializeParams?: InitializeParams;
+    private handlers: RequestHandler<InitializeParams, PartialInitializeResult, InitializeError>[] = []
+    public clientInitializeParams?: InitializeParams
 
-  constructor(
-    private name: string,
-    private version?: string,
-  ) {}
+    constructor(
+        private name: string,
+        private version?: string
+    ) {}
 
-  public onInitialize = async (
-    params: InitializeParams,
-    token: CancellationToken,
-  ): Promise<InitializeResult | ResponseError<InitializeError>> => {
-    this.clientInitializeParams = params;
-    const defaultResponse: InitializeResult = {
-      serverInfo: {
-        name: this.name,
-        version: this.version,
-      },
-      capabilities: {
-        textDocumentSync: {
-          openClose: true,
-          change: TextDocumentSyncKind.Incremental,
-        },
-        hoverProvider: true,
-      },
-    };
+    public onInitialize = async (
+        params: InitializeParams,
+        token: CancellationToken
+    ): Promise<InitializeResult | ResponseError<InitializeError>> => {
+        this.clientInitializeParams = params
+        const defaultResponse: InitializeResult = {
+            serverInfo: {
+                name: this.name,
+                version: this.version,
+            },
+            capabilities: {
+                textDocumentSync: {
+                    openClose: true,
+                    change: TextDocumentSyncKind.Incremental,
+                },
+                hoverProvider: true,
+            },
+        }
 
-    const responsesList = await Promise.all(
-      this.handlers.map((f) => asPromise(f(params, token))),
-    );
-    if (responsesList.some((el) => el instanceof ResponseError)) {
-      return responsesList.find(
-        (el) => el instanceof ResponseError,
-      ) as ResponseError<InitializeError>;
+        const responsesList = await Promise.all(this.handlers.map(f => asPromise(f(params, token))))
+        if (responsesList.some(el => el instanceof ResponseError)) {
+            return responsesList.find(el => el instanceof ResponseError) as ResponseError<InitializeError>
+        }
+        const resultList = responsesList as InitializeResult[]
+        resultList.unshift(defaultResponse)
+        return resultList.reduceRight((acc, curr) => {
+            return mergeObjects(acc, curr)
+        })
     }
-    const resultList = responsesList as InitializeResult[];
-    resultList.unshift(defaultResponse);
-    return resultList.reduceRight((acc, curr) => {
-      return mergeObjects(acc, curr);
-    });
-  };
 
-  public addHandler = (
-    handler: RequestHandler<
-      InitializeParams,
-      PartialInitializeResult,
-      InitializeError
-    >,
-  ): void => {
-    this.handlers.push(handler);
-  };
+    public addHandler = (handler: RequestHandler<InitializeParams, PartialInitializeResult, InitializeError>): void => {
+        this.handlers.push(handler)
+    }
 }
 
 function mergeObjects(obj1: any, obj2: any) {
-  const merged: any = {};
+    const merged: any = {}
 
-  for (let key in obj1) {
-    if (obj1.hasOwnProperty(key)) {
-      if (typeof obj1[key] === "object" && typeof obj2[key] === "object") {
-        merged[key] = mergeObjects(obj1[key], obj2[key]);
-      } else {
-        merged[key] = obj1[key];
-        if (obj2.hasOwnProperty(key)) {
-          merged[key] = obj2[key];
+    for (let key in obj1) {
+        if (obj1.hasOwnProperty(key)) {
+            if (typeof obj1[key] === 'object' && typeof obj2[key] === 'object') {
+                merged[key] = mergeObjects(obj1[key], obj2[key])
+            } else {
+                merged[key] = obj1[key]
+                if (obj2.hasOwnProperty(key)) {
+                    merged[key] = obj2[key]
+                }
+            }
         }
-      }
     }
-  }
 
-  for (let key in obj2) {
-    if (obj2.hasOwnProperty(key) && !obj1.hasOwnProperty(key)) {
-      merged[key] = obj2[key];
+    for (let key in obj2) {
+        if (obj2.hasOwnProperty(key) && !obj1.hasOwnProperty(key)) {
+            merged[key] = obj2[key]
+        }
     }
-  }
-  return merged;
+    return merged
 }
 
 function func(value: any): value is Function {
-  return typeof value === "function";
+    return typeof value === 'function'
 }
 
 function thenable<T>(value: any): value is Thenable<T> {
-  return value && func(value.then);
+    return value && func(value.then)
 }
 
-function asPromise<T>(value: Promise<T>): Promise<T>;
-function asPromise<T>(value: Thenable<T>): Promise<T>;
-function asPromise<T>(value: T): Promise<T>;
+function asPromise<T>(value: Promise<T>): Promise<T>
+function asPromise<T>(value: Thenable<T>): Promise<T>
+function asPromise<T>(value: T): Promise<T>
 function asPromise(value: any): Promise<any> {
-  if (value instanceof Promise) {
-    return value;
-  } else if (thenable(value)) {
-    return new Promise((resolve, reject) => {
-      value.then(
-        (resolved) => resolve(resolved),
-        (error) => reject(error),
-      );
-    });
-  } else {
-    return Promise.resolve(value);
-  }
+    if (value instanceof Promise) {
+        return value
+    } else if (thenable(value)) {
+        return new Promise((resolve, reject) => {
+            value.then(
+                resolved => resolve(resolved),
+                error => reject(error)
+            )
+        })
+    } else {
+        return Promise.resolve(value)
+    }
 }

--- a/src/runtimes/runtime.ts
+++ b/src/runtimes/runtime.ts
@@ -1,19 +1,19 @@
-import { Server } from "./server";
+import { Server } from './server'
 
 /**
  * Properties used for runtime initialisation
  */
 export type RuntimeProps = {
-  /**
-   * Version of the build artifact resulting from initialising the runtime with the list of servers
-   */
-  version?: string;
-  /**
-   *  The list of servers to initialize and run
-   */
-  servers: Server[];
-  /**
-   * Name of the server used inside the runtime
-   */
-  name: string;
-};
+    /**
+     * Version of the build artifact resulting from initialising the runtime with the list of servers
+     */
+    version?: string
+    /**
+     *  The list of servers to initialize and run
+     */
+    servers: Server[]
+    /**
+     * Name of the server used inside the runtime
+     */
+    name: string
+}

--- a/src/runtimes/server.ts
+++ b/src/runtimes/server.ts
@@ -1,10 +1,4 @@
-import {
-  Logging,
-  Lsp,
-  Telemetry,
-  Workspace,
-  CredentialsProvider,
-} from "../features";
+import { Logging, Lsp, Telemetry, Workspace, CredentialsProvider } from '../features'
 
 /**
  * Servers are used to provide features to the client.
@@ -22,9 +16,9 @@ import {
  * @returns A function that will be called when the client exits, used to dispose of any held resources.
  */
 export type Server = (features: {
-  credentialsProvider: CredentialsProvider;
-  lsp: Lsp;
-  workspace: Workspace;
-  logging: Logging;
-  telemetry: Telemetry;
-}) => () => void;
+    credentialsProvider: CredentialsProvider
+    lsp: Lsp
+    workspace: Workspace
+    logging: Logging
+    telemetry: Telemetry
+}) => () => void

--- a/src/runtimes/standalone.ts
+++ b/src/runtimes/standalone.ts
@@ -1,34 +1,34 @@
 import {
-  DidChangeConfigurationNotification,
-  PublishDiagnosticsNotification,
-  TextDocuments,
-} from "vscode-languageserver";
-import { TextDocument } from "vscode-languageserver-textdocument";
-import { ProposedFeatures, createConnection } from "vscode-languageserver/node";
+    DidChangeConfigurationNotification,
+    PublishDiagnosticsNotification,
+    TextDocuments,
+} from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
-  EncryptionInitialization,
-  readEncryptionDetails,
-  shouldWaitForEncryptionKey,
-  validateEncryptionDetails,
-} from "../features/auth/standalone/encryption";
-import { Logging, Lsp, Telemetry, Workspace } from "../features";
-import { inlineCompletionRequestType } from "../features/lsp/inline-completions/futureProtocol";
-import { Auth, CredentialsProvider } from "../features/auth/auth";
+    EncryptionInitialization,
+    readEncryptionDetails,
+    shouldWaitForEncryptionKey,
+    validateEncryptionDetails,
+} from '../features/auth/standalone/encryption'
+import { Logging, Lsp, Telemetry, Workspace } from '../features'
+import { inlineCompletionRequestType } from '../features/lsp/inline-completions/futureProtocol'
+import { Auth, CredentialsProvider } from '../features/auth/auth'
 
-import { handleVersionArgument } from "../features/versioning";
-import { RuntimeProps } from "./runtime";
+import { handleVersionArgument } from '../features/versioning'
+import { RuntimeProps } from './runtime'
 
 import {
-  inlineCompletionWithReferencesRequestType,
-  logInlineCompletionSessionResultsNotificationType,
-} from "../features/lsp/inline-completions/protocolExtensions";
-import { observe } from "../features/lsp/textDocuments/textDocumentConnection";
+    inlineCompletionWithReferencesRequestType,
+    logInlineCompletionSessionResultsNotificationType,
+} from '../features/lsp/inline-completions/protocolExtensions'
+import { observe } from '../features/lsp/textDocuments/textDocumentConnection'
 
-import { access, mkdirSync, existsSync } from "fs";
-import { readdir, readFile, rm, stat, copyFile } from "fs/promises";
-import * as os from "os";
-import * as path from "path";
-import { InitializeHandler } from "./initialize";
+import { access, mkdirSync, existsSync } from 'fs'
+import { readdir, readFile, rm, stat, copyFile } from 'fs/promises'
+import * as os from 'os'
+import * as path from 'path'
+import { InitializeHandler } from './initialize'
 
 /**
  * The runtime for standalone LSP-based servers.
@@ -55,187 +55,153 @@ import { InitializeHandler } from "./initialize";
  * @returns
  */
 export const standalone = (props: RuntimeProps) => {
-  handleVersionArgument(props.version);
+    handleVersionArgument(props.version)
 
-  const lspConnection = createConnection(ProposedFeatures.all);
-  const documentsObserver = observe(lspConnection);
+    const lspConnection = createConnection(ProposedFeatures.all)
+    const documentsObserver = observe(lspConnection)
 
-  let auth: Auth;
-  initializeAuth();
+    let auth: Auth
+    initializeAuth()
 
-  // Initialize Auth service
-  function initializeAuth() {
-    if (shouldWaitForEncryptionKey()) {
-      // Before starting the runtime, accept encryption initialization details
-      // directly from the destination for standalone runtimes.
-      // Contract: Only read up to (and including) the first newline (\n).
-      readEncryptionDetails(process.stdin).then(
-        (encryptionDetails: EncryptionInitialization) => {
-          validateEncryptionDetails(encryptionDetails);
-          lspConnection.console.info(
-            "Runtime: Initializing runtime with encryption",
-          );
-          auth = new Auth(
-            lspConnection,
-            encryptionDetails.key,
-            encryptionDetails.mode,
-          );
-          initializeRuntime();
-        },
-        (error) => {
-          console.error(error);
-          process.exit(10);
-        },
-      );
-    } else {
-      lspConnection.console.info(
-        "Runtime: Initializing runtime without encryption",
-      );
-      auth = new Auth(lspConnection);
-      initializeRuntime();
-    }
-  }
-
-  // Initialize the LSP connection based on the supported LSP capabilities
-  // TODO: make this dependent on the actual requirements of the
-  // capabilities parameter.
-
-  function initializeRuntime() {
-    const documents = new TextDocuments(TextDocument);
-
-    let initializeHandler = new InitializeHandler(props.name, props.version);
-    lspConnection.onInitialize(initializeHandler.onInitialize);
-
-    // Set up logging over LSP
-    // TODO: set up Logging once implemented
-    const logging: Logging = {
-      log: (message) =>
-        lspConnection.console.info(`[${new Date().toISOString()}] ${message}`),
-    };
-
-    // Set up telemetry over LSP
-
-    const telemetry: Telemetry = {
-      emitMetric: (metric) => lspConnection.telemetry.logEvent(metric),
-    };
-
-    // Set up the workspace sync to use the LSP Text Document Sync capability
-    const workspace: Workspace = {
-      getTextDocument: async (uri) => documents.get(uri),
-      // Get all workspace folders and return the workspace folder that contains the uri
-      getWorkspaceFolder: (uri) => {
-        const fileUrl = new URL(uri);
-        const normalizedFileUri = fileUrl.pathname || "";
-
-        const folders =
-          initializeHandler.clientInitializeParams!.workspaceFolders;
-        if (!folders) return undefined;
-
-        for (const folder of folders) {
-          const folderUrl = new URL(folder.uri);
-          const normalizedFolderUri = folderUrl.pathname || "";
-          if (normalizedFileUri.startsWith(normalizedFolderUri)) {
-            return folder;
-          }
+    // Initialize Auth service
+    function initializeAuth() {
+        if (shouldWaitForEncryptionKey()) {
+            // Before starting the runtime, accept encryption initialization details
+            // directly from the destination for standalone runtimes.
+            // Contract: Only read up to (and including) the first newline (\n).
+            readEncryptionDetails(process.stdin).then(
+                (encryptionDetails: EncryptionInitialization) => {
+                    validateEncryptionDetails(encryptionDetails)
+                    lspConnection.console.info('Runtime: Initializing runtime with encryption')
+                    auth = new Auth(lspConnection, encryptionDetails.key, encryptionDetails.mode)
+                    initializeRuntime()
+                },
+                error => {
+                    console.error(error)
+                    process.exit(10)
+                }
+            )
+        } else {
+            lspConnection.console.info('Runtime: Initializing runtime without encryption')
+            auth = new Auth(lspConnection)
+            initializeRuntime()
         }
-      },
-      fs: {
-        copy: (src, dest) => {
-          const destDir = path.dirname(dest);
-          if (!existsSync(destDir)) {
-            mkdirSync(destDir, { recursive: true });
-          }
-          return copyFile(src, dest);
-        },
-        exists: (path) =>
-          new Promise((resolve) => {
-            access(path, (err) => {
-              if (!err) resolve(true);
-              resolve(false);
-            });
-          }),
-        getFileSize: (path) => stat(path),
-        getTempDirPath: () =>
-          path.join(
-            // https://github.com/aws/aws-toolkit-vscode/issues/240
-            os.type() === "Darwin" ? "/tmp" : os.tmpdir(),
-            "aws-language-servers",
-          ),
-        readdir: (path) => readdir(path, { withFileTypes: true }),
-        readFile: (path) => readFile(path, "utf-8"),
-        remove: (dir) => rm(dir, { recursive: true, force: true }),
-        isFile: (path) => stat(path).then(({ isFile }) => isFile()),
-      },
-    };
+    }
 
-    // Map the LSP client to the LSP feature.
-    const lsp: Lsp = {
-      addInitializer: initializeHandler.addHandler,
-      onInitialized: (handler) =>
-        lspConnection.onInitialized((p) => {
-          const workspaceCapabilities =
-            initializeHandler.clientInitializeParams?.capabilities.workspace;
-          if (
-            workspaceCapabilities?.didChangeConfiguration?.dynamicRegistration
-          ) {
-            // Ask the client to notify the server on configuration changes
-            lspConnection.client.register(
-              DidChangeConfigurationNotification.type,
-              undefined,
-            );
-          }
-          handler(p);
-        }),
-      onCompletion: (handler) => lspConnection.onCompletion(handler),
-      onInlineCompletion: (handler) =>
-        lspConnection.onRequest(inlineCompletionRequestType, handler),
-      didChangeConfiguration: (handler) =>
-        lspConnection.onDidChangeConfiguration(handler),
-      onDidChangeTextDocument: (handler) =>
-        documentsObserver.callbacks.onDidChangeTextDocument(handler),
-      onDidCloseTextDocument: (handler) =>
-        documentsObserver.callbacks.onDidCloseTextDocument(handler),
-      onExecuteCommand: (handler) => lspConnection.onExecuteCommand(handler),
-      workspace: {
-        getConfiguration: (section) =>
-          lspConnection.workspace.getConfiguration(section),
-      },
-      publishDiagnostics: (params) =>
-        lspConnection.sendNotification(
-          PublishDiagnosticsNotification.method,
-          params,
-        ),
-      onHover: (handler) => lspConnection.onHover(handler),
-      extensions: {
-        onInlineCompletionWithReferences: (handler) =>
-          lspConnection.onRequest(
-            inlineCompletionWithReferencesRequestType,
-            handler,
-          ),
-        onLogInlineCompletionSessionResults: (handler) => {
-          lspConnection.onNotification(
-            logInlineCompletionSessionResultsNotificationType,
-            handler,
-          );
-        },
-      },
-    };
+    // Initialize the LSP connection based on the supported LSP capabilities
+    // TODO: make this dependent on the actual requirements of the
+    // capabilities parameter.
 
-    const credentialsProvider: CredentialsProvider =
-      auth.getCredentialsProvider();
+    function initializeRuntime() {
+        const documents = new TextDocuments(TextDocument)
 
-    // Initialize every Server
-    const disposables = props.servers.map((s) =>
-      s({ credentialsProvider, lsp, workspace, telemetry, logging }),
-    );
+        let initializeHandler = new InitializeHandler(props.name, props.version)
+        lspConnection.onInitialize(initializeHandler.onInitialize)
 
-    // Free up any resources or threads used by Servers
-    lspConnection.onExit(() => {
-      disposables.forEach((d) => d());
-    });
+        // Set up logging over LSP
+        // TODO: set up Logging once implemented
+        const logging: Logging = {
+            log: message => lspConnection.console.info(`[${new Date().toISOString()}] ${message}`),
+        }
 
-    // Initialize the documents listener and start the LSP connection
-    documents.listen(documentsObserver.callbacks);
-    lspConnection.listen();
-  }
-};
+        // Set up telemetry over LSP
+
+        const telemetry: Telemetry = {
+            emitMetric: metric => lspConnection.telemetry.logEvent(metric),
+        }
+
+        // Set up the workspace sync to use the LSP Text Document Sync capability
+        const workspace: Workspace = {
+            getTextDocument: async uri => documents.get(uri),
+            // Get all workspace folders and return the workspace folder that contains the uri
+            getWorkspaceFolder: uri => {
+                const fileUrl = new URL(uri)
+                const normalizedFileUri = fileUrl.pathname || ''
+
+                const folders = initializeHandler.clientInitializeParams!.workspaceFolders
+                if (!folders) return undefined
+
+                for (const folder of folders) {
+                    const folderUrl = new URL(folder.uri)
+                    const normalizedFolderUri = folderUrl.pathname || ''
+                    if (normalizedFileUri.startsWith(normalizedFolderUri)) {
+                        return folder
+                    }
+                }
+            },
+            fs: {
+                copy: (src, dest) => {
+                    const destDir = path.dirname(dest)
+                    if (!existsSync(destDir)) {
+                        mkdirSync(destDir, { recursive: true })
+                    }
+                    return copyFile(src, dest)
+                },
+                exists: path =>
+                    new Promise(resolve => {
+                        access(path, err => {
+                            if (!err) resolve(true)
+                            resolve(false)
+                        })
+                    }),
+                getFileSize: path => stat(path),
+                getTempDirPath: () =>
+                    path.join(
+                        // https://github.com/aws/aws-toolkit-vscode/issues/240
+                        os.type() === 'Darwin' ? '/tmp' : os.tmpdir(),
+                        'aws-language-servers'
+                    ),
+                readdir: path => readdir(path, { withFileTypes: true }),
+                readFile: path => readFile(path, 'utf-8'),
+                remove: dir => rm(dir, { recursive: true, force: true }),
+                isFile: path => stat(path).then(({ isFile }) => isFile()),
+            },
+        }
+
+        // Map the LSP client to the LSP feature.
+        const lsp: Lsp = {
+            addInitializer: initializeHandler.addHandler,
+            onInitialized: handler =>
+                lspConnection.onInitialized(p => {
+                    const workspaceCapabilities = initializeHandler.clientInitializeParams?.capabilities.workspace
+                    if (workspaceCapabilities?.didChangeConfiguration?.dynamicRegistration) {
+                        // Ask the client to notify the server on configuration changes
+                        lspConnection.client.register(DidChangeConfigurationNotification.type, undefined)
+                    }
+                    handler(p)
+                }),
+            onCompletion: handler => lspConnection.onCompletion(handler),
+            onInlineCompletion: handler => lspConnection.onRequest(inlineCompletionRequestType, handler),
+            didChangeConfiguration: handler => lspConnection.onDidChangeConfiguration(handler),
+            onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),
+            onDidCloseTextDocument: handler => documentsObserver.callbacks.onDidCloseTextDocument(handler),
+            onExecuteCommand: handler => lspConnection.onExecuteCommand(handler),
+            workspace: {
+                getConfiguration: section => lspConnection.workspace.getConfiguration(section),
+            },
+            publishDiagnostics: params => lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),
+            onHover: handler => lspConnection.onHover(handler),
+            extensions: {
+                onInlineCompletionWithReferences: handler =>
+                    lspConnection.onRequest(inlineCompletionWithReferencesRequestType, handler),
+                onLogInlineCompletionSessionResults: handler => {
+                    lspConnection.onNotification(logInlineCompletionSessionResultsNotificationType, handler)
+                },
+            },
+        }
+
+        const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
+
+        // Initialize every Server
+        const disposables = props.servers.map(s => s({ credentialsProvider, lsp, workspace, telemetry, logging }))
+
+        // Free up any resources or threads used by Servers
+        lspConnection.onExit(() => {
+            disposables.forEach(d => d())
+        })
+
+        // Initialize the documents listener and start the LSP connection
+        documents.listen(documentsObserver.callbacks)
+        lspConnection.listen()
+    }
+}

--- a/src/runtimes/webworker.ts
+++ b/src/runtimes/webworker.ts
@@ -1,138 +1,107 @@
 import {
-  DidChangeConfigurationNotification,
-  PublishDiagnosticsNotification,
-  TextDocuments,
-} from "vscode-languageserver";
-import { TextDocument } from "vscode-languageserver-textdocument";
-import {
-  BrowserMessageReader,
-  BrowserMessageWriter,
-  createConnection,
-} from "vscode-languageserver/browser";
-import { Logging, Lsp, Telemetry, Workspace } from "../features";
-import { inlineCompletionRequestType } from "../features/lsp/inline-completions/futureProtocol";
-import { Auth } from "../features/auth/auth";
+    DidChangeConfigurationNotification,
+    PublishDiagnosticsNotification,
+    TextDocuments,
+} from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { BrowserMessageReader, BrowserMessageWriter, createConnection } from 'vscode-languageserver/browser'
+import { Logging, Lsp, Telemetry, Workspace } from '../features'
+import { inlineCompletionRequestType } from '../features/lsp/inline-completions/futureProtocol'
+import { Auth } from '../features/auth/auth'
 
-import { RuntimeProps } from "./runtime";
+import { RuntimeProps } from './runtime'
 import {
-  inlineCompletionWithReferencesRequestType,
-  logInlineCompletionSessionResultsNotificationType,
-} from "../features/lsp/inline-completions/protocolExtensions";
-import { observe } from "../features/lsp";
-import { InitializeHandler } from "./initialize";
+    inlineCompletionWithReferencesRequestType,
+    logInlineCompletionSessionResultsNotificationType,
+} from '../features/lsp/inline-completions/protocolExtensions'
+import { observe } from '../features/lsp'
+import { InitializeHandler } from './initialize'
 
-declare const self: WindowOrWorkerGlobalScope;
+declare const self: WindowOrWorkerGlobalScope
 
 // TODO: testing rig for runtimes
 export const webworker = (props: RuntimeProps) => {
-  const lspConnection = createConnection(
-    new BrowserMessageReader(self),
-    new BrowserMessageWriter(self),
-  );
+    const lspConnection = createConnection(new BrowserMessageReader(self), new BrowserMessageWriter(self))
 
-  const documentsObserver = observe(lspConnection);
-  const documents = new TextDocuments(TextDocument);
+    const documentsObserver = observe(lspConnection)
+    const documents = new TextDocuments(TextDocument)
 
-  let initializeHandler = new InitializeHandler(props.name, props.version);
-  lspConnection.onInitialize(initializeHandler.onInitialize);
+    let initializeHandler = new InitializeHandler(props.name, props.version)
+    lspConnection.onInitialize(initializeHandler.onInitialize)
 
-  // Set up logigng over LSP
-  const logging: Logging = {
-    log: (message) =>
-      lspConnection.console.info(`[${new Date().toISOString()}] ${message}`),
-  };
+    // Set up logigng over LSP
+    const logging: Logging = {
+        log: message => lspConnection.console.info(`[${new Date().toISOString()}] ${message}`),
+    }
 
-  // Set up telemetry over LSP
-  const telemetry: Telemetry = {
-    emitMetric: (metric) => lspConnection.telemetry.logEvent(metric),
-  };
+    // Set up telemetry over LSP
+    const telemetry: Telemetry = {
+        emitMetric: metric => lspConnection.telemetry.logEvent(metric),
+    }
 
-  // Set up the workspace to use the LSP Text Documents component
-  const workspace: Workspace = {
-    getTextDocument: async (uri) => documents.get(uri),
-    getWorkspaceFolder: (_uri) =>
-      initializeHandler.clientInitializeParams!.workspaceFolders &&
-      initializeHandler.clientInitializeParams!.workspaceFolders[0],
-    fs: {
-      copy: (_src, _dest) => Promise.resolve(),
-      exists: (_path) => Promise.resolve(false),
-      getFileSize: (_path) => Promise.resolve({ size: 0 }),
-      getTempDirPath: () => "/tmp",
-      readFile: (_path) => Promise.resolve(""),
-      readdir: (_path) => Promise.resolve([]),
-      isFile: (_path) => Promise.resolve(false),
-      remove: (_dir) => Promise.resolve(),
-    },
-  };
+    // Set up the workspace to use the LSP Text Documents component
+    const workspace: Workspace = {
+        getTextDocument: async uri => documents.get(uri),
+        getWorkspaceFolder: _uri =>
+            initializeHandler.clientInitializeParams!.workspaceFolders &&
+            initializeHandler.clientInitializeParams!.workspaceFolders[0],
+        fs: {
+            copy: (_src, _dest) => Promise.resolve(),
+            exists: _path => Promise.resolve(false),
+            getFileSize: _path => Promise.resolve({ size: 0 }),
+            getTempDirPath: () => '/tmp',
+            readFile: _path => Promise.resolve(''),
+            readdir: _path => Promise.resolve([]),
+            isFile: _path => Promise.resolve(false),
+            remove: _dir => Promise.resolve(),
+        },
+    }
 
-  // Map the LSP client to the LSP feature.
-  const lsp: Lsp = {
-    addInitializer: initializeHandler.addHandler,
-    onInitialized: (handler) =>
-      lspConnection.onInitialized((p) => {
-        const workspaceCapabilities =
-          initializeHandler.clientInitializeParams?.capabilities.workspace;
-        if (
-          workspaceCapabilities?.didChangeConfiguration?.dynamicRegistration
-        ) {
-          // Ask the client to notify the server on configuration changes
-          lspConnection.client.register(
-            DidChangeConfigurationNotification.type,
-            undefined,
-          );
-        }
-        handler(p);
-      }),
-    onCompletion: (handler) => lspConnection.onCompletion(handler),
-    onInlineCompletion: (handler) =>
-      lspConnection.onRequest(inlineCompletionRequestType, handler),
-    didChangeConfiguration: (handler) =>
-      lspConnection.onDidChangeConfiguration(handler),
-    onDidChangeTextDocument: (handler) =>
-      documentsObserver.callbacks.onDidChangeTextDocument(handler),
-    onDidCloseTextDocument: (handler) =>
-      lspConnection.onDidCloseTextDocument(handler),
-    onExecuteCommand: (handler) => lspConnection.onExecuteCommand(handler),
-    workspace: {
-      getConfiguration: (section) =>
-        lspConnection.workspace.getConfiguration(section),
-    },
-    publishDiagnostics: (params) =>
-      lspConnection.sendNotification(
-        PublishDiagnosticsNotification.method,
-        params,
-      ),
-    onHover: (handler) => lspConnection.onHover(handler),
-    extensions: {
-      onInlineCompletionWithReferences: (handler) =>
-        lspConnection.onRequest(
-          inlineCompletionWithReferencesRequestType,
-          handler,
-        ),
-      onLogInlineCompletionSessionResults: (handler) => {
-        lspConnection.onNotification(
-          logInlineCompletionSessionResultsNotificationType,
-          handler,
-        );
-      },
-    },
-  };
+    // Map the LSP client to the LSP feature.
+    const lsp: Lsp = {
+        addInitializer: initializeHandler.addHandler,
+        onInitialized: handler =>
+            lspConnection.onInitialized(p => {
+                const workspaceCapabilities = initializeHandler.clientInitializeParams?.capabilities.workspace
+                if (workspaceCapabilities?.didChangeConfiguration?.dynamicRegistration) {
+                    // Ask the client to notify the server on configuration changes
+                    lspConnection.client.register(DidChangeConfigurationNotification.type, undefined)
+                }
+                handler(p)
+            }),
+        onCompletion: handler => lspConnection.onCompletion(handler),
+        onInlineCompletion: handler => lspConnection.onRequest(inlineCompletionRequestType, handler),
+        didChangeConfiguration: handler => lspConnection.onDidChangeConfiguration(handler),
+        onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),
+        onDidCloseTextDocument: handler => lspConnection.onDidCloseTextDocument(handler),
+        onExecuteCommand: handler => lspConnection.onExecuteCommand(handler),
+        workspace: {
+            getConfiguration: section => lspConnection.workspace.getConfiguration(section),
+        },
+        publishDiagnostics: params => lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),
+        onHover: handler => lspConnection.onHover(handler),
+        extensions: {
+            onInlineCompletionWithReferences: handler =>
+                lspConnection.onRequest(inlineCompletionWithReferencesRequestType, handler),
+            onLogInlineCompletionSessionResults: handler => {
+                lspConnection.onNotification(logInlineCompletionSessionResultsNotificationType, handler)
+            },
+        },
+    }
 
-  // Set up auth without encryption
-  const auth = new Auth(lspConnection);
-  const credentialsProvider = auth.getCredentialsProvider();
+    // Set up auth without encryption
+    const auth = new Auth(lspConnection)
+    const credentialsProvider = auth.getCredentialsProvider()
 
-  // Initialize every Server
-  const disposables = props.servers.map((s) =>
-    s({ credentialsProvider, lsp, workspace, telemetry, logging }),
-  );
+    // Initialize every Server
+    const disposables = props.servers.map(s => s({ credentialsProvider, lsp, workspace, telemetry, logging }))
 
-  // Free up any resources or threads used by Servers
-  lspConnection.onExit(() => {
-    disposables.forEach((d) => d());
-  });
+    // Free up any resources or threads used by Servers
+    lspConnection.onExit(() => {
+        disposables.forEach(d => d())
+    })
 
-  // Initialize the documents listener and start the LSP connection
-  documents.listen(documentsObserver.callbacks);
-  lspConnection.listen();
-};
+    // Initialize the documents listener and start the LSP connection
+    documents.listen(documentsObserver.callbacks)
+    lspConnection.listen()
+}

--- a/src/testing/TestFeatures.ts
+++ b/src/testing/TestFeatures.ts
@@ -1,20 +1,14 @@
+import { CredentialsProvider, Logging, Lsp, Telemetry, Workspace } from '../features'
+import { Server } from '../runtimes'
+import { StubbedInstance, stubInterface } from 'ts-sinon'
 import {
-  CredentialsProvider,
-  Logging,
-  Lsp,
-  Telemetry,
-  Workspace,
-} from "../features";
-import { Server } from "../runtimes";
-import { StubbedInstance, stubInterface } from "ts-sinon";
-import {
-  CancellationToken,
-  CompletionParams,
-  DidChangeTextDocumentParams,
-  ExecuteCommandParams,
-  InlineCompletionParams,
-} from "vscode-languageserver";
-import { TextDocument } from "vscode-languageserver-textdocument";
+    CancellationToken,
+    CompletionParams,
+    DidChangeTextDocumentParams,
+    ExecuteCommandParams,
+    InlineCompletionParams,
+} from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 
 /**
  * A test helper package to test Server implementations. Accepts a single callback
@@ -26,147 +20,131 @@ import { TextDocument } from "vscode-languageserver-textdocument";
  * testing the effects and responses.
  */
 export class TestFeatures {
-  credentialsProvider: StubbedInstance<CredentialsProvider>;
-  // TODO: This needs to improve, somehow sinon doesn't stub nested objects
-  lsp: StubbedInstance<Lsp> & {
-    workspace: StubbedInstance<Lsp["workspace"]>;
-  } & {
-    extensions: StubbedInstance<Lsp["extensions"]>;
-  };
-  workspace: StubbedInstance<Workspace>;
-  logging: StubbedInstance<Logging>;
-  telemetry: StubbedInstance<Telemetry>;
-  documents: {
-    [uri: string]: TextDocument;
-  };
-
-  private disposables: (() => void)[] = [];
-
-  constructor() {
-    this.credentialsProvider = stubInterface<CredentialsProvider>();
-    this.lsp = stubInterface<
-      Lsp & { workspace: StubbedInstance<Lsp["workspace"]> } & {
-        extensions: StubbedInstance<Lsp["extensions"]>;
-      }
-    >();
-    this.lsp.workspace = stubInterface<typeof this.lsp.workspace>();
-    this.lsp.extensions = stubInterface<typeof this.lsp.extensions>();
-    this.workspace = stubInterface<Workspace>();
-    this.logging = stubInterface<Logging>();
-    this.telemetry = stubInterface<Telemetry>();
-    this.documents = {};
-
-    this.workspace.getTextDocument.callsFake(
-      async (uri) => this.documents[uri],
-    );
-  }
-
-  async start(server: Server) {
-    this.disposables.push(server(this));
-    return Promise.resolve(this).then((f) => {
-      this.lsp.onInitialized.args[0]?.[0]({});
-      return f;
-    });
-  }
-
-  async doInlineCompletion(
-    params: InlineCompletionParams,
-    token: CancellationToken,
-  ) {
-    return this.lsp.onInlineCompletion.args[0]?.[0](params, token);
-  }
-
-  async doCompletion(params: CompletionParams, token: CancellationToken) {
-    return this.lsp.onCompletion.args[0]?.[0](params, token);
-  }
-
-  async doInlineCompletionWithReferences(
-    ...args: Parameters<
-      Parameters<Lsp["extensions"]["onInlineCompletionWithReferences"]>[0]
-    >
-  ) {
-    return this.lsp.extensions.onInlineCompletionWithReferences.args[0]?.[0](
-      ...args,
-    );
-  }
-
-  async doLogInlineCompletionSessionResults(
-    ...args: Parameters<
-      Parameters<Lsp["extensions"]["onLogInlineCompletionSessionResults"]>[0]
-    >
-  ) {
-    return this.lsp.extensions.onLogInlineCompletionSessionResults.args[0]?.[0](
-      ...args,
-    );
-  }
-
-  openDocument(document: TextDocument) {
-    this.documents[document.uri] = document;
-    return this;
-  }
-
-  async doChangeConfiguration() {
-    // Force the call to handle after the current task completes
-    await undefined;
-    this.lsp.didChangeConfiguration.args[0]?.[0]({ settings: undefined });
-    return this;
-  }
-
-  async doChangeTextDocument(params: DidChangeTextDocumentParams) {
-    // Force the call to handle after the current task completes
-    await undefined;
-    this.lsp.onDidChangeTextDocument.args[0]?.[0](params);
-    return this;
-  }
-
-  async doExecuteCommand(
-    params: ExecuteCommandParams,
-    token: CancellationToken,
-  ) {
-    return this.lsp.onExecuteCommand.args[0]?.[0](params, token);
-  }
-
-  async simulateTyping(uri: string, text: string) {
-    let remainder = text;
-
-    while (remainder.length > 0) {
-      const document = this.documents[uri]!;
-      const contentChange = remainder.substring(0, 1);
-      remainder = remainder.substring(1);
-      const newDocument = TextDocument.create(
-        document.uri,
-        document.languageId,
-        document.version + 1,
-        document.getText() + contentChange,
-      );
-      this.documents[uri] = newDocument;
-
-      const endPosition = document.positionAt(document.getText().length);
-      const range = {
-        start: endPosition,
-        end: endPosition,
-      };
-
-      // Force the call to handle after the current task completes
-      await undefined;
-      this.lsp.onDidChangeTextDocument.args[0]?.[0]({
-        textDocument: {
-          uri,
-          version: document.version,
-        },
-        contentChanges: [
-          {
-            range,
-            text: contentChange,
-          },
-        ],
-      });
+    credentialsProvider: StubbedInstance<CredentialsProvider>
+    // TODO: This needs to improve, somehow sinon doesn't stub nested objects
+    lsp: StubbedInstance<Lsp> & {
+        workspace: StubbedInstance<Lsp['workspace']>
+    } & {
+        extensions: StubbedInstance<Lsp['extensions']>
+    }
+    workspace: StubbedInstance<Workspace>
+    logging: StubbedInstance<Logging>
+    telemetry: StubbedInstance<Telemetry>
+    documents: {
+        [uri: string]: TextDocument
     }
 
-    return this;
-  }
+    private disposables: (() => void)[] = []
 
-  dispose() {
-    this.disposables.forEach((d) => d());
-  }
+    constructor() {
+        this.credentialsProvider = stubInterface<CredentialsProvider>()
+        this.lsp = stubInterface<
+            Lsp & { workspace: StubbedInstance<Lsp['workspace']> } & {
+                extensions: StubbedInstance<Lsp['extensions']>
+            }
+        >()
+        this.lsp.workspace = stubInterface<typeof this.lsp.workspace>()
+        this.lsp.extensions = stubInterface<typeof this.lsp.extensions>()
+        this.workspace = stubInterface<Workspace>()
+        this.logging = stubInterface<Logging>()
+        this.telemetry = stubInterface<Telemetry>()
+        this.documents = {}
+
+        this.workspace.getTextDocument.callsFake(async uri => this.documents[uri])
+    }
+
+    async start(server: Server) {
+        this.disposables.push(server(this))
+        return Promise.resolve(this).then(f => {
+            this.lsp.onInitialized.args[0]?.[0]({})
+            return f
+        })
+    }
+
+    async doInlineCompletion(params: InlineCompletionParams, token: CancellationToken) {
+        return this.lsp.onInlineCompletion.args[0]?.[0](params, token)
+    }
+
+    async doCompletion(params: CompletionParams, token: CancellationToken) {
+        return this.lsp.onCompletion.args[0]?.[0](params, token)
+    }
+
+    async doInlineCompletionWithReferences(
+        ...args: Parameters<Parameters<Lsp['extensions']['onInlineCompletionWithReferences']>[0]>
+    ) {
+        return this.lsp.extensions.onInlineCompletionWithReferences.args[0]?.[0](...args)
+    }
+
+    async doLogInlineCompletionSessionResults(
+        ...args: Parameters<Parameters<Lsp['extensions']['onLogInlineCompletionSessionResults']>[0]>
+    ) {
+        return this.lsp.extensions.onLogInlineCompletionSessionResults.args[0]?.[0](...args)
+    }
+
+    openDocument(document: TextDocument) {
+        this.documents[document.uri] = document
+        return this
+    }
+
+    async doChangeConfiguration() {
+        // Force the call to handle after the current task completes
+        await undefined
+        this.lsp.didChangeConfiguration.args[0]?.[0]({ settings: undefined })
+        return this
+    }
+
+    async doChangeTextDocument(params: DidChangeTextDocumentParams) {
+        // Force the call to handle after the current task completes
+        await undefined
+        this.lsp.onDidChangeTextDocument.args[0]?.[0](params)
+        return this
+    }
+
+    async doExecuteCommand(params: ExecuteCommandParams, token: CancellationToken) {
+        return this.lsp.onExecuteCommand.args[0]?.[0](params, token)
+    }
+
+    async simulateTyping(uri: string, text: string) {
+        let remainder = text
+
+        while (remainder.length > 0) {
+            const document = this.documents[uri]!
+            const contentChange = remainder.substring(0, 1)
+            remainder = remainder.substring(1)
+            const newDocument = TextDocument.create(
+                document.uri,
+                document.languageId,
+                document.version + 1,
+                document.getText() + contentChange
+            )
+            this.documents[uri] = newDocument
+
+            const endPosition = document.positionAt(document.getText().length)
+            const range = {
+                start: endPosition,
+                end: endPosition,
+            }
+
+            // Force the call to handle after the current task completes
+            await undefined
+            this.lsp.onDidChangeTextDocument.args[0]?.[0]({
+                textDocument: {
+                    uri,
+                    version: document.version,
+                },
+                contentChanges: [
+                    {
+                        range,
+                        text: contentChange,
+                    },
+                ],
+            })
+        }
+
+        return this
+    }
+
+    dispose() {
+        this.disposables.forEach(d => d())
+    }
 }

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,1 +1,1 @@
-export { TestFeatures } from "./TestFeatures";
+export { TestFeatures } from './TestFeatures'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
-  "compilerOptions": {
-    "target": "es2016",
-    "module": "commonjs",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "rootDir": "./src",
-    "outDir": "./out",
-    "declaration": true
-  }
+    "compilerOptions": {
+        "target": "es2016",
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "rootDir": "./src",
+        "outDir": "./out",
+        "declaration": true
+    }
 }


### PR DESCRIPTION
## Problem
Formatting rules between team-owned packages are misaligned.

## Solution

[Added prettier rules](https://github.com/aws/language-server-runtimes/compare/formatting?expand=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R48-R56) matching https://github.com/aws/language-servers package and formatted all files.
No code changes were introduced, only cosmetic formatting changes.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
