### PR TITLE
Update chat types

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -9,7 +9,7 @@ export function isValidAuthFollowUpType(value: string): value is AuthFollowUpTyp
 export type GenericCommandVerb = 'Explain' | 'Refactor' | 'Fix' | 'Optimize'
 export type TriggerType = 'hotkeys' | 'click' | 'contextMenu'
 
-export const TAB_ID_RECEIVED = 'triggerTabIdReceived'
+export const TRIGGER_TYPE_RECEIVED = 'triggerTypeReceived'
 export const SEND_TO_PROMPT = 'sendToPrompt'
 export const ERROR_MESSAGE = 'errorMessage'
 export const INSERT_TO_CURSOR_POSITION = 'insertToCursorPosition'
@@ -17,7 +17,7 @@ export const AUTH_FOLLOW_UP_CLICKED = 'authFollowUpClicked'
 export const GENERIC_COMMAND = 'genericCommand'
 
 export type UiMessageCommand =
-    | typeof TAB_ID_RECEIVED
+    | typeof TRIGGER_TYPE_RECEIVED
     | typeof SEND_TO_PROMPT
     | typeof ERROR_MESSAGE
     | typeof INSERT_TO_CURSOR_POSITION
@@ -29,16 +29,16 @@ export interface UiMessage {
     params?: UiMessageParams
 }
 
-export type UiMessageParams = TabIdReceivedParams | InsertToCursorPositionParams | AuthFollowUpClickedParams
+export type UiMessageParams = TriggerTypeReceivedParams | InsertToCursorPositionParams | AuthFollowUpClickedParams
 
-export interface TabIdReceivedParams {
+export interface TriggerTypeReceivedParams {
     triggerType: TriggerType
     tabId: string
 }
 
-export interface TabIdReceivedMessage {
-    command: typeof TAB_ID_RECEIVED
-    params: TabIdReceivedParams
+export interface TriggerTypeReceivedMessage {
+    command: typeof TRIGGER_TYPE_RECEIVED
+    params: TriggerTypeReceivedParams
 }
 
 export interface SendToPromptParams {

--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -7,6 +7,7 @@ export function isValidAuthFollowUpType(value: string): value is AuthFollowUpTyp
 }
 
 export type GenericCommandVerb = 'Explain' | 'Refactor' | 'Fix' | 'Optimize'
+export type TriggerType = 'hotkeys' | 'click' | 'contextMenu'
 
 export const TAB_ID_RECEIVED = 'triggerTabIdReceived'
 export const SEND_TO_PROMPT = 'sendToPrompt'
@@ -31,7 +32,7 @@ export interface UiMessage {
 export type UiMessageParams = TabIdReceivedParams | InsertToCursorPositionParams | AuthFollowUpClickedParams
 
 export interface TabIdReceivedParams {
-    eventId: string
+    triggerType: TriggerType
     tabId: string
 }
 
@@ -42,7 +43,7 @@ export interface TabIdReceivedMessage {
 
 export interface SendToPromptParams {
     selection: string
-    eventId: string
+    triggerType: TriggerType
 }
 
 export interface SendToPromptMessage {
@@ -58,7 +59,6 @@ export interface InsertToCursorPositionMessage {
 export interface AuthFollowUpClickedParams {
     tabId: string
     messageId: string
-    eventId?: string
     authFollowupType: AuthFollowUpType
 }
 
@@ -70,7 +70,7 @@ export interface AuthFollowUpClickedMessage {
 export interface GenericCommandParams {
     tabId: string
     selection: string
-    eventId?: string
+    triggerType: TriggerType
     genericCommand: GenericCommandVerb
 }
 
@@ -81,7 +81,7 @@ export interface GenericCommandMessage {
 
 export interface ErrorParams {
     tabId: string
-    eventId?: string
+    triggerType?: TriggerType
     message: string
     title: string
 }

--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -9,7 +9,6 @@ export function isValidAuthFollowUpType(value: string): value is AuthFollowUpTyp
 export type GenericCommandVerb = 'Explain' | 'Refactor' | 'Fix' | 'Optimize'
 export type TriggerType = 'hotkeys' | 'click' | 'contextMenu'
 
-export const TRIGGER_TYPE_RECEIVED = 'triggerTypeReceived'
 export const SEND_TO_PROMPT = 'sendToPrompt'
 export const ERROR_MESSAGE = 'errorMessage'
 export const INSERT_TO_CURSOR_POSITION = 'insertToCursorPosition'
@@ -17,7 +16,6 @@ export const AUTH_FOLLOW_UP_CLICKED = 'authFollowUpClicked'
 export const GENERIC_COMMAND = 'genericCommand'
 
 export type UiMessageCommand =
-    | typeof TRIGGER_TYPE_RECEIVED
     | typeof SEND_TO_PROMPT
     | typeof ERROR_MESSAGE
     | typeof INSERT_TO_CURSOR_POSITION
@@ -30,21 +28,10 @@ export interface UiMessage {
 }
 
 export type UiMessageParams =
-    | TriggerTypeReceivedParams
     | InsertToCursorPositionParams
     | AuthFollowUpClickedParams
     | GenericCommandParams
     | ErrorParams
-
-export interface TriggerTypeReceivedParams {
-    triggerType: TriggerType
-    tabId: string
-}
-
-export interface TriggerTypeReceivedMessage {
-    command: typeof TRIGGER_TYPE_RECEIVED
-    params: TriggerTypeReceivedParams
-}
 
 export interface SendToPromptParams {
     selection: string

--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -29,7 +29,12 @@ export interface UiMessage {
     params?: UiMessageParams
 }
 
-export type UiMessageParams = TriggerTypeReceivedParams | InsertToCursorPositionParams | AuthFollowUpClickedParams
+export type UiMessageParams =
+    | TriggerTypeReceivedParams
+    | InsertToCursorPositionParams
+    | AuthFollowUpClickedParams
+    | GenericCommandParams
+    | ErrorParams
 
 export interface TriggerTypeReceivedParams {
     triggerType: TriggerType


### PR DESCRIPTION
## Problem
The `eventId` name (which was initially `triggerId`)  is confusing, this field will be used to send the information about what triggered the said action. For example send to prompt can be triggered by using a keyboard shortcut or using the context menu. This information will be useful for telemetry done by the server. 

The chat client will use the trigger type and send it to the server through the `telemetry` event, the server will then use this information for telemetry purposes as it will have the information about what kind of an interaction triggered a message/conversation

With this PR I am also removing the `tabidReceived` event since that information will be sent through `telemetry` operation

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
