### PR TITLE
Add support for handling `workspace/didChangeWorkspaceFolders` notification

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -1,4 +1,4 @@
-import { TextDocuments } from 'vscode-languageserver'
+import { DidChangeWorkspaceFoldersNotification, TextDocuments } from 'vscode-languageserver'
 import {
     DidChangeConfigurationNotification,
     ProgressToken,
@@ -226,6 +226,7 @@ export const standalone = (props: RuntimeProps) => {
                 onExecuteCommand: lspServer.setExecuteCommandHandler,
                 workspace: {
                     getConfiguration: section => lspConnection.workspace.getConfiguration(section),
+                    onDidChangeWorkspaceFolders: handler => lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler)
                 },
                 publishDiagnostics: params =>
                     lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -1,6 +1,7 @@
-import { DidChangeWorkspaceFoldersNotification, TextDocuments } from 'vscode-languageserver'
+import { TextDocuments } from 'vscode-languageserver'
 import {
     DidChangeConfigurationNotification,
+    DidChangeWorkspaceFoldersNotification,
     ProgressToken,
     ProgressType,
     PublishDiagnosticsNotification,

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -226,7 +226,8 @@ export const standalone = (props: RuntimeProps) => {
                 onExecuteCommand: lspServer.setExecuteCommandHandler,
                 workspace: {
                     getConfiguration: section => lspConnection.workspace.getConfiguration(section),
-                    onDidChangeWorkspaceFolders: handler => lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler)
+                    onDidChangeWorkspaceFolders: handler =>
+                        lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler),
                 },
                 publishDiagnostics: params =>
                     lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -1,6 +1,7 @@
-import { DidChangeWorkspaceFoldersNotification, TextDocuments } from 'vscode-languageserver'
+import { TextDocuments } from 'vscode-languageserver'
 import {
     DidChangeConfigurationNotification,
+    DidChangeWorkspaceFoldersNotification,
     ProgressToken,
     ProgressType,
     PublishDiagnosticsNotification,

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -128,7 +128,8 @@ export const webworker = (props: RuntimeProps) => {
             onExecuteCommand: lspServer.setExecuteCommandHandler,
             workspace: {
                 getConfiguration: section => lspConnection.workspace.getConfiguration(section),
-                onDidChangeWorkspaceFolders: handler => lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler)
+                onDidChangeWorkspaceFolders: handler =>
+                    lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler),
             },
             publishDiagnostics: params => lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),
             sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -1,4 +1,4 @@
-import { TextDocuments } from 'vscode-languageserver'
+import { DidChangeWorkspaceFoldersNotification, TextDocuments } from 'vscode-languageserver'
 import {
     DidChangeConfigurationNotification,
     ProgressToken,
@@ -128,6 +128,7 @@ export const webworker = (props: RuntimeProps) => {
             onExecuteCommand: lspServer.setExecuteCommandHandler,
             workspace: {
                 getConfiguration: section => lspConnection.workspace.getConfiguration(section),
+                onDidChangeWorkspaceFolders: handler => lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler)
             },
             publishDiagnostics: params => lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),
             sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -26,6 +26,7 @@ import {
     TextEdit,
     ProgressType,
     ProgressToken,
+    DidChangeWorkspaceFoldersParams,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -77,6 +78,7 @@ export type Lsp = {
     onExecuteCommand: (handler: RequestHandler<ExecuteCommandParams, any | undefined | null, void>) => void
     workspace: {
         getConfiguration: (section: string) => Promise<any>
+        onDidChangeWorkspaceFolders: (handler: NotificationHandler<DidChangeWorkspaceFoldersParams>) => void
     }
     extensions: {
         onInlineCompletionWithReferences: (


### PR DESCRIPTION
## Description
Adds support for detecting and handling `workspace/didChangeWorkspaceFolders` notification. This will leveraged by CWSPR security scan server in the `aws/language-servers` repo to detect workspace change events and clear ir-relevant diagnostics.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
