### PR TITLE
Added onDidFormatDocument and onDidOpenTextDocument capabilities to DEXP LSP

### DIFF
--- a/src/features/lsp/index.ts
+++ b/src/features/lsp/index.ts
@@ -14,12 +14,13 @@ import {
     InlineCompletionItem,
     InlineCompletionList,
     InlineCompletionParams,
-    LSPAny,
     NotificationHandler,
     PublishDiagnosticsParams,
     RequestHandler,
-    ServerRequestHandler,
     ServerCapabilities,
+    DidOpenTextDocumentParams,
+    DocumentFormattingParams,
+    TextEdit,
 } from 'vscode-languageserver'
 import {
     InlineCompletionItemWithReferences,
@@ -59,6 +60,10 @@ export type Lsp = {
         handler: RequestHandler<CompletionParams, CompletionItem[] | CompletionList | undefined | null, void>
     ) => void
     didChangeConfiguration: (handler: NotificationHandler<DidChangeConfigurationParams>) => void
+    onDidFormatDocument: (
+        handler: RequestHandler<DocumentFormattingParams, TextEdit[] | undefined | null, never>
+    ) => void
+    onDidOpenTextDocument: (handler: NotificationHandler<DidOpenTextDocumentParams>) => void
     onDidChangeTextDocument: (handler: NotificationHandler<DidChangeTextDocumentParams>) => void
     onDidCloseTextDocument: (handler: NotificationHandler<DidCloseTextDocumentParams>) => void
     publishDiagnostics: (params: PublishDiagnosticsParams) => Promise<void>

--- a/src/runtimes/standalone.ts
+++ b/src/runtimes/standalone.ts
@@ -173,6 +173,8 @@ export const standalone = (props: RuntimeProps) => {
             onCompletion: handler => lspConnection.onCompletion(handler),
             onInlineCompletion: handler => lspConnection.onRequest(inlineCompletionRequestType, handler),
             didChangeConfiguration: handler => lspConnection.onDidChangeConfiguration(handler),
+            onDidFormatDocument: handler => lspConnection.onDocumentFormatting(handler),
+            onDidOpenTextDocument: handler => documentsObserver.callbacks.onDidOpenTextDocument(handler),
             onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),
             onDidCloseTextDocument: handler => documentsObserver.callbacks.onDidCloseTextDocument(handler),
             onExecuteCommand: handler => lspConnection.onExecuteCommand(handler),

--- a/src/runtimes/webworker.ts
+++ b/src/runtimes/webworker.ts
@@ -72,6 +72,8 @@ export const webworker = (props: RuntimeProps) => {
         onCompletion: handler => lspConnection.onCompletion(handler),
         onInlineCompletion: handler => lspConnection.onRequest(inlineCompletionRequestType, handler),
         didChangeConfiguration: handler => lspConnection.onDidChangeConfiguration(handler),
+        onDidFormatDocument: handler => lspConnection.onDocumentFormatting(handler),
+        onDidOpenTextDocument: handler => documentsObserver.callbacks.onDidOpenTextDocument(handler),
         onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),
         onDidCloseTextDocument: handler => lspConnection.onDidCloseTextDocument(handler),
         onExecuteCommand: handler => lspConnection.onExecuteCommand(handler),

--- a/src/testing/TestFeatures.ts
+++ b/src/testing/TestFeatures.ts
@@ -5,7 +5,10 @@ import {
     CancellationToken,
     CompletionParams,
     DidChangeTextDocumentParams,
+    DidOpenTextDocumentParams,
+    DocumentFormattingParams,
     ExecuteCommandParams,
+    HoverParams,
     InlineCompletionParams,
 } from 'vscode-languageserver'
 import { TextDocument } from 'vscode-languageserver-textdocument'
@@ -69,6 +72,14 @@ export class TestFeatures {
         return this.lsp.onCompletion.args[0]?.[0](params, token)
     }
 
+    async doFormat(params: DocumentFormattingParams, token: CancellationToken) {
+        return this.lsp.onDidFormatDocument.args[0]?.[0](params, token)
+    }
+
+    async doHover(params: HoverParams, token: CancellationToken) {
+        return this.lsp.onHover.args[0]?.[0](params, token)
+    }
+
     async doInlineCompletionWithReferences(
         ...args: Parameters<Parameters<Lsp['extensions']['onInlineCompletionWithReferences']>[0]>
     ) {
@@ -97,6 +108,13 @@ export class TestFeatures {
         // Force the call to handle after the current task completes
         await undefined
         this.lsp.onDidChangeTextDocument.args[0]?.[0](params)
+        return this
+    }
+
+    async doOpenTextDocument(params: DidOpenTextDocumentParams) {
+        // Force the call to handle after the current task completes
+        await undefined
+        this.lsp.onDidOpenTextDocument.args[0]?.[0](params)
         return this
     }
 


### PR DESCRIPTION
## Problem
YAML JSON LSP Server needs to support formatting documents and send diagnostics when file opened.

## Solution

- Added onDidFormatDocument and onDidOpenTextDocument support to LSP server interface.
- Added onDidOpenTextDocument, onHover, onDidFormatDocument to TestFeatures to add more tests in language-servers package

## Testing

Tested in language-servers package, added tests there.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
