### PR TITLE
Fix main entry for types package

### DIFF
--- a/types/package.json
+++ b/types/package.json
@@ -2,7 +2,7 @@
     "name": "@aws/language-server-runtimes-types",
     "version": "0.0.1",
     "description": "Type definitions in Language Servers and Runtimes for AWS",
-    "main": "out/index.js",
+    "main": "index.js",
     "scripts": {
         "clean": "rm -rf out/",
         "compile": "tsc --build",


### PR DESCRIPTION
## Problem
"main" entry points to `out/` folder which is not included in the npm package structure when published, thus any programs that uses it (ex. vite) results in failed builds

## Solution
Update main entry to default `index.js`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
