### PR TITLE
Bump runtimes to version 0.2.4

### DIFF
--- a/runtimes/CHANGELOG.md
+++ b/runtimes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.4] - 2024-05-10
+
+- Remove `onCopyCodeToClipboard` and `onVote` events from chat interface
+
 ## [0.2.3] - 2024-04-24
 
 - Added support for `didChangeWorkspaceFolders` notification to LSP feature

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",


### PR DESCRIPTION
## Problem
Bump runtimes to version 0.2.4

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
