### PR TITLE
Fix tsconfig rootdir for chat ui types

### DIFF
--- a/chat-client-ui-types/tsconfig.json
+++ b/chat-client-ui-types/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "extends": "../tsconfig.packages.json",
     "compilerOptions": {
-        "rootDir": ".",
-        "outDir": "./out"
+        "rootDir": "./src",
+        "outDir": "./out",
+        "tsBuildInfoFile": "./out/tsconfig.tsbuildinfo"
     }
 }


### PR DESCRIPTION
## Description

Followup to https://github.com/aws/language-server-runtimes/pull/114, making tsconfig `rootDir` point to the `src` directory and not the root.

As per, https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile, since we are now setting both outDir and rootDir, the `tsconfig.tsbuildinfo` file gets generated in the root instead of in the outDir. I set the `tsbuildinfo` field in tsconfig to make sure the file continues to be generated into the out directory

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
