### PR TITLE
Remove hardcoded hoverProvide set in server initialisation handler

### DIFF
--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -69,7 +69,6 @@ describe('LspRouter', () => {
                         openClose: true,
                         change: TextDocumentSyncKind.Incremental,
                     },
-                    hoverProvider: true,
                 },
             }
             assert.deepStrictEqual(result, expected)
@@ -89,7 +88,6 @@ describe('LspRouter', () => {
                         openClose: true,
                         change: TextDocumentSyncKind.Incremental,
                     },
-                    hoverProvider: true,
                 },
             }
             assert.deepStrictEqual(result, expected)
@@ -105,9 +103,7 @@ describe('LspRouter', () => {
             }
             const handler2 = () => {
                 return Promise.resolve({
-                    capabilities: {
-                        hoverProvider: true,
-                    },
+                    capabilities: {},
                     extraField: 'extraValue',
                 })
             }
@@ -128,7 +124,6 @@ describe('LspRouter', () => {
                         change: TextDocumentSyncKind.Incremental,
                     },
                     completionProvider: { resolveProvider: true },
-                    hoverProvider: true,
                 },
                 extraField: 'extraValue',
             }
@@ -168,7 +163,6 @@ describe('LspRouter', () => {
                         change: TextDocumentSyncKind.Incremental,
                     },
                     completionProvider: { resolveProvider: true },
-                    hoverProvider: true,
                 },
             }
 

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -39,7 +39,6 @@ export class LspRouter {
                     openClose: true,
                     change: TextDocumentSyncKind.Incremental,
                 },
-                hoverProvider: true,
             },
         }
 

--- a/runtimes/runtimes/lsp/textDocuments/textDocumentConnection.test.ts
+++ b/runtimes/runtimes/lsp/textDocuments/textDocumentConnection.test.ts
@@ -144,7 +144,7 @@ describe('TextDocumentConnection', () => {
         })
     })
 
-    describe('onWillSaeTextDocumentWaitUntil', () => {
+    describe('onWillSaveTextDocumentWaitUntil', () => {
         it('supports only last handler', () => {
             const connection = observe(testConnection)
             connection.callbacks.onWillSaveTextDocumentWaitUntil(p => {


### PR DESCRIPTION
## Problem
`hoverProvider` in server initialization response is always set to true. Hover is not handled by runtime directly, and instead should be set by injected capabilities servers at runtime time.

## Solution

Remove hardcoded `hoverProvider` in `InitializeResult` response sent from runtime during connection handshake.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
