### PR TITLE
Make optional fields inside recommendationContentSpan mandatory

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -19,8 +19,8 @@ export interface ReferenceTrackerInformation {
     repository?: string
     url?: string
     recommendationContentSpan?: {
-        start?: number
-        end?: number
+        start: number
+        end: number
     }
     information: string
 }


### PR DESCRIPTION
## Problem
The `recommendationContentSpan` field is optional but the fields inside it shouldn't be. This PR fixes it

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
