### PR TITLE
Added custom awsServerCapabilities registration for servers at initialization flow

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ node_modules/
 out/
 **/*.md
 package-lock.json
+.prettierrc
+.vscode

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+    "printWidth": 120,
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "singleQuote": true,
+    "semi": false,
+    "bracketSpacing": true,
+    "arrowParens": "avoid",
+    "endOfLine": "lf"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "typescript.preferences.quoteStyle": "single",
+    "[typescript]": {
+        "editor.insertSpaces": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll.eslint": "explicit",
+            // "source.organizeImports": "explicit",
+            // "source.sortMembers": "explicit"
+        },
+        "editor.formatOnSave": true
+    }
+}

--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -31,7 +31,6 @@ import {
     TAB_REMOVE_NOTIFICATION_METHOD,
 } from './lsp'
 
-
 /**
  * Configuration object for chat quick action.
  */

--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -1,35 +1,63 @@
 import {
+    CHAT_REQUEST_METHOD,
     ChatParams,
     ChatResult,
+    END_CHAT_REQUEST_METHOD,
     EndChatParams,
     EndChatResult,
-    FeedbackParams,
-    FollowUpClickParams,
-    InfoLinkClickParams,
-    InsertToCursorPositionParams,
-    LinkClickParams,
-    QuickActionParams,
-    SourceLinkClickParams,
-    TabAddParams,
-    TabChangeParams,
-    TabRemoveParams,
-    ProtocolNotificationType,
-    ProtocolRequestType,
-    ProgressToken,
-    CHAT_REQUEST_METHOD,
-    END_CHAT_REQUEST_METHOD,
     FEEDBACK_NOTIFICATION_METHOD,
     FOLLOW_UP_CLICK_NOTIFICATION_METHOD,
+    FeedbackParams,
+    FollowUpClickParams,
     INFO_LINK_CLICK_NOTIFICATION_METHOD,
     INSERT_TO_CURSOR_POSITION_NOTIFICATION_METHOD,
+    InfoLinkClickParams,
+    InsertToCursorPositionParams,
     LINK_CLICK_NOTIFICATION_METHOD,
+    LinkClickParams,
+    ProgressToken,
+    ProtocolNotificationType,
+    ProtocolRequestType,
     QUICK_ACTION_REQUEST_METHOD,
+    QuickActionParams,
     READY_NOTIFICATION_METHOD,
     SOURCE_LINK_CLICK_NOTIFICATION_METHOD,
+    SourceLinkClickParams,
     TAB_ADD_NOTIFICATION_METHOD,
     TAB_CHANGE_NOTIFICATION_METHOD,
     TAB_REMOVE_NOTIFICATION_METHOD,
-} from './lsp'
+    TabAddParams,
+    TabChangeParams,
+    TabRemoveParams,
+} from './lsp';
+
+/**
+ * Configuration object for chat quick action.
+ */
+export interface QuickActionCommand {
+    command: string;
+    disabled?: boolean;
+    description?: string;
+    placeholder?: string;
+}
+
+/**
+ * Configuration object for registering chat quick actions groups.
+ */
+export interface QuickActionCommandGroup {
+    groupName?: string;
+    commands: QuickActionCommand[];
+}
+
+/**
+ * Registration options for a Chat QuickActionRequest.
+ */
+export interface QuickActionsOptions {
+    /**
+     * The chat quick actions groupd and commands to be executed on server.
+     */
+    quickActionsCommandGroups: QuickActionCommandGroup[]
+}
 
 export interface ChatRequest extends ChatParams {
     partialResultToken?: ProgressToken

--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -1,52 +1,53 @@
 import {
-    CHAT_REQUEST_METHOD,
     ChatParams,
     ChatResult,
-    END_CHAT_REQUEST_METHOD,
     EndChatParams,
     EndChatResult,
-    FEEDBACK_NOTIFICATION_METHOD,
-    FOLLOW_UP_CLICK_NOTIFICATION_METHOD,
     FeedbackParams,
     FollowUpClickParams,
-    INFO_LINK_CLICK_NOTIFICATION_METHOD,
-    INSERT_TO_CURSOR_POSITION_NOTIFICATION_METHOD,
     InfoLinkClickParams,
     InsertToCursorPositionParams,
-    LINK_CLICK_NOTIFICATION_METHOD,
     LinkClickParams,
-    ProgressToken,
-    ProtocolNotificationType,
-    ProtocolRequestType,
-    QUICK_ACTION_REQUEST_METHOD,
     QuickActionParams,
-    READY_NOTIFICATION_METHOD,
-    SOURCE_LINK_CLICK_NOTIFICATION_METHOD,
     SourceLinkClickParams,
-    TAB_ADD_NOTIFICATION_METHOD,
-    TAB_CHANGE_NOTIFICATION_METHOD,
-    TAB_REMOVE_NOTIFICATION_METHOD,
     TabAddParams,
     TabChangeParams,
     TabRemoveParams,
-} from './lsp';
+    ProtocolNotificationType,
+    ProtocolRequestType,
+    ProgressToken,
+    CHAT_REQUEST_METHOD,
+    END_CHAT_REQUEST_METHOD,
+    FEEDBACK_NOTIFICATION_METHOD,
+    FOLLOW_UP_CLICK_NOTIFICATION_METHOD,
+    INFO_LINK_CLICK_NOTIFICATION_METHOD,
+    INSERT_TO_CURSOR_POSITION_NOTIFICATION_METHOD,
+    LINK_CLICK_NOTIFICATION_METHOD,
+    QUICK_ACTION_REQUEST_METHOD,
+    READY_NOTIFICATION_METHOD,
+    SOURCE_LINK_CLICK_NOTIFICATION_METHOD,
+    TAB_ADD_NOTIFICATION_METHOD,
+    TAB_CHANGE_NOTIFICATION_METHOD,
+    TAB_REMOVE_NOTIFICATION_METHOD,
+} from './lsp'
+
 
 /**
  * Configuration object for chat quick action.
  */
 export interface QuickActionCommand {
-    command: string;
-    disabled?: boolean;
-    description?: string;
-    placeholder?: string;
+    command: string
+    disabled?: boolean
+    description?: string
+    placeholder?: string
 }
 
 /**
  * Configuration object for registering chat quick actions groups.
  */
 export interface QuickActionCommandGroup {
-    groupName?: string;
-    commands: QuickActionCommand[];
+    groupName?: string
+    commands: QuickActionCommand[]
 }
 
 /**

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -1,5 +1,6 @@
-import { ParameterStructures, ProgressType, RegistrationType, RequestType } from 'vscode-languageserver-protocol'
 import { _EM } from 'vscode-jsonrpc'
+import { InitializeResult as InitializeResultBase, ParameterStructures, ProgressType, RegistrationType, RequestType } from 'vscode-languageserver-protocol'
+import { QuickActionsOptions } from './chat'
 
 export * from '@aws/language-server-runtimes-types'
 export { TextDocument } from 'vscode-languageserver-textdocument'
@@ -12,8 +13,8 @@ export { TextDocument } from 'vscode-languageserver-textdocument'
 export * from 'vscode-languageserver-protocol'
 
 // Custom Runtimes LSP extensions
-export * from './inlineCompletions'
 export * from './inlineCompletionWithReferences'
+export * from './inlineCompletions'
 
 // AutoParameterStructuresProtocolRequestType allows ParameterStructures both by-name and by-position
 export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
@@ -30,5 +31,20 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
 
     public constructor(method: string) {
         super(method, ParameterStructures.auto)
+    }
+}
+
+/**
+ * Custom AWS Runtimes InitializeResult object interface with extended options.
+ */
+export interface InitializeResult extends InitializeResultBase {
+    /**
+     * The server signals custom AWS Runtimes capabilities it supports.
+     */
+    awsServerCapabilities?: {
+        /**
+         * The server provides quick actions support.
+         */
+        chatQuickActionsProvider?: QuickActionsOptions
     }
 }

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -1,5 +1,11 @@
 import { _EM } from 'vscode-jsonrpc'
-import { InitializeResult as InitializeResultBase, ParameterStructures, ProgressType, RegistrationType, RequestType } from 'vscode-languageserver-protocol'
+import {
+    InitializeResult as InitializeResultBase,
+    ParameterStructures,
+    ProgressType,
+    RegistrationType,
+    RequestType,
+} from 'vscode-languageserver-protocol'
 import { QuickActionsOptions } from './chat'
 
 export * from '@aws/language-server-runtimes-types'
@@ -33,6 +39,7 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
         super(method, ParameterStructures.auto)
     }
 }
+
 
 /**
  * Custom AWS Runtimes InitializeResult object interface with extended options.

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -40,7 +40,6 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
     }
 }
 
-
 /**
  * Custom AWS Runtimes InitializeResult object interface with extended options.
  */

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -176,6 +176,7 @@ export const standalone = (props: RuntimeProps) => {
         const chat: Chat = {
             onChatPrompt: handler => lspConnection.onRequest(chatRequestType.method, handler),
             onEndChat: handler => lspConnection.onRequest(endChatRequestType, handler),
+            // TODO: consider adding LSP router for quick actions in case multiple servers providing actions
             onQuickAction: handler => lspConnection.onRequest(quickActionRequestType, handler),
             onSendFeedback: handler => lspConnection.onNotification(feedbackNotificationType.method, handler),
             onReady: handler => lspConnection.onNotification(readyNotificationType.method, handler),

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -176,7 +176,6 @@ export const standalone = (props: RuntimeProps) => {
         const chat: Chat = {
             onChatPrompt: handler => lspConnection.onRequest(chatRequestType.method, handler),
             onEndChat: handler => lspConnection.onRequest(endChatRequestType, handler),
-            // TODO: consider adding LSP router for quick actions in case multiple servers providing actions
             onQuickAction: handler => lspConnection.onRequest(quickActionRequestType, handler),
             onSendFeedback: handler => lspConnection.onNotification(feedbackNotificationType.method, handler),
             onReady: handler => lspConnection.onNotification(readyNotificationType.method, handler),

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -28,20 +28,20 @@ import {
     RequestHandler,
     ServerCapabilities,
     TextEdit,
-} from '../protocol';
+} from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
 // This is needed for LSP features as we pass messages down.
-export * from '../protocol/lsp';
+export * from '../protocol/lsp'
 
 export type PartialServerCapabilities<T = any> = Pick<
     ServerCapabilities<T>,
     'completionProvider' | 'hoverProvider' | 'executeCommandProvider'
 >
 export type PartialInitializeResult<T = any> = {
-    capabilities: PartialServerCapabilities<T>,
+    capabilities: PartialServerCapabilities<T>
     awsServerCapabilities?: {
-        chatQuickActionsProvider?: QuickActionsOptions,
+        chatQuickActionsProvider?: QuickActionsOptions
     }
 }
 

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -1,44 +1,48 @@
 import {
     CompletionItem,
     CompletionList,
-    InlineCompletionItem,
     CompletionParams,
     DidChangeConfigurationParams,
     DidChangeTextDocumentParams,
+    DidChangeWorkspaceFoldersParams,
     DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams,
+    DocumentFormattingParams,
     ExecuteCommandParams,
     Hover,
     HoverParams,
     InitializeError,
     InitializeParams,
     InitializedParams,
-    InlineCompletionList,
-    InlineCompletionParams,
-    NotificationHandler,
-    PublishDiagnosticsParams,
-    ServerCapabilities,
+    InlineCompletionItem,
     InlineCompletionItemWithReferences,
+    InlineCompletionList,
     InlineCompletionListWithReferences,
+    InlineCompletionParams,
     LogInlineCompletionSessionResultsParams,
-    RequestHandler,
-    DidOpenTextDocumentParams,
-    DocumentFormattingParams,
-    TextEdit,
-    ProgressType,
+    NotificationHandler,
     ProgressToken,
-    DidChangeWorkspaceFoldersParams,
-} from '../protocol'
+    ProgressType,
+    PublishDiagnosticsParams,
+    QuickActionsOptions,
+    RequestHandler,
+    ServerCapabilities,
+    TextEdit,
+} from '../protocol';
 
 // Re-export whole surface of LSP protocol used in Runtimes.
 // This is needed for LSP features as we pass messages down.
-export * from '../protocol/lsp'
+export * from '../protocol/lsp';
 
 export type PartialServerCapabilities<T = any> = Pick<
     ServerCapabilities<T>,
     'completionProvider' | 'hoverProvider' | 'executeCommandProvider'
 >
 export type PartialInitializeResult<T = any> = {
-    capabilities: PartialServerCapabilities<T>
+    capabilities: PartialServerCapabilities<T>,
+    awsServerCapabilities?: {
+        chatQuickActionsProvider?: QuickActionsOptions,
+    }
 }
 
 // Using `RequestHandler` here from `vscode-languageserver-protocol` which doesn't support partial progress.

--- a/runtimes/tsconfig.json
+++ b/runtimes/tsconfig.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "rootDir": ".",
         "outDir": "./out"
-    }
+    },
+    "exclude": ["./node_modules", "./out"]
 }

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -10,5 +10,5 @@
         "composite": true,
         "esModuleInterop": true
     },
-    "exclude": ["node_modules"]
+    "exclude": ["./node_modules", "./out"]
 }

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "rootDir": ".",
         "outDir": "./out"
-    }
+    },
+    "exclude": ["node_modules", "out"]
 }


### PR DESCRIPTION
## Problem
We want to allow server implementations to register it's supported quick actions for Chat feature, to properly render chat at start time.

## Solution

Extending default LSP `InitializeResult` objects with new backwards-compatible optional `awsServerCapabilities` attribute, scoped with `AWS`. This attribute is used to allow Server implementations to register customer features, defined by Language Servers runtimes protocol. First feature which is added is `chatQuickActionsProvider` for registering Quick Actions in Chat Client implementation (https://github.com/aws/language-servers/tree/main/chat-client).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
