### PR TITLE
Move types to types package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1915,9 +1915,7 @@
                 "jose": "^5.2.3",
                 "rxjs": "^7.8.1",
                 "vscode-languageserver": "^9.0.1",
-                "vscode-languageserver-protocol": "^3.17.5",
-                "vscode-languageserver-textdocument": "^1.0.11",
-                "vscode-languageserver-types": "^3.17.5"
+                "vscode-languageserver-protocol": "^3.17.5"
             },
             "devDependencies": {
                 "@types/mocha": "^10.0.1",
@@ -1947,7 +1945,9 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "vscode-languageserver-protocol": "^3.17.5"
+                "vscode-languageserver-protocol": "^3.17.5",
+                "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-languageserver-types": "^3.17.5"
             }
         }
     }

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -38,9 +38,7 @@
         "jose": "^5.2.3",
         "rxjs": "^7.8.1",
         "vscode-languageserver": "^9.0.1",
-        "vscode-languageserver-protocol": "^3.17.5",
-        "vscode-languageserver-textdocument": "^1.0.11",
-        "vscode-languageserver-types": "^3.17.5"
+        "vscode-languageserver-protocol": "^3.17.5"
     },
     "devDependencies": {
         "@types/mocha": "^10.0.1",

--- a/runtimes/protocol/auth.ts
+++ b/runtimes/protocol/auth.ts
@@ -1,35 +1,10 @@
 import {
-    ProtocolRequestType,
+    UpdateCredentialsParams,
+    ConnectionMetadata,
     ProtocolNotificationType0,
     ProtocolRequestType0,
     AutoParameterStructuresProtocolRequestType,
 } from './lsp'
-
-export type IamCredentials = {
-    readonly accessKeyId: string
-    readonly secretAccessKey: string
-    readonly sessionToken?: string
-}
-
-export type BearerCredentials = {
-    readonly token: string
-}
-
-export interface SsoProfileData {
-    startUrl?: string
-}
-
-export interface ConnectionMetadata {
-    sso?: SsoProfileData
-}
-
-export interface UpdateCredentialsParams {
-    // Plaintext Credentials (for browser based environments) or encrypted JWT token
-    data: IamCredentials | BearerCredentials | string
-    // If the payload is encrypted
-    // Defaults to false if undefined or null
-    encrypted?: boolean
-}
 
 export const iamCredentialsUpdateRequestType = new AutoParameterStructuresProtocolRequestType<
     UpdateCredentialsParams,

--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -17,9 +17,14 @@ import {
     VoteParams,
     ProtocolNotificationType,
     ProtocolRequestType,
+    ProgressToken,
 } from './lsp'
 
-export const chatRequestType = new ProtocolRequestType<ChatParams, ChatResult, ChatResult, void, void>(
+export interface ChatRequest extends ChatParams {
+    partialResultToken?: ProgressToken
+}
+
+export const chatRequestType = new ProtocolRequestType<ChatRequest, ChatResult, ChatResult, void, void>(
     'aws/chat/sendChatPrompt'
 )
 

--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -15,8 +15,9 @@ import {
     TabChangeParams,
     TabRemoveParams,
     VoteParams,
-} from '@aws/language-server-runtimes-types'
-import { ProtocolNotificationType, ProtocolRequestType } from './lsp'
+    ProtocolNotificationType,
+    ProtocolRequestType,
+} from './lsp'
 
 export const chatRequestType = new ProtocolRequestType<ChatParams, ChatResult, ChatResult, void, void>(
     'aws/chat/sendChatPrompt'

--- a/runtimes/protocol/inlineCompletionWithReferences.ts
+++ b/runtimes/protocol/inlineCompletionWithReferences.ts
@@ -1,12 +1,14 @@
 import {
-    InlineCompletionWithReferencesParams,
     InlineCompletionListWithReferences,
     InlineCompletionItemWithReferences,
     LogInlineCompletionSessionResultsParams,
     InlineCompletionRegistrationOptions,
     ProtocolNotificationType,
     ProtocolRequestType,
+    InlineCompletionParams,
 } from './lsp'
+
+export type InlineCompletionWithReferencesParams = InlineCompletionParams & {}
 
 export const inlineCompletionWithReferencesRequestType = new ProtocolRequestType<
     InlineCompletionWithReferencesParams,

--- a/runtimes/protocol/inlineCompletionWithReferences.ts
+++ b/runtimes/protocol/inlineCompletionWithReferences.ts
@@ -1,51 +1,12 @@
 import {
-    InlineCompletionItem,
-    InlineCompletionParams,
+    InlineCompletionWithReferencesParams,
+    InlineCompletionListWithReferences,
+    InlineCompletionItemWithReferences,
+    LogInlineCompletionSessionResultsParams,
     InlineCompletionRegistrationOptions,
     ProtocolNotificationType,
     ProtocolRequestType,
 } from './lsp'
-
-export type InlineCompletionWithReferencesParams = InlineCompletionParams & {
-    // No added parameters
-}
-
-/**
- * Extend InlineCompletionItem to include optional references.
- */
-export type InlineCompletionItemWithReferences = InlineCompletionItem & {
-    /**
-     * Identifier for the the recommendation returned by server.
-     */
-    itemId: string
-
-    references?: {
-        referenceName?: string
-        referenceUrl?: string
-        licenseName?: string
-        position?: {
-            startCharacter?: number
-            endCharacter?: number
-        }
-    }[]
-}
-
-/**
- * Extend InlineCompletionList to include optional references. This is not inheriting from `InlineCompletionList`
- * since the `items` arrays are incompatible.
- */
-export type InlineCompletionListWithReferences = {
-    /**
-     * Server returns a session ID for current recommendation session.
-     * Client need to attach this session ID in the request when sending
-     * a completion session results.
-     */
-    sessionId: string
-    /**
-     * The inline completion items with optional references
-     */
-    items: InlineCompletionItemWithReferences[]
-}
 
 export const inlineCompletionWithReferencesRequestType = new ProtocolRequestType<
     InlineCompletionWithReferencesParams,
@@ -54,48 +15,6 @@ export const inlineCompletionWithReferencesRequestType = new ProtocolRequestType
     void,
     InlineCompletionRegistrationOptions
 >('aws/textDocument/inlineCompletionWithReferences')
-
-export interface InlineCompletionStates {
-    /**
-     * Completion item was displayed in the client application UI.
-     */
-    seen: boolean
-    /**
-     * Completion item was accepted.
-     */
-    accepted: boolean
-    /**
-     * Recommendation was filtered out on the client-side and marked as discarded.
-     */
-    discarded: boolean
-}
-
-export interface LogInlineCompletionSessionResultsParams {
-    /**
-     * Session Id attached to get completion items response.
-     * This value must match to the one that server returned in InlineCompletionListWithReferences response.
-     */
-    sessionId: string
-    /**
-     * Map with results of interaction with completion items in the client UI.
-     * This list contain a state of each recommendation items from the recommendation session.
-     */
-    completionSessionResult: {
-        [itemId: string /* Completion itemId */]: InlineCompletionStates
-    }
-    /**
-     * Time from completion request invocation start to rendering of the first recommendation in the UI.
-     */
-    firstCompletionDisplayLatency?: number
-    /**
-     * Total time when items from this completion session were visible in UI
-     */
-    totalSessionDisplayTime?: number
-    /**
-     * Length of additional characters inputed by user from when the trigger happens to when the user decision was made
-     */
-    typeaheadLength?: number
-}
 
 export const logInlineCompletionSessionResultsNotificationType = new ProtocolNotificationType<
     LogInlineCompletionSessionResultsParams,

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -1,7 +1,7 @@
 import { ParameterStructures, ProgressType, RegistrationType, RequestType } from 'vscode-languageserver-protocol'
 import { _EM } from 'vscode-jsonrpc'
 
-export { TextDocument, Position } from 'vscode-languageserver-textdocument'
+export * from '@aws/language-server-runtimes-types'
 
 // LSP protocol is a core dependency for LSP feature provided by runtimes.
 // Since we aim to provide whole range of LSP specification for Clients and Capabilities,

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -2,6 +2,7 @@ import { ParameterStructures, ProgressType, RegistrationType, RequestType } from
 import { _EM } from 'vscode-jsonrpc'
 
 export * from '@aws/language-server-runtimes-types'
+export { TextDocument } from 'vscode-languageserver-textdocument'
 
 // LSP protocol is a core dependency for LSP feature provided by runtimes.
 // Since we aim to provide whole range of LSP specification for Clients and Capabilities,

--- a/runtimes/server-interface/chat.ts
+++ b/runtimes/server-interface/chat.ts
@@ -1,5 +1,6 @@
-import { NotificationHandler, RequestHandler } from '../protocol'
 import {
+    NotificationHandler,
+    RequestHandler,
     ChatParams,
     ChatResult,
     CopyCodeToClipboardParams,
@@ -17,7 +18,7 @@ import {
     TabAddParams,
     TabRemoveParams,
     VoteParams,
-} from '@aws/language-server-runtimes-types'
+} from '../protocol'
 
 /**
  * The Chat feature interface. Provides access to chat features

--- a/types/README.md
+++ b/types/README.md
@@ -1,0 +1,11 @@
+# Language Server Runtimes Types
+
+Language Server Runtimes Types is a package containing types used by the [Language Server Runtimes](../runtimes/) package.
+
+
+This package is independent of [VSCode Protocol](https://github.com/microsoft/vscode-languageserver-node/tree/main/protocol) type definitions.
+
+
+## License
+
+This project is licensed under the Apache-2.0 License.

--- a/types/README.md
+++ b/types/README.md
@@ -2,9 +2,8 @@
 
 Language Server Runtimes Types is a package containing types used by the [Language Server Runtimes](../runtimes/) package.
 
-
 This package is independent of [VSCode Protocol](https://github.com/microsoft/vscode-languageserver-node/tree/main/protocol) type definitions.
-
+Interfaces defined here must contain only type definitions with no implementations or side effects. For example, it should not re-export classes from `vscode-languageserver-protocol` or `vscode-jsonrpc` packages.
 
 ## License
 

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,0 +1,25 @@
+export type IamCredentials = {
+    readonly accessKeyId: string
+    readonly secretAccessKey: string
+    readonly sessionToken?: string
+}
+
+export type BearerCredentials = {
+    readonly token: string
+}
+
+export interface SsoProfileData {
+    startUrl?: string
+}
+
+export interface ConnectionMetadata {
+    sso?: SsoProfileData
+}
+
+export interface UpdateCredentialsParams {
+    // Plaintext Credentials (for browser based environments) or encrypted JWT token
+    data: IamCredentials | BearerCredentials | string
+    // If the payload is encrypted
+    // Defaults to false if undefined or null
+    encrypted?: boolean
+}

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,5 +1,3 @@
-import { ProgressToken } from 'vscode-languageserver-protocol'
-
 // Chat Data Model
 
 export interface ChatItemAction {
@@ -51,7 +49,6 @@ export type CodeSelectionType = 'selection' | 'block'
 export interface ChatParams {
     tabId: string
     prompt: ChatPrompt
-    partialResultToken?: ProgressToken
 }
 export interface ChatResult {
     body?: string

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,1 +1,4 @@
 export * from './chat'
+export * from './auth'
+export * from './lsp'
+export * from './inlineCompletionWithReferences'

--- a/types/inlineCompletionWithReferences.ts
+++ b/types/inlineCompletionWithReferences.ts
@@ -1,10 +1,8 @@
-import { InlineCompletionItem, InlineCompletionParams } from 'vscode-languageserver-protocol'
+import { InlineCompletionItem } from 'vscode-languageserver-types'
 
-export type InlineCompletionWithReferencesParams = InlineCompletionParams & {}
 /**
  * Extend InlineCompletionItem to include optional references.
  */
-
 export type InlineCompletionItemWithReferences = InlineCompletionItem & {
     /**
      * Identifier for the the recommendation returned by server.

--- a/types/inlineCompletionWithReferences.ts
+++ b/types/inlineCompletionWithReferences.ts
@@ -1,0 +1,82 @@
+import { InlineCompletionItem, InlineCompletionParams } from 'vscode-languageserver-protocol'
+
+export type InlineCompletionWithReferencesParams = InlineCompletionParams & {}
+/**
+ * Extend InlineCompletionItem to include optional references.
+ */
+
+export type InlineCompletionItemWithReferences = InlineCompletionItem & {
+    /**
+     * Identifier for the the recommendation returned by server.
+     */
+    itemId: string
+
+    references?: {
+        referenceName?: string
+        referenceUrl?: string
+        licenseName?: string
+        position?: {
+            startCharacter?: number
+            endCharacter?: number
+        }
+    }[]
+}
+/**
+ * Extend InlineCompletionList to include optional references. This is not inheriting from `InlineCompletionList`
+ * since the `items` arrays are incompatible.
+ */
+
+export type InlineCompletionListWithReferences = {
+    /**
+     * Server returns a session ID for current recommendation session.
+     * Client need to attach this session ID in the request when sending
+     * a completion session results.
+     */
+    sessionId: string
+    /**
+     * The inline completion items with optional references
+     */
+    items: InlineCompletionItemWithReferences[]
+}
+
+export interface InlineCompletionStates {
+    /**
+     * Completion item was displayed in the client application UI.
+     */
+    seen: boolean
+    /**
+     * Completion item was accepted.
+     */
+    accepted: boolean
+    /**
+     * Recommendation was filtered out on the client-side and marked as discarded.
+     */
+    discarded: boolean
+}
+
+export interface LogInlineCompletionSessionResultsParams {
+    /**
+     * Session Id attached to get completion items response.
+     * This value must match to the one that server returned in InlineCompletionListWithReferences response.
+     */
+    sessionId: string
+    /**
+     * Map with results of interaction with completion items in the client UI.
+     * This list contain a state of each recommendation items from the recommendation session.
+     */
+    completionSessionResult: {
+        [itemId: string /* Completion itemId */]: InlineCompletionStates
+    }
+    /**
+     * Time from completion request invocation start to rendering of the first recommendation in the UI.
+     */
+    firstCompletionDisplayLatency?: number
+    /**
+     * Total time when items from this completion session were visible in UI
+     */
+    totalSessionDisplayTime?: number
+    /**
+     * Length of additional characters inputed by user from when the trigger happens to when the user decision was made
+     */
+    typeaheadLength?: number
+}

--- a/types/lsp.ts
+++ b/types/lsp.ts
@@ -1,3 +1,3 @@
-export { TextDocument, Position } from 'vscode-languageserver-textdocument'
+export { TextDocument } from 'vscode-languageserver-textdocument'
 
 export * from 'vscode-languageserver-types'

--- a/types/lsp.ts
+++ b/types/lsp.ts
@@ -1,0 +1,3 @@
+export { TextDocument, Position } from 'vscode-languageserver-textdocument'
+
+export * from 'vscode-languageserver-types'

--- a/types/lsp.ts
+++ b/types/lsp.ts
@@ -1,3 +1,3 @@
-export { TextDocument } from 'vscode-languageserver-textdocument'
+export type { TextDocument } from 'vscode-languageserver-textdocument'
 
 export * from 'vscode-languageserver-types'

--- a/types/package.json
+++ b/types/package.json
@@ -14,7 +14,6 @@
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
     "dependencies": {
-        "vscode-languageserver-protocol": "^3.17.5",
         "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-languageserver-types": "^3.17.5"
     }

--- a/types/package.json
+++ b/types/package.json
@@ -14,6 +14,8 @@
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
     "dependencies": {
-        "vscode-languageserver-protocol": "^3.17.5"
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-types": "^3.17.5"
     }
 }


### PR DESCRIPTION
## Problem
All type besides chat-types are still in the runtimes package

## Solution
- Move types to `types` package.
- Change re-export of  `vscode-languageserver-protocol` to `types` package in `runtimes` package
- Update dependencies

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
