### PR TITLE
Extend server handshake to register chat quick actions

### DIFF
--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -31,6 +31,34 @@ import {
     TAB_REMOVE_NOTIFICATION_METHOD,
 } from './lsp'
 
+/**
+ * Configuration object for chat quick action.
+ */
+export interface QuickActionCommand {
+    command: string
+    disabled?: boolean
+    description?: string
+    placeholder?: string
+}
+
+/**
+ * Configuration object for registering chat quick actions groups.
+ */
+export interface QuickActionCommandGroup {
+    groupName?: string
+    commands: QuickActionCommand[]
+}
+
+/**
+ * Registration options for a Chat QuickActionRequest.
+ */
+export interface QuickActionsOptions {
+    /**
+     * The chat quick actions groupd and commands to be executed on server.
+     */
+    quickActionsCommandGroups: QuickActionCommandGroup[]
+}
+
 export interface ChatRequest extends ChatParams {
     partialResultToken?: ProgressToken
 }

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -1,5 +1,12 @@
-import { ParameterStructures, ProgressType, RegistrationType, RequestType } from 'vscode-languageserver-protocol'
 import { _EM } from 'vscode-jsonrpc'
+import {
+    InitializeResult as InitializeResultBase,
+    ParameterStructures,
+    ProgressType,
+    RegistrationType,
+    RequestType,
+} from 'vscode-languageserver-protocol'
+import { QuickActionsOptions } from './chat'
 
 export * from '@aws/language-server-runtimes-types'
 export { TextDocument } from 'vscode-languageserver-textdocument'
@@ -12,8 +19,8 @@ export { TextDocument } from 'vscode-languageserver-textdocument'
 export * from 'vscode-languageserver-protocol'
 
 // Custom Runtimes LSP extensions
-export * from './inlineCompletions'
 export * from './inlineCompletionWithReferences'
+export * from './inlineCompletions'
 
 // AutoParameterStructuresProtocolRequestType allows ParameterStructures both by-name and by-position
 export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
@@ -30,5 +37,20 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
 
     public constructor(method: string) {
         super(method, ParameterStructures.auto)
+    }
+}
+
+/**
+ * Custom AWS Runtimes InitializeResult object interface with extended options.
+ */
+export interface InitializeResult extends InitializeResultBase {
+    /**
+     * The server signals custom AWS Runtimes capabilities it supports.
+     */
+    awsServerCapabilities?: {
+        /**
+         * The server provides quick actions support.
+         */
+        chatQuickActionsProvider?: QuickActionsOptions
     }
 }

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -1,32 +1,33 @@
 import {
     CompletionItem,
     CompletionList,
-    InlineCompletionItem,
     CompletionParams,
     DidChangeConfigurationParams,
     DidChangeTextDocumentParams,
+    DidChangeWorkspaceFoldersParams,
     DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams,
+    DocumentFormattingParams,
     ExecuteCommandParams,
     Hover,
     HoverParams,
     InitializeError,
     InitializeParams,
     InitializedParams,
-    InlineCompletionList,
-    InlineCompletionParams,
-    NotificationHandler,
-    PublishDiagnosticsParams,
-    ServerCapabilities,
+    InlineCompletionItem,
     InlineCompletionItemWithReferences,
+    InlineCompletionList,
     InlineCompletionListWithReferences,
+    InlineCompletionParams,
     LogInlineCompletionSessionResultsParams,
-    RequestHandler,
-    DidOpenTextDocumentParams,
-    DocumentFormattingParams,
-    TextEdit,
-    ProgressType,
+    NotificationHandler,
     ProgressToken,
-    DidChangeWorkspaceFoldersParams,
+    ProgressType,
+    PublishDiagnosticsParams,
+    QuickActionsOptions,
+    RequestHandler,
+    ServerCapabilities,
+    TextEdit,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -39,6 +40,9 @@ export type PartialServerCapabilities<T = any> = Pick<
 >
 export type PartialInitializeResult<T = any> = {
     capabilities: PartialServerCapabilities<T>
+    awsServerCapabilities?: {
+        chatQuickActionsProvider?: QuickActionsOptions
+    }
 }
 
 // Using `RequestHandler` here from `vscode-languageserver-protocol` which doesn't support partial progress.


### PR DESCRIPTION
Following up on: https://github.com/aws/language-server-runtimes/pull/131, this PR takes only the chat quick action related changes from the other PR. Copying the description from the other PR:

## Problem
We want to allow server implementations to register it's supported quick actions for Chat feature, to properly render chat at start time.

## Solution

Extending default LSP `InitializeResult` objects with new backwards-compatible optional `awsServerCapabilities` attribute, scoped with `AWS`. This attribute is used to allow Server implementations to register customer features, defined by Language Servers runtimes protocol. First feature which is added is `chatQuickActionsProvider` for registering Quick Actions in Chat Client implementation (https://github.com/aws/language-servers/tree/main/chat-client).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


