### PR TITLE
Allow UpdateCredentials request params by-name and by-position

### DIFF
--- a/src/protocol/auth.ts
+++ b/src/protocol/auth.ts
@@ -1,4 +1,9 @@
-import { ProtocolRequestType, ProtocolNotificationType0, ProtocolRequestType0 } from './lsp'
+import {
+    ProtocolRequestType,
+    ProtocolNotificationType0,
+    ProtocolRequestType0,
+    AutoParameterStructuresProtocolRequestType,
+} from './lsp'
 
 export type IamCredentials = {
     readonly accessKeyId: string
@@ -26,13 +31,17 @@ export interface UpdateCredentialsParams {
     encrypted?: boolean
 }
 
-export const iamCredentialsUpdateRequestType = new ProtocolRequestType<UpdateCredentialsParams, null, void, void, void>(
-    'aws/credentials/iam/update'
-)
+export const iamCredentialsUpdateRequestType = new AutoParameterStructuresProtocolRequestType<
+    UpdateCredentialsParams,
+    null,
+    void,
+    void,
+    void
+>('aws/credentials/iam/update')
 
 export const iamCredentialsDeleteNotificationType = new ProtocolNotificationType0<void>('aws/credentials/iam/delete')
 
-export const bearerCredentialsUpdateRequestType = new ProtocolRequestType<
+export const bearerCredentialsUpdateRequestType = new AutoParameterStructuresProtocolRequestType<
     UpdateCredentialsParams,
     null,
     void,

--- a/src/protocol/lsp.ts
+++ b/src/protocol/lsp.ts
@@ -1,3 +1,6 @@
+import { ParameterStructures, ProgressType, RegistrationType, RequestType } from 'vscode-languageserver-protocol'
+import { _EM } from 'vscode-jsonrpc'
+
 export { TextDocument, Position } from 'vscode-languageserver-textdocument'
 
 // LSP protocol is a core dependency for LSP feature provided by runtimes.
@@ -10,3 +13,21 @@ export * from 'vscode-languageserver-protocol'
 // Custom Runtimes LSP extensions
 export * from './inlineCompletions'
 export * from './inlineCompletionWithReferences'
+
+// AutoParameterStructuresProtocolRequestType allows ParameterStructures both by-name and by-position
+export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
+    extends RequestType<P, R, E>
+    implements ProgressType<PR>, RegistrationType<RO>
+{
+    /**
+     * Clients must not use this property. It is here to ensure correct typing.
+     */
+    public readonly __: [PR, _EM] | undefined
+    public readonly ___: [PR, RO, _EM] | undefined
+    public readonly ____: [RO, _EM] | undefined
+    public readonly _pr: PR | undefined
+
+    public constructor(method: string) {
+        super(method, ParameterStructures.auto)
+    }
+}

--- a/src/runtimes/auth/auth.test.ts
+++ b/src/runtimes/auth/auth.test.ts
@@ -4,7 +4,7 @@ import * as jose from 'jose'
 import { Duplex } from 'stream'
 import { Connection, createConnection } from 'vscode-languageserver/node'
 import { Auth } from './auth'
-import { UpdateCredentialsParams } from '../../protocol'
+import { ParameterStructures, UpdateCredentialsParams } from '../../protocol'
 import { IamCredentials, BearerCredentials, CredentialsType, CredentialsProvider } from '../../server-interface'
 
 export const credentialsProtocolMethodNames = {
@@ -111,6 +111,27 @@ describe('Auth', () => {
         authHandlers.iamDeleteHandler()
         assert(!credentialsProvider.hasCredentials('iam'))
         assert(credentialsProvider.getCredentials('iam') === undefined)
+    })
+
+    it('Handles Set Bearer credentials request when parameters sent by position', async () => {
+        const updateRequest: UpdateCredentialsParams = {
+            data: bearerCredentials,
+            encrypted: false,
+        }
+        const auth = new Auth(serverConnection)
+        const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
+
+        assert(!credentialsProvider.hasCredentials('bearer'))
+
+        // @ts-ignore
+        await clientConnection.sendRequest(
+            credentialsProtocolMethodNames.bearerCredentialsUpdate,
+            ParameterStructures.byPosition,
+            updateRequest
+        )
+
+        assert(credentialsProvider.hasCredentials('bearer'))
+        assert.deepEqual(credentialsProvider.getCredentials('bearer'), bearerCredentials)
     })
 
     it('Handles Set Bearer credentials request', async () => {


### PR DESCRIPTION
## Problem
[JSON-RPC protocol](https://www.jsonrpc.org/specification) allows passing parameters as an array (positinal) or as an object (by names). For example, 
```
rpc call with positional parameters:
--> {"jsonrpc": "2.0", "method": "subtract", "params": [42, 23], "id": 1}
<-- {"jsonrpc": "2.0", "result": 19, "id": 1}

rpc call with named parameters:
--> {"jsonrpc": "2.0", "method": "subtract", "params": {"subtrahend": 23, "minuend": 42}, "id": 3}
<-- {"jsonrpc": "2.0", "result": 19, "id": 3}
```

Previously, the CodeWhisperer LSP Server allowed `'aws/credentials/token/update'` JSON-RPC requests to pass parameters by name and positional. 
But [a recent refactoring in `aws/language-server-runtimes` changed the implementation](https://github.com/aws/language-server-runtimes/commit/3c74fee7af9c0cb2792c5d9683bfd5afce1dfa7d#diff-8d9c26fb3fabe4ac9c52241e64600a45dbe451928e1201031acc4a0f61d12707R29) of this method:
```
export const bearerCredentialsUpdateRequestType = new ProtocolRequestType<
    UpdateCredentialsParams,
    null,
    void,
    void,
    void
>('aws/credentials/token/update')
```
Now it uses [`vscode-language-server-protocol`'s `ProtocolRequestType`](https://github.com/microsoft/vscode-languageserver-node/blob/main/protocol/src/common/messages.ts#L51) class which limits the requests to pass parameters by name only:
```

export class ProtocolRequestType<P, R, PR, E, RO> ... {
    //...
	public constructor(method: string) {
		super(method, ParameterStructures.byName);
	}
}
```

Thus when the VisualStudio sends the JSON-RPC message to pass the bearer token as positional arguments the server now responds with the error:
```
Request aws/credentials/token/update defines parameters by name but received parameters by position
```

The problem wasn't reproducible in the VSCode client because it sent the parameters by name. 

## Solution

A new `RequestType` is exported in protocol now - `AutoParameterStructuresProtocolRequestType`. The class repeats the `ProtocolRequestType` but it allows ParameterStructures both by-name and by-position. 

Updated `bearerCredentialsUpdateRequestType` and `iamCredentialsUpdateRequestType` to base on `AutoParameterStructuresProtocolRequestType`. 

Added a test case that checks the server allows the bearer token by-position as well as by-name.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
