### PR TITLE
Telemetry endpoint in protocol

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -1,22 +1,9 @@
-import {
-    CodeSelectionType,
-    InsertToCursorPositionParams,
-    ReferenceTrackerInformation,
-} from '@aws/language-server-runtimes-types'
-export {
-    CodeSelectionType,
-    InsertToCursorPositionParams,
-    ReferenceTrackerInformation,
-} from '@aws/language-server-runtimes-types'
+import { InsertToCursorPositionParams } from '@aws/language-server-runtimes-types'
+export { InsertToCursorPositionParams } from '@aws/language-server-runtimes-types'
 
 export type AuthFollowUpType = 'full-auth' | 're-auth' | 'missing_scopes' | 'use-supported-auth'
 export function isValidAuthFollowUpType(value: string): value is AuthFollowUpType {
     return ['full-auth', 're-auth', 'missing_scopes', 'use-supported-auth'].includes(value)
-}
-
-export enum RelevancyVoteType {
-    UP = 'upvote',
-    DOWN = 'downvote',
 }
 
 export type GenericCommandVerb = 'Explain' | 'Refactor' | 'Fix' | 'Optimize'
@@ -78,24 +65,6 @@ export interface AuthFollowUpClickedParams {
 export interface AuthFollowUpClickedMessage {
     command: typeof AUTH_FOLLOW_UP_CLICKED
     params: AuthFollowUpClickedParams
-}
-
-export interface CopyCodeToClipboardParams {
-    tabId: string
-    messageId: string
-    code?: string
-    type?: CodeSelectionType
-    referenceTrackerInformation?: ReferenceTrackerInformation[]
-    eventId: string
-    codeBlockIndex?: number
-    totalCodeBlocks?: number
-}
-
-export interface VoteParams {
-    tabId: string
-    messageId: string
-    vote: RelevancyVoteType
-    eventId?: string
 }
 
 export interface GenericCommandParams {

--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -1,5 +1,13 @@
-import { CodeSelectionType, InsertToCursorPositionParams, ReferenceTrackerInformation } from '@aws/language-server-runtimes-types'
-export { CodeSelectionType, InsertToCursorPositionParams, ReferenceTrackerInformation } from '@aws/language-server-runtimes-types'
+import {
+    CodeSelectionType,
+    InsertToCursorPositionParams,
+    ReferenceTrackerInformation,
+} from '@aws/language-server-runtimes-types'
+export {
+    CodeSelectionType,
+    InsertToCursorPositionParams,
+    ReferenceTrackerInformation,
+} from '@aws/language-server-runtimes-types'
 
 export type AuthFollowUpType = 'full-auth' | 're-auth' | 'missing_scopes' | 'use-supported-auth'
 export function isValidAuthFollowUpType(value: string): value is AuthFollowUpType {
@@ -8,7 +16,7 @@ export function isValidAuthFollowUpType(value: string): value is AuthFollowUpTyp
 
 export enum RelevancyVoteType {
     UP = 'upvote',
-    DOWN = 'downvote'
+    DOWN = 'downvote',
 }
 
 export type GenericCommandVerb = 'Explain' | 'Refactor' | 'Fix' | 'Optimize'
@@ -73,20 +81,20 @@ export interface AuthFollowUpClickedMessage {
 }
 
 export interface CopyCodeToClipboardParams {
-    tabId: string,
-    messageId: string,
-    code?: string,
-    type?: CodeSelectionType,
-    referenceTrackerInformation?: ReferenceTrackerInformation[],
-    eventId:string,
-    codeBlockIndex?: number,
+    tabId: string
+    messageId: string
+    code?: string
+    type?: CodeSelectionType
+    referenceTrackerInformation?: ReferenceTrackerInformation[]
+    eventId: string
+    codeBlockIndex?: number
     totalCodeBlocks?: number
 }
 
 export interface VoteParams {
-    tabId: string,
-    messageId: string,
-    vote: RelevancyVoteType,
+    tabId: string
+    messageId: string
+    vote: RelevancyVoteType
     eventId?: string
 }
 

--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -1,9 +1,14 @@
-import { InsertToCursorPositionParams } from '@aws/language-server-runtimes-types'
-export { InsertToCursorPositionParams } from '@aws/language-server-runtimes-types'
+import { CodeSelectionType, InsertToCursorPositionParams, ReferenceTrackerInformation } from '@aws/language-server-runtimes-types'
+export { CodeSelectionType, InsertToCursorPositionParams, ReferenceTrackerInformation } from '@aws/language-server-runtimes-types'
 
 export type AuthFollowUpType = 'full-auth' | 're-auth' | 'missing_scopes' | 'use-supported-auth'
 export function isValidAuthFollowUpType(value: string): value is AuthFollowUpType {
     return ['full-auth', 're-auth', 'missing_scopes', 'use-supported-auth'].includes(value)
+}
+
+export enum RelevancyVoteType {
+    UP = 'upvote',
+    DOWN = 'downvote'
 }
 
 export type GenericCommandVerb = 'Explain' | 'Refactor' | 'Fix' | 'Optimize'
@@ -65,6 +70,24 @@ export interface AuthFollowUpClickedParams {
 export interface AuthFollowUpClickedMessage {
     command: typeof AUTH_FOLLOW_UP_CLICKED
     params: AuthFollowUpClickedParams
+}
+
+export interface CopyCodeToClipboardParams {
+    tabId: string,
+    messageId: string,
+    code?: string,
+    type?: CodeSelectionType,
+    referenceTrackerInformation?: ReferenceTrackerInformation[],
+    eventId:string,
+    codeBlockIndex?: number,
+    totalCodeBlocks?: number
+}
+
+export interface VoteParams {
+    tabId: string,
+    messageId: string,
+    vote: RelevancyVoteType,
+    eventId?: string
 }
 
 export interface GenericCommandParams {

--- a/runtimes/protocol/index.ts
+++ b/runtimes/protocol/index.ts
@@ -1,3 +1,4 @@
 export * from './lsp'
 export * from './auth'
 export * from './chat'
+export * from './telemetry'

--- a/runtimes/protocol/telemetry.ts
+++ b/runtimes/protocol/telemetry.ts
@@ -1,0 +1,3 @@
+import { TelemetryEventNotification } from './lsp'
+
+export const telemetryNotificationType = TelemetryEventNotification.type

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -9,6 +9,7 @@ import {
     logInlineCompletionSessionResultsNotificationType,
     inlineCompletionRequestType,
     TextDocument,
+    telemetryNotificationType,
 
     // Chat protocol
     chatRequestType,
@@ -121,6 +122,7 @@ export const standalone = (props: RuntimeProps) => {
         // Set up telemetry over LSP
         const telemetry: Telemetry = {
             emitMetric: metric => lspConnection.telemetry.logEvent(metric),
+            onClientTelemetry: handler => lspConnection.onRequest(telemetryNotificationType.method, handler),
         }
 
         // Set up the workspace sync to use the LSP Text Document Sync capability

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -122,7 +122,7 @@ export const standalone = (props: RuntimeProps) => {
         // Set up telemetry over LSP
         const telemetry: Telemetry = {
             emitMetric: metric => lspConnection.telemetry.logEvent(metric),
-            onClientTelemetry: handler => lspConnection.onRequest(telemetryNotificationType.method, handler),
+            onClientTelemetry: handler => lspConnection.onNotification(telemetryNotificationType.method, handler),
         }
 
         // Set up the workspace sync to use the LSP Text Document Sync capability

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -9,6 +9,7 @@ import {
     logInlineCompletionSessionResultsNotificationType,
     inlineCompletionRequestType,
     TextDocument,
+    telemetryNotificationType,
 
     // Chat protocol
     chatRequestType,
@@ -55,6 +56,7 @@ export const webworker = (props: RuntimeProps) => {
     // Set up telemetry over LSP
     const telemetry: Telemetry = {
         emitMetric: metric => lspConnection.telemetry.logEvent(metric),
+        onClientTelemetry: handler => lspConnection.onNotification(telemetryNotificationType.method, handler),
     }
 
     // Set up the workspace to use the LSP Text Documents component

--- a/runtimes/server-interface/telemetry.ts
+++ b/runtimes/server-interface/telemetry.ts
@@ -1,4 +1,4 @@
-import { NotificationHandler } from "vscode-languageserver-protocol"
+import { NotificationHandler } from 'vscode-languageserver-protocol'
 
 export type Metric = {
     name: string
@@ -27,6 +27,6 @@ type ErrorData = {
  */
 export type Telemetry = {
     emitMetric: (metric: MetricEvent) => void
-    // Handles telemetry events sent from clients 
+    // Handles telemetry events sent from clients
     onClientTelemetry: (handler: NotificationHandler<any>) => void
 }

--- a/runtimes/server-interface/telemetry.ts
+++ b/runtimes/server-interface/telemetry.ts
@@ -1,3 +1,5 @@
+import { NotificationHandler } from "vscode-languageserver-protocol"
+
 export type Metric = {
     name: string
 }
@@ -25,4 +27,6 @@ type ErrorData = {
  */
 export type Telemetry = {
     emitMetric: (metric: MetricEvent) => void
+    // Handles telemetry events sent from clients 
+    onClientTelemetry: (handler: NotificationHandler<any>) => void
 }


### PR DESCRIPTION
## Problem
Telemetry endpoint in the protocol is not yet exposed

## Solution
Enable endpoint in telemetry feature to enable clients sending telemetry to server

Also added additional UI chat contracts for copyCodeToClipboard and vote events 

This PR supports implementation in https://github.com/aws/language-servers/pull/249

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
