### PR TITLE
Add missing field in ChatItemAction and adjust link params fields

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -6,6 +6,7 @@ export interface ChatItemAction {
     prompt?: string
     disabled?: boolean
     description?: string
+    type?: string
 }
 
 export interface SourceLink {
@@ -84,8 +85,8 @@ export interface QuickActionResult extends ChatResult {}
 
 export interface FeedbackParams {
     tabId: string
-    messageId: string
     feedbackPayload: FeedbackPayload
+    eventId?: string
 }
 
 export interface TabEventParams {
@@ -109,15 +110,18 @@ export interface InsertToCursorPositionParams {
     totalCodeBlocks?: number
 }
 
-export interface LinkClickParams {
+export interface InfoLinkClickParams {
     tabId: string
-    messageId: string
     link: string
-    mouseEvent?: MouseEvent
+    eventId?: string
 }
-export interface InfoLinkClickParams extends LinkClickParams {}
+export interface LinkClickParams extends InfoLinkClickParams {
+    messageId: string
+}
 
-export interface SourceLinkClickParams extends LinkClickParams {}
+export interface SourceLinkClickParams extends InfoLinkClickParams {
+    messageId: string
+}
 
 export interface FollowUpClickParams {
     tabId: string


### PR DESCRIPTION
## Problem
ChatItemAction is missing optional `type` field (needed for auth follow-ups). 
FeedbackParams is missing optional `eventId` field
InfoLinkClick does not pass `messageId` but is required in it's params

## Solution
Add missing fields and rearrange params for links interface structure

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
