### PR TITLE
Position in chat

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,6 +1,5 @@
 // Chat Data Model
-
-import { PartialResultParams } from './lsp'
+import { Position, Range, TextDocumentIdentifier } from './lsp'
 
 export interface ChatItemAction {
     pillText: string
@@ -46,11 +45,18 @@ export interface FeedbackPayload {
 
 export type CodeSelectionType = 'selection' | 'block'
 
+export type CursorState = { position: Position } | { range: Range }
+
 // LSP Types
+interface PartialResultParams {
+    partialResultToken?: number | string
+}
 
 export interface ChatParams extends PartialResultParams {
     tabId: string
     prompt: ChatPrompt
+    cursorState?: CursorState[]
+    textDocument?: TextDocumentIdentifier
 }
 export interface ChatResult {
     body?: string
@@ -74,6 +80,8 @@ export interface QuickActionParams extends PartialResultParams {
     tabId: string
     quickAction: string
     prompt?: string
+    cursorState?: CursorState[]
+    textDocument?: TextDocumentIdentifier
 }
 
 // Currently the QuickAction result and ChatResult share the same shape

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,5 +1,7 @@
 // Chat Data Model
 
+import { PartialResultParams } from './lsp'
+
 export interface ChatItemAction {
     pillText: string
     prompt?: string
@@ -46,7 +48,7 @@ export type CodeSelectionType = 'selection' | 'block'
 
 // LSP Types
 
-export interface ChatParams {
+export interface ChatParams extends PartialResultParams {
     tabId: string
     prompt: ChatPrompt
 }
@@ -68,7 +70,7 @@ export interface ChatResult {
 export type EndChatParams = { tabId: string }
 export type EndChatResult = boolean
 
-export interface QuickActionParams {
+export interface QuickActionParams extends PartialResultParams {
     tabId: string
     quickAction: string
     prompt?: string

--- a/types/lsp.ts
+++ b/types/lsp.ts
@@ -1,3 +1,11 @@
 export type { TextDocument } from 'vscode-languageserver-textdocument'
 
 export * from 'vscode-languageserver-types'
+
+export interface PartialResultParams {
+    /**
+     * An optional token that a server can use to report partial results (e.g.
+     * streaming) to the client.
+     */
+    partialResultToken?: number | string
+}

--- a/types/lsp.ts
+++ b/types/lsp.ts
@@ -1,11 +1,3 @@
 export type { TextDocument } from 'vscode-languageserver-textdocument'
 
 export * from 'vscode-languageserver-types'
-
-export interface PartialResultParams {
-    /**
-     * An optional token that a server can use to report partial results (e.g.
-     * streaming) to the client.
-     */
-    partialResultToken?: number | string
-}


### PR DESCRIPTION
## Description

This PR makes 2 extensions to chat and quick action requests:
1. Adds optional partialResultToken to the request params to allow partial progress reporting
2. Adds optional cursorState field to the request params to allow clients to send cursor position or selection range details along with chat requests as additional context 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
