### PR TITLE
Fix main entry typo

### DIFF
--- a/chat-client-ui-types/package.json
+++ b/chat-client-ui-types/package.json
@@ -2,7 +2,7 @@
     "name": "@aws/chat-client-ui-types",
     "version": "0.0.3",
     "description": "Type definitions for Chat UIs in Language Servers and Runtimes for AWS",
-    "main": "/out/index.js",
+    "main": "./out/index.js",
     "scripts": {
         "clean": "rm -rf out/",
         "compile": "tsc --build",


### PR DESCRIPTION
## Problem
Package imports couldn't be used without `/out` in path
## Solution
Fix main entry in package.json
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
