### PR TITLE
Release/UI types 0.0.6

### DIFF
--- a/chat-client-ui-types/CHANGELOG.md
+++ b/chat-client-ui-types/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.6] - 2024-06-20
+
+- Introduce `CHAT_OPTIONS` contract to allow sending chat options like available quick actions to the UI
+
 ## [0.0.5] - 2024-06-05
 
 - Removed `tabIdReceived` from contracts

--- a/chat-client-ui-types/package.json
+++ b/chat-client-ui-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/chat-client-ui-types",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Type definitions for Chat UIs in Language Servers and Runtimes for AWS",
     "main": "./out/index.js",
     "scripts": {
@@ -18,6 +18,6 @@
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
     "dependencies": {
-        "@aws/language-server-runtimes-types": "0.x.x"
+        "@aws/language-server-runtimes-types": "^0.0.6"
     }
 }


### PR DESCRIPTION
## Description
Release chat-client-ui-types 0.0.6

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
