### PR TITLE
Upgrade chat-client-ui-types version to 0.1.0

### DIFF
--- a/chat-client-ui-types/CHANGELOG.md
+++ b/chat-client-ui-types/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.0] - 2024-06-03
+
+- Update package folder structure
+- Consume latest `@aws/language-server-runtimes-types`
+
 ## [0.0.3] - 2024-05-10
 
 - Update `@aws/language-server-runtimes-types` to `0.0.3`

--- a/chat-client-ui-types/package.json
+++ b/chat-client-ui-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/chat-client-ui-types",
-    "version": "0.0.3",
+    "version": "0.1.0",
     "description": "Type definitions for Chat UIs in Language Servers and Runtimes for AWS",
     "main": "/out/index.js",
     "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         },
         "chat-client-ui-types": {
             "name": "@aws/chat-client-ui-types",
-            "version": "0.0.3",
+            "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "0.x.x"


### PR DESCRIPTION
## Problem
We want to use the latest chat-client-ui-types
## Solution
Release a new version

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
