### PR TITLE
bump chat-ui-types minor version to 0.0.2

### DIFF
--- a/chat-client-ui-types/package.json
+++ b/chat-client-ui-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/chat-client-ui-types",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Type definitions for Chat UIs in Language Servers and Runtimes for AWS",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Problem
Updated the release in npm because the first version had wrong file structure

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
