### PR TITLE
Release/0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1908,7 +1908,7 @@
         },
         "runtimes": {
             "name": "@aws/language-server-runtimes",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "0.0.1",
@@ -1945,7 +1945,6 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "vscode-languageserver-protocol": "^3.17.5",
                 "vscode-languageserver-textdocument": "^1.0.11",
                 "vscode-languageserver-types": "^3.17.5"
             }

--- a/runtimes/CHANGELOG.md
+++ b/runtimes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.3] - 2024-04-24
+
+- Added support for `didChangeWorkspaceFolders` notification to LSP feature
+- Migrated away type definitons to new `@aws/language-server-runtimes-types` package
+- Remove hardcoded `hoverProvider` from runtimes during connection handshake
+
 ## [0.2.2] - 2024-04-16
 
 - Fixed Auth feature: allowed params by-name and by-position

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",
@@ -24,7 +24,7 @@
         "compile": "tsc --build",
         "fix:prettier": "prettier . --write",
         "prepare": "husky install",
-        "prepub:copyFiles": "cp ../.npmignore ../CHANGELOG.md ../LICENSE ../NOTICE ../README.md ../SECURITY.md package.json out/",
+        "prepub:copyFiles": "cp ../.npmignore CHANGELOG.md ../LICENSE ../NOTICE README.md ../SECURITY.md package.json out/",
         "prepub": "npm run clean && npm run test && npm run compile && npm run prepub:copyFiles",
         "pub": "cd out && npm publish",
         "test:prettier": "prettier . --check",

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.0.1] - 2024-04-24
+
+- Initial release containing type definitions migrated from `@aws/language-server-runtimes` package

--- a/types/package.json
+++ b/types/package.json
@@ -4,7 +4,11 @@
     "description": "Type definitions in Language Servers and Runtimes for AWS",
     "main": "out/index.js",
     "scripts": {
-        "compile": "tsc --build"
+        "clean": "rm -rf out/",
+        "compile": "tsc --build",
+        "prepub:copyFiles": "cp ../.npmignore CHANGELOG.md ../LICENSE ../NOTICE README.md ../SECURITY.md package.json out/",
+        "prepub": "npm run clean && npm run compile && npm run prepub:copyFiles",
+        "pub": "cd out && npm publish"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Description
Release new version 0.2.3 of `@aws/language-server-runtimes` 
Release new package 0.0.1 of `@aws/language-server-runtimes-types` 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
