### PR TITLE
Release/0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.1] - 2024-04-03
+
+- Add routing to `LSP.executeCommand` server runtimes implementation: not runtimes will route LSP commands for execution to server between multiple registered servers
+
 ## [0.2.0] - 2024-03-26
 
 - Refactored repository directories structure to better match project architecture

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@aws/language-server-runtimes",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "jose": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",


### PR DESCRIPTION
## Description

Release new patch version 0.2.1

Changes:
- Introduced routing for LSP.executeCommand feature.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
