### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.0] - 2024-03-26
+
+- Refactored repository directories structure to better match project architecture
+- Added new Chat feature to model and implement Chat-based GenAI assistant server feature
+- Added support for `onDidFormatDocument` and `onDidOpenTextDocument` requests to LSP feature
+
 ## [0.1.1] - 2023-11-21
 
 - Initial release containing `standalone` and `webworker` runtimes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/language-server-runtimes",
-            "version": "0.1.1",
+            "version": "0.2.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "jose": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
         "pub": "cd out && npm publish",
         "test:prettier": "prettier . --check",
         "test:unit": "ts-mocha -b 'src/**/*.test.ts'",
-        "test": "npm run test:prettier && npm run test:unit"
+        "test": "npm run test:prettier && npm run test:unit",
+        "preversion": "npm run test",
+        "version": "npm run compile && git add -A ."
     },
     "dependencies": {
         "jose": "^5.2.3",


### PR DESCRIPTION
## Problem
We need to release latest additions to runtimes package for consumption in language-servers implementations.

## Solution
Release new version and publish it to npm. 
New version is 0.2.0, as this release contains breaking project directory structure changes, which will require upgrading imports structure in downstream dependencies.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
