### PR TITLE
Add encryption to chat

### DIFF
--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -15,7 +15,6 @@ import {
     TabRemoveParams,
     ProtocolNotificationType,
     ProtocolRequestType,
-    ProgressToken,
     CHAT_REQUEST_METHOD,
     END_CHAT_REQUEST_METHOD,
     FEEDBACK_NOTIFICATION_METHOD,
@@ -29,6 +28,10 @@ import {
     TAB_ADD_NOTIFICATION_METHOD,
     TAB_CHANGE_NOTIFICATION_METHOD,
     TAB_REMOVE_NOTIFICATION_METHOD,
+    AutoParameterStructuresProtocolRequestType,
+    EncryptedChatParams,
+    EncryptedQuickActionParams,
+    QuickActionResult,
 } from './lsp'
 
 /**
@@ -59,19 +62,23 @@ export interface QuickActionsOptions {
     quickActionsCommandGroups: QuickActionCommandGroup[]
 }
 
-export interface ChatRequest extends ChatParams {
-    partialResultToken?: ProgressToken
-}
-
-export const chatRequestType = new ProtocolRequestType<ChatRequest, ChatResult, ChatResult, void, void>(
-    CHAT_REQUEST_METHOD
-)
+export const chatRequestType = new AutoParameterStructuresProtocolRequestType<
+    ChatParams | EncryptedChatParams,
+    ChatResult | string,
+    ChatResult | string,
+    void,
+    void
+>(CHAT_REQUEST_METHOD)
 export const endChatRequestType = new ProtocolRequestType<EndChatParams, EndChatResult, never, void, void>(
     END_CHAT_REQUEST_METHOD
 )
-export const quickActionRequestType = new ProtocolRequestType<QuickActionParams, ChatResult, ChatResult, void, void>(
-    QUICK_ACTION_REQUEST_METHOD
-)
+export const quickActionRequestType = new AutoParameterStructuresProtocolRequestType<
+    QuickActionParams | EncryptedQuickActionParams,
+    QuickActionResult | string,
+    QuickActionResult | string,
+    void,
+    void
+>(QUICK_ACTION_REQUEST_METHOD)
 export const readyNotificationType = new ProtocolNotificationType<void, void>(READY_NOTIFICATION_METHOD)
 export const feedbackNotificationType = new ProtocolNotificationType<FeedbackParams, void>(FEEDBACK_NOTIFICATION_METHOD)
 export const tabAddNotificationType = new ProtocolNotificationType<TabAddParams, void>(TAB_ADD_NOTIFICATION_METHOD)

--- a/runtimes/runtimes/auth/standalone/encryption.ts
+++ b/runtimes/runtimes/auth/standalone/encryption.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'stream'
+import { CompactEncrypt } from 'jose'
 
 export function shouldWaitForEncryptionKey(): boolean {
     return process.argv.some(arg => arg === '--set-credentials-encryption-key')
@@ -84,4 +85,13 @@ export function readEncryptionDetails(stream: Readable): Promise<EncryptionIniti
 
         stream.on('readable', onStreamIsReadable)
     })
+}
+
+/**
+ * Encrypt an object with the provided key
+ */
+export function encryptObjectWithKey(request: Object, key: string): Promise<string> {
+    const payload = new TextEncoder().encode(JSON.stringify(request))
+    const keyBuffer = Buffer.from(key, 'base64')
+    return new CompactEncrypt(payload).setProtectedHeader({ alg: 'dir', enc: 'A256GCM' }).encrypt(keyBuffer)
 }

--- a/runtimes/runtimes/chat/encryptedChat.ts
+++ b/runtimes/runtimes/chat/encryptedChat.ts
@@ -64,7 +64,7 @@ export class EncryptedChat implements Chat {
             // call the handler with plaintext
             const response = (await handler(decryptedRequest, CancellationToken.None)) as ChatResult
             // encrypt the response
-            const encryptedResponse = await this.encryptRequest(response as JWTPayload)
+            const encryptedResponse = await this.encryptObject(response as JWTPayload)
             // send it back
             return encryptedResponse
         })
@@ -86,7 +86,7 @@ export class EncryptedChat implements Chat {
                 // call the handler with plaintext
                 const response = (await handler(decryptedRequest, CancellationToken.None)) as QuickActionResult
                 // encrypt the response
-                const encryptedResponse = await this.encryptRequest(response as JWTPayload)
+                const encryptedResponse = await this.encryptObject(response as JWTPayload)
                 // send it back
                 return encryptedResponse
             }
@@ -147,8 +147,8 @@ export class EncryptedChat implements Chat {
         throw new Error('Encoding mode not implemented')
     }
 
-    private async encryptRequest(request: JWTPayload): Promise<string> {
-        const encryptedJWT = await new EncryptJWT(request)
+    private async encryptObject(object: JWTPayload): Promise<string> {
+        const encryptedJWT = await new EncryptJWT(object)
             .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
             .encrypt(this.key)
         return encryptedJWT

--- a/runtimes/runtimes/chat/encryptedChat.ts
+++ b/runtimes/runtimes/chat/encryptedChat.ts
@@ -1,0 +1,156 @@
+import { jwtDecrypt, EncryptJWT, JWTPayload } from 'jose'
+import { Connection } from 'vscode-languageserver'
+import {
+    ChatParams,
+    ChatResult,
+    EndChatParams,
+    FeedbackParams,
+    FollowUpClickParams,
+    InfoLinkClickParams,
+    InsertToCursorPositionParams,
+    LinkClickParams,
+    NotificationHandler,
+    QuickActionParams,
+    QuickActionResult,
+    RequestHandler,
+    SourceLinkClickParams,
+    TabAddParams,
+    TabChangeParams,
+    TabRemoveParams,
+    chatRequestType,
+    feedbackNotificationType,
+    readyNotificationType,
+    tabAddNotificationType,
+    tabChangeNotificationType,
+    tabRemoveNotificationType,
+    insertToCursorPositionNotificationType,
+    linkClickNotificationType,
+    infoLinkClickNotificationType,
+    sourceLinkClickNotificationType,
+    followUpClickNotificationType,
+    endChatRequestType,
+    CancellationToken,
+    EncryptedChatParams,
+    EncryptedQuickActionParams,
+    quickActionRequestType,
+} from '../../protocol'
+import { Chat } from '../../server-interface'
+import { CredentialsEncoding } from '../auth/standalone/encryption'
+
+export class EncryptedChat implements Chat {
+    private key: Buffer
+    private encoding: CredentialsEncoding | undefined
+
+    constructor(
+        private readonly connection: Connection,
+        key: string,
+        encoding?: CredentialsEncoding
+    ) {
+        this.key = Buffer.from(key, 'base64')
+        this.encoding = encoding
+    }
+
+    public onChatPrompt(handler: RequestHandler<ChatParams, ChatResult | null | undefined, ChatResult>) {
+        this.connection.onRequest(chatRequestType, async (request: ChatParams | EncryptedChatParams) => {
+            request = request as EncryptedChatParams
+            // decrypt the request params
+            let decryptedRequest = (await this.decodeRequest(request)) as ChatParams
+
+            // make sure we don't lose the partial result token
+            if (request.partialResultToken) {
+                decryptedRequest.partialResultToken = request.partialResultToken
+            }
+
+            // call the handler with plaintext
+            const response = (await handler(decryptedRequest, CancellationToken.None)) as ChatResult
+            // encrypt the response
+            const encryptedResponse = await this.encryptRequest(response as JWTPayload)
+            // send it back
+            return encryptedResponse
+        })
+    }
+
+    public onQuickAction(handler: RequestHandler<QuickActionParams, QuickActionResult, void>) {
+        this.connection.onRequest(
+            quickActionRequestType,
+            async (request: QuickActionParams | EncryptedQuickActionParams) => {
+                request = request as EncryptedQuickActionParams
+                // decrypt the request params
+                let decryptedRequest = (await this.decodeRequest(request)) as QuickActionParams
+
+                // make sure we don't lose the partial result token
+                if (request.partialResultToken) {
+                    decryptedRequest.partialResultToken = request.partialResultToken
+                }
+
+                // call the handler with plaintext
+                const response = (await handler(decryptedRequest, CancellationToken.None)) as QuickActionResult
+                // encrypt the response
+                const encryptedResponse = await this.encryptRequest(response as JWTPayload)
+                // send it back
+                return encryptedResponse
+            }
+        )
+    }
+    public onEndChat(handler: RequestHandler<EndChatParams, boolean, void>) {
+        return this.connection.onRequest(endChatRequestType, handler)
+    }
+
+    public onSendFeedback(handler: NotificationHandler<FeedbackParams>) {
+        this.connection.onNotification(feedbackNotificationType.method, handler)
+    }
+    public onReady(handler: NotificationHandler<void>) {
+        this.connection.onNotification(readyNotificationType.method, handler)
+    }
+    public onTabAdd(handler: NotificationHandler<TabAddParams>) {
+        this.connection.onNotification(tabAddNotificationType.method, handler)
+    }
+    public onTabChange(handler: NotificationHandler<TabChangeParams>) {
+        this.connection.onNotification(tabChangeNotificationType.method, handler)
+    }
+    public onTabRemove(handler: NotificationHandler<TabRemoveParams>) {
+        this.connection.onNotification(tabRemoveNotificationType.method, handler)
+    }
+    public onCodeInsertToCursorPosition(handler: NotificationHandler<InsertToCursorPositionParams>) {
+        this.connection.onNotification(insertToCursorPositionNotificationType.method, handler)
+    }
+    public onLinkClick(handler: NotificationHandler<LinkClickParams>) {
+        this.connection.onNotification(linkClickNotificationType.method, handler)
+    }
+    public onInfoLinkClick(handler: NotificationHandler<InfoLinkClickParams>) {
+        this.connection.onNotification(infoLinkClickNotificationType.method, handler)
+    }
+    public onSourceLinkClick(handler: NotificationHandler<SourceLinkClickParams>) {
+        this.connection.onNotification(sourceLinkClickNotificationType.method, handler)
+    }
+    public onFollowUpClicked(handler: NotificationHandler<FollowUpClickParams>) {
+        this.connection.onNotification(followUpClickNotificationType.method, handler)
+    }
+
+    private async decodeRequest<T>(request: EncryptedChatParams | EncryptedQuickActionParams): Promise<T> {
+        if (!this.key) {
+            throw new Error('No encryption key')
+        }
+
+        if (this.encoding === 'JWT') {
+            const result = await jwtDecrypt(request.message, this.key, {
+                clockTolerance: 60, // Allow up to 60 seconds to account for clock differences
+                contentEncryptionAlgorithms: ['A256GCM'],
+                keyManagementAlgorithms: ['dir'],
+            })
+
+            if (!result.payload) {
+                throw new Error('JWT payload not found')
+            }
+            return result.payload as T
+        }
+        throw new Error('Encoding mode not implemented')
+    }
+
+    private async encryptRequest(request: JWTPayload): Promise<string> {
+        const encryptedJWT = await new EncryptJWT(request)
+            .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+            .encrypt(this.key)
+        return encryptedJWT
+    }
+}

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -35,6 +35,7 @@ import {
 } from './auth/standalone/encryption'
 import { Logging, Lsp, Telemetry, Workspace, CredentialsProvider, Chat } from '../server-interface'
 import { Auth } from './auth'
+import { EncryptedChat } from './chat/encryptedChat'
 
 import { handleVersionArgument } from './versioning'
 import { RuntimeProps } from './runtime'
@@ -47,6 +48,7 @@ import * as os from 'os'
 import * as path from 'path'
 import { LspRouter } from './lsp/router/lspRouter'
 import { LspServer } from './lsp/router/lspServer'
+import { CompactEncrypt } from 'jose'
 
 /**
  * The runtime for standalone LSP-based servers.
@@ -79,6 +81,7 @@ export const standalone = (props: RuntimeProps) => {
     const documentsObserver = observe(lspConnection)
 
     let auth: Auth
+    let chat: Chat
     initializeAuth()
 
     // Initialize Auth service
@@ -92,7 +95,8 @@ export const standalone = (props: RuntimeProps) => {
                     validateEncryptionDetails(encryptionDetails)
                     lspConnection.console.info('Runtime: Initializing runtime with encryption')
                     auth = new Auth(lspConnection, encryptionDetails.key, encryptionDetails.mode)
-                    initializeRuntime()
+                    chat = new EncryptedChat(lspConnection, encryptionDetails.key, encryptionDetails.mode)
+                    initializeRuntime(encryptionDetails.key)
                 },
                 error => {
                     console.error(error)
@@ -102,6 +106,26 @@ export const standalone = (props: RuntimeProps) => {
         } else {
             lspConnection.console.info('Runtime: Initializing runtime without encryption')
             auth = new Auth(lspConnection)
+
+            chat = {
+                onChatPrompt: handler => lspConnection.onRequest(chatRequestType.method, handler),
+                onEndChat: handler => lspConnection.onRequest(endChatRequestType.method, handler),
+                onQuickAction: handler => lspConnection.onRequest(quickActionRequestType.method, handler),
+                onSendFeedback: handler => lspConnection.onNotification(feedbackNotificationType.method, handler),
+                onReady: handler => lspConnection.onNotification(readyNotificationType.method, handler),
+                onTabAdd: handler => lspConnection.onNotification(tabAddNotificationType.method, handler),
+                onTabChange: handler => lspConnection.onNotification(tabChangeNotificationType.method, handler),
+                onTabRemove: handler => lspConnection.onNotification(tabRemoveNotificationType.method, handler),
+                onCodeInsertToCursorPosition: handler =>
+                    lspConnection.onNotification(insertToCursorPositionNotificationType.method, handler),
+                onLinkClick: handler => lspConnection.onNotification(linkClickNotificationType.method, handler),
+                onInfoLinkClick: handler => lspConnection.onNotification(infoLinkClickNotificationType.method, handler),
+                onSourceLinkClick: handler =>
+                    lspConnection.onNotification(sourceLinkClickNotificationType.method, handler),
+                onFollowUpClicked: handler =>
+                    lspConnection.onNotification(followUpClickNotificationType.method, handler),
+            }
+
             initializeRuntime()
         }
     }
@@ -110,7 +134,7 @@ export const standalone = (props: RuntimeProps) => {
     // TODO: make this dependent on the actual requirements of the
     // capabilities parameter.
 
-    function initializeRuntime() {
+    function initializeRuntime(encryptionKey?: string) {
         const documents = new TextDocuments(TextDocument)
 
         // Set up logging over LSP
@@ -173,23 +197,6 @@ export const standalone = (props: RuntimeProps) => {
             },
         }
 
-        const chat: Chat = {
-            onChatPrompt: handler => lspConnection.onRequest(chatRequestType.method, handler),
-            onEndChat: handler => lspConnection.onRequest(endChatRequestType, handler),
-            onQuickAction: handler => lspConnection.onRequest(quickActionRequestType, handler),
-            onSendFeedback: handler => lspConnection.onNotification(feedbackNotificationType.method, handler),
-            onReady: handler => lspConnection.onNotification(readyNotificationType.method, handler),
-            onTabAdd: handler => lspConnection.onNotification(tabAddNotificationType.method, handler),
-            onTabChange: handler => lspConnection.onNotification(tabChangeNotificationType.method, handler),
-            onTabRemove: handler => lspConnection.onNotification(tabRemoveNotificationType.method, handler),
-            onCodeInsertToCursorPosition: handler =>
-                lspConnection.onNotification(insertToCursorPositionNotificationType.method, handler),
-            onLinkClick: handler => lspConnection.onNotification(linkClickNotificationType.method, handler),
-            onInfoLinkClick: handler => lspConnection.onNotification(infoLinkClickNotificationType.method, handler),
-            onSourceLinkClick: handler => lspConnection.onNotification(sourceLinkClickNotificationType.method, handler),
-            onFollowUpClicked: handler => lspConnection.onNotification(followUpClickNotificationType.method, handler),
-        }
-
         const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
 
         // Create router that will be routing LSP events from the client to server(s)
@@ -232,6 +239,13 @@ export const standalone = (props: RuntimeProps) => {
                 sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {
                     return lspConnection.sendProgress(type, token, value)
                 },
+                sendEncryptedProgress: async <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {
+                    if (encryptionKey) {
+                        const encryptedProgress = await encryptRequest(value as Object, encryptionKey)
+                        return lspConnection.sendProgress(type, token, encryptedProgress as P)
+                    }
+                },
+
                 onHover: handler => lspConnection.onHover(handler),
                 extensions: {
                     onInlineCompletionWithReferences: handler =>
@@ -254,4 +268,10 @@ export const standalone = (props: RuntimeProps) => {
         documents.listen(documentsObserver.callbacks)
         lspConnection.listen()
     }
+}
+
+async function encryptRequest(request: Object, key: string): Promise<string> {
+    const payload = new TextEncoder().encode(JSON.stringify(request))
+    const keyBuffer = Buffer.from(key, 'base64')
+    return new CompactEncrypt(payload).setProtectedHeader({ alg: 'dir', enc: 'A256GCM' }).encrypt(keyBuffer)
 }

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -78,8 +78,8 @@ export const webworker = (props: RuntimeProps) => {
 
     const chat: Chat = {
         onChatPrompt: handler => lspConnection.onRequest(chatRequestType.method, handler),
-        onEndChat: handler => lspConnection.onRequest(endChatRequestType, handler),
-        onQuickAction: handler => lspConnection.onRequest(quickActionRequestType, handler),
+        onEndChat: handler => lspConnection.onRequest(endChatRequestType.method, handler),
+        onQuickAction: handler => lspConnection.onRequest(quickActionRequestType.method, handler),
         onSendFeedback: handler => lspConnection.onNotification(feedbackNotificationType.method, handler),
         onReady: handler => lspConnection.onNotification(readyNotificationType.method, handler),
         onTabAdd: handler => lspConnection.onNotification(tabAddNotificationType.method, handler),
@@ -131,6 +131,10 @@ export const webworker = (props: RuntimeProps) => {
             },
             publishDiagnostics: params => lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),
             sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {
+                return lspConnection.sendProgress(type, token, value)
+            },
+            sendEncryptedProgress: async <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {
+                // TODO, implement encryption if encryption is needed in webworker runtime
                 return lspConnection.sendProgress(type, token, value)
             },
             onHover: handler => lspConnection.onHover(handler),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -133,10 +133,6 @@ export const webworker = (props: RuntimeProps) => {
             sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {
                 return lspConnection.sendProgress(type, token, value)
             },
-            sendEncryptedProgress: async <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {
-                // TODO, implement encryption if encryption is needed in webworker runtime
-                return lspConnection.sendProgress(type, token, value)
-            },
             onHover: handler => lspConnection.onHover(handler),
             extensions: {
                 onInlineCompletionWithReferences: handler =>

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -78,7 +78,6 @@ export type Lsp = {
     onDidCloseTextDocument: (handler: NotificationHandler<DidCloseTextDocumentParams>) => void
     publishDiagnostics: (params: PublishDiagnosticsParams) => Promise<void>
     sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => Promise<void>
-    sendEncryptedProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => Promise<void>
     onHover: (handler: RequestHandler<HoverParams, Hover | null | undefined, void>) => void
     onExecuteCommand: (handler: RequestHandler<ExecuteCommandParams, any | undefined | null, void>) => void
     workspace: {

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -78,6 +78,7 @@ export type Lsp = {
     onDidCloseTextDocument: (handler: NotificationHandler<DidCloseTextDocumentParams>) => void
     publishDiagnostics: (params: PublishDiagnosticsParams) => Promise<void>
     sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => Promise<void>
+    sendEncryptedProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => Promise<void>
     onHover: (handler: RequestHandler<HoverParams, Hover | null | undefined, void>) => void
     onExecuteCommand: (handler: RequestHandler<ExecuteCommandParams, any | undefined | null, void>) => void
     workspace: {

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -68,6 +68,11 @@ export interface ChatParams extends PartialResultParams {
     cursorState?: CursorState[]
     textDocument?: TextDocumentIdentifier
 }
+
+export interface EncryptedChatParams extends PartialResultParams {
+    message: string
+}
+
 export interface ChatResult {
     body?: string
     messageId?: string
@@ -92,6 +97,10 @@ export interface QuickActionParams extends PartialResultParams {
     prompt?: string
     cursorState?: CursorState[]
     textDocument?: TextDocumentIdentifier
+}
+
+export interface EncryptedQuickActionParams extends PartialResultParams {
+    message: string
 }
 
 // Currently the QuickAction result and ChatResult share the same shape


### PR DESCRIPTION
## Description
This PR introduces the encrypted chat class which ensures that quick action and chat prompt communication passing through the LSP connection is encrypted. The runtime handles the encryption and decryption and servers don't need to change anything

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
