### PR TITLE
Create new subpackage for chat client ui types

### DIFF
--- a/chat-client-ui-types/CHANGELOG.md
+++ b/chat-client-ui-types/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.0.1] - 2024-05-07
+
+- Initial release containing type definitions

--- a/chat-client-ui-types/README.md
+++ b/chat-client-ui-types/README.md
@@ -1,0 +1,7 @@
+# Chat Client UI Types
+
+TODO
+
+## License
+
+This project is licensed under the Apache-2.0 License.

--- a/chat-client-ui-types/index.ts
+++ b/chat-client-ui-types/index.ts
@@ -1,0 +1,1 @@
+export * from './uiContracts'

--- a/chat-client-ui-types/package.json
+++ b/chat-client-ui-types/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@aws/chat-client-ui-types",
+    "version": "0.0.1",
+    "description": "Type definitions for Chat UIs in Language Servers and Runtimes for AWS",
+    "main": "index.js",
+    "scripts": {
+        "clean": "rm -rf out/",
+        "compile": "tsc --build",
+        "prepub:copyFiles": "cp ../.npmignore CHANGELOG.md ../LICENSE ../NOTICE README.md ../SECURITY.md package.json out/",
+        "prepub": "npm run clean && npm run compile && npm run prepub:copyFiles",
+        "pub": "cd out && npm publish"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/aws/language-server-runtimes",
+        "directory": "chat-client-ui-types"
+    },
+    "author": "Amazon Web Services",
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@aws/language-server-runtimes-types": "^0.0.2"
+    }
+}

--- a/chat-client-ui-types/tsconfig.json
+++ b/chat-client-ui-types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "outDir": "./out"
+    }
+}

--- a/chat-client-ui-types/uiContracts.ts
+++ b/chat-client-ui-types/uiContracts.ts
@@ -1,0 +1,102 @@
+import { ReferenceTrackerInformation, CodeSelectionType } from '@aws/language-server-runtimes-types'
+
+export type AuthFollowUpType = 'full-auth' | 're-auth' | 'missing_scopes' | 'use-supported-auth'
+export function isValidAuthFollowUpType(value: string): value is AuthFollowUpType {
+    return ['full-auth', 're-auth', 'missing_scopes', 'use-supported-auth'].includes(value)
+}
+
+export type GenericCommandVerb = 'Explain' | 'Refactor' | 'Fix' | 'Optimize'
+
+export const TAB_ID_RECEIVED = 'triggerTabIdReceived'
+export const SEND_TO_PROMPT = 'sendToPrompt'
+export const ERROR_MESSAGE = 'errorMessage'
+export const INSERT_TO_CURSOR_POSITION = 'insertToCursorPosition'
+export const AUTH_FOLLOW_UP_CLICKED = 'authFollowUpClicked'
+export const GENERIC_COMMAND = 'genericCommand'
+
+export type UiMessageCommand =
+    | typeof TAB_ID_RECEIVED
+    | typeof SEND_TO_PROMPT
+    | typeof ERROR_MESSAGE
+    | typeof INSERT_TO_CURSOR_POSITION
+    | typeof AUTH_FOLLOW_UP_CLICKED
+    | typeof GENERIC_COMMAND
+
+export interface UiMessage {
+    command: UiMessageCommand
+    params?: UiMessageParams
+}
+
+export type UiMessageParams = TabIdReceivedParams | InsertToCursorPositionParams | AuthFollowUpClickedParams
+
+export interface TabIdReceivedParams {
+    eventId: string
+    tabId: string
+}
+
+export interface TabIdReceivedMessage {
+    command: typeof TAB_ID_RECEIVED
+    params: TabIdReceivedParams
+}
+
+export interface SendToPromptParams {
+    selection: string
+    eventId: string
+}
+
+export interface SendToPromptMessage {
+    command: typeof SEND_TO_PROMPT
+    params: SendToPromptParams
+}
+
+export interface InsertToCursorPositionParams {
+    tabId: string
+    messageId: string
+    code?: string
+    type?: CodeSelectionType
+    referenceTrackerInformation?: ReferenceTrackerInformation[]
+    eventId?: string
+    codeBlockIndex?: number
+    totalCodeBlocks?: number
+}
+
+export interface InsertToCursorPositionMessage {
+    command: typeof INSERT_TO_CURSOR_POSITION
+    params: InsertToCursorPositionParams
+}
+
+export interface AuthFollowUpClickedParams {
+    tabId: string
+    messageId: string
+    eventId?: string
+    authFollowupType: AuthFollowUpType
+}
+
+export interface AuthFollowUpClickedMessage {
+    command: typeof AUTH_FOLLOW_UP_CLICKED
+    params: AuthFollowUpClickedParams
+}
+
+export interface GenericCommandParams {
+    tabId: string
+    selection: string
+    eventId?: string
+    genericCommand: GenericCommandVerb
+}
+
+export interface GenericCommandMessage {
+    command: typeof GENERIC_COMMAND
+    params: GenericCommandParams
+}
+
+export interface ErrorParams {
+    tabId: string
+    eventId?: string
+    message: string
+    title: string
+}
+
+export interface ErrorMessage {
+    command: typeof ERROR_MESSAGE
+    params: ErrorParams
+}

--- a/chat-client-ui-types/uiContracts.ts
+++ b/chat-client-ui-types/uiContracts.ts
@@ -1,4 +1,5 @@
-import { ReferenceTrackerInformation, CodeSelectionType } from '@aws/language-server-runtimes-types'
+import { InsertToCursorPositionParams } from '@aws/language-server-runtimes-types'
+export { InsertToCursorPositionParams } from '@aws/language-server-runtimes-types'
 
 export type AuthFollowUpType = 'full-auth' | 're-auth' | 'missing_scopes' | 'use-supported-auth'
 export function isValidAuthFollowUpType(value: string): value is AuthFollowUpType {
@@ -47,17 +48,6 @@ export interface SendToPromptParams {
 export interface SendToPromptMessage {
     command: typeof SEND_TO_PROMPT
     params: SendToPromptParams
-}
-
-export interface InsertToCursorPositionParams {
-    tabId: string
-    messageId: string
-    code?: string
-    type?: CodeSelectionType
-    referenceTrackerInformation?: ReferenceTrackerInformation[]
-    eventId?: string
-    codeBlockIndex?: number
-    totalCodeBlocks?: number
 }
 
 export interface InsertToCursorPositionMessage {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     ],
     "workspaces": [
         "types",
-        "runtimes"
+        "runtimes",
+        "chat-client-ui-types"
     ],
     "repository": {
         "type": "git",

--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -1,7 +1,6 @@
 import {
     ChatParams,
     ChatResult,
-    CopyCodeToClipboardParams,
     EndChatParams,
     EndChatResult,
     FeedbackParams,
@@ -14,7 +13,6 @@ import {
     TabAddParams,
     TabChangeParams,
     TabRemoveParams,
-    VoteParams,
     ProtocolNotificationType,
     ProtocolRequestType,
     ProgressToken,
@@ -38,8 +36,6 @@ export const quickActionRequestType = new ProtocolRequestType<QuickActionParams,
 
 export const readyNotificationType = new ProtocolNotificationType<void, void>('aws/chat/ready')
 
-export const voteNotificationType = new ProtocolNotificationType<VoteParams, void>('aws/chat/vote')
-
 export const feedbackNotificationType = new ProtocolNotificationType<FeedbackParams, void>('aws/chat/feedback')
 
 export const tabAddNotificationType = new ProtocolNotificationType<TabAddParams, void>('aws/chat/tabAdd')
@@ -51,11 +47,6 @@ export const tabRemoveNotificationType = new ProtocolNotificationType<TabRemoveP
 export const insertToCursorPositionNotificationType = new ProtocolNotificationType<InsertToCursorPositionParams, void>(
     'aws/chat/insertToCursorPosition'
 )
-
-export const copyCodeToClipboardNotificationType = new ProtocolNotificationType<CopyCodeToClipboardParams, void>(
-    'aws/chat/copyCodeToClipboard'
-)
-
 export const linkClickNotificationType = new ProtocolNotificationType<LinkClickParams, void>('aws/chat/linkClick')
 
 export const infoLinkClickNotificationType = new ProtocolNotificationType<InfoLinkClickParams, void>(

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -12,7 +12,6 @@ import {
 
     // Chat protocol
     chatRequestType,
-    copyCodeToClipboardNotificationType,
     endChatRequestType,
     feedbackNotificationType,
     followUpClickNotificationType,
@@ -25,7 +24,6 @@ import {
     tabAddNotificationType,
     tabChangeNotificationType,
     tabRemoveNotificationType,
-    voteNotificationType,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -182,11 +180,8 @@ export const standalone = (props: RuntimeProps) => {
             onTabAdd: handler => lspConnection.onNotification(tabAddNotificationType.method, handler),
             onTabChange: handler => lspConnection.onNotification(tabChangeNotificationType.method, handler),
             onTabRemove: handler => lspConnection.onNotification(tabRemoveNotificationType.method, handler),
-            onVote: handler => lspConnection.onNotification(voteNotificationType.method, handler),
             onCodeInsertToCursorPosition: handler =>
                 lspConnection.onNotification(insertToCursorPositionNotificationType.method, handler),
-            onCopyCodeToClipboard: handler =>
-                lspConnection.onNotification(copyCodeToClipboardNotificationType.method, handler),
             onLinkClick: handler => lspConnection.onNotification(linkClickNotificationType.method, handler),
             onInfoLinkClick: handler => lspConnection.onNotification(infoLinkClickNotificationType.method, handler),
             onSourceLinkClick: handler => lspConnection.onNotification(sourceLinkClickNotificationType.method, handler),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -18,10 +18,8 @@ import {
     sourceLinkClickNotificationType,
     infoLinkClickNotificationType,
     linkClickNotificationType,
-    copyCodeToClipboardNotificationType,
     insertToCursorPositionNotificationType,
     feedbackNotificationType,
-    voteNotificationType,
     readyNotificationType,
     tabChangeNotificationType,
     tabAddNotificationType,
@@ -85,11 +83,8 @@ export const webworker = (props: RuntimeProps) => {
         onTabAdd: handler => lspConnection.onNotification(tabAddNotificationType.method, handler),
         onTabChange: handler => lspConnection.onNotification(tabChangeNotificationType.method, handler),
         onTabRemove: handler => lspConnection.onNotification(tabRemoveNotificationType.method, handler),
-        onVote: handler => lspConnection.onNotification(voteNotificationType.method, handler),
         onCodeInsertToCursorPosition: handler =>
             lspConnection.onNotification(insertToCursorPositionNotificationType.method, handler),
-        onCopyCodeToClipboard: handler =>
-            lspConnection.onNotification(copyCodeToClipboardNotificationType.method, handler),
         onLinkClick: handler => lspConnection.onNotification(linkClickNotificationType.method, handler),
         onInfoLinkClick: handler => lspConnection.onNotification(infoLinkClickNotificationType.method, handler),
         onSourceLinkClick: handler => lspConnection.onNotification(sourceLinkClickNotificationType.method, handler),

--- a/runtimes/server-interface/chat.ts
+++ b/runtimes/server-interface/chat.ts
@@ -3,7 +3,6 @@ import {
     RequestHandler,
     ChatParams,
     ChatResult,
-    CopyCodeToClipboardParams,
     EndChatParams,
     EndChatResult,
     FeedbackParams,
@@ -17,7 +16,6 @@ import {
     TabChangeParams,
     TabAddParams,
     TabRemoveParams,
-    VoteParams,
 } from '../protocol'
 
 /**
@@ -34,9 +32,7 @@ export type Chat = {
     onTabAdd: (handler: NotificationHandler<TabAddParams>) => void
     onTabChange: (handler: NotificationHandler<TabChangeParams>) => void
     onTabRemove: (handler: NotificationHandler<TabRemoveParams>) => void
-    onVote: (handler: NotificationHandler<VoteParams>) => void
     onCodeInsertToCursorPosition: (handler: NotificationHandler<InsertToCursorPositionParams>) => void
-    onCopyCodeToClipboard: (handler: NotificationHandler<CopyCodeToClipboardParams>) => void
     onLinkClick: (handler: NotificationHandler<LinkClickParams>) => void
     onInfoLinkClick: (handler: NotificationHandler<InfoLinkClickParams>) => void
     onSourceLinkClick: (handler: NotificationHandler<SourceLinkClickParams>) => void

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -31,11 +31,6 @@ export interface ChatPrompt {
     command?: string
 }
 
-export enum VoteType {
-    UP = 'upvote',
-    DOWN = 'downvote',
-}
-
 export interface FeedbackPayload {
     messageId: string
     tabId: string
@@ -87,12 +82,6 @@ export interface QuickActionParams extends PartialResultParams {
 // Currently the QuickAction result and ChatResult share the same shape
 export interface QuickActionResult extends ChatResult {}
 
-export interface VoteParams {
-    tabId: string
-    messageId: string
-    vote: VoteType
-}
-
 export interface FeedbackParams {
     tabId: string
     messageId: string
@@ -115,11 +104,10 @@ export interface InsertToCursorPositionParams {
     code?: string
     type?: CodeSelectionType
     referenceTrackerInformation?: ReferenceTrackerInformation[]
+    eventId?: string
+    codeBlockIndex?: number
+    totalCodeBlocks?: number
 }
-
-// Currently CopyCodeToClipboardParams and InsertToCursorPositionParams have the same shape
-// Exporting the two interfaces separately makes future interface changes easier
-export interface CopyCodeToClipboardParams extends InsertToCursorPositionParams {}
 
 export interface LinkClickParams {
     tabId: string


### PR DESCRIPTION
## Description

Creating a new package for defining chat client ui contracts between `chat client <-> ide extension` and `ide extension <-> chat server` These types will be consumed by chat clients defined in `aws/language-servers` 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
