### PR TITLE
Run npm ci instead of npm install in GitHub actions

### DIFF
--- a/.github/workflows/runtimes-ci.yaml
+++ b/.github/workflows/runtimes-ci.yaml
@@ -18,7 +18,7 @@ jobs:
                   node-version: 20
             - name: Build
               run: |
-                  npm install
+                  npm ci
                   npm run compile
             - name: Test
               run: |


### PR DESCRIPTION
## Problem
Our GitHub actions use `npm install` which means that the resulting dependency tree can be different from what is in a `package-lock.json`.

## Solution
Switched to the `npm ci` which is recommended for automated environments such as GitHub actions
https://docs.npmjs.com/cli/v10/commands/npm-ci


More info: [Why developers should use npm ci instead of npm install and its benefits?](https://support.deploybot.com/article/131-why-developers-should-use-npm-ci-instead-of-npm-install-and-its-benefits)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
