### PR TITLE
Add request handler for SemanticTokens

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -10,6 +10,7 @@ import {
     inlineCompletionRequestType,
     TextDocument,
     telemetryNotificationType,
+    SemanticTokensRequest,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -196,6 +197,7 @@ export const standalone = (props: RuntimeProps) => {
                 onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),
                 onDidCloseTextDocument: handler => documentsObserver.callbacks.onDidCloseTextDocument(handler),
                 onExecuteCommand: lspServer.setExecuteCommandHandler,
+                onSemanticTokens: handler => lspConnection.onRequest(SemanticTokensRequest.type, handler),
                 workspace: {
                     getConfiguration: section => lspConnection.workspace.getConfiguration(section),
                     onDidChangeWorkspaceFolders: handler =>

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -10,6 +10,7 @@ import {
     inlineCompletionRequestType,
     TextDocument,
     telemetryNotificationType,
+    SemanticTokensRequest,
 
     // Chat protocol
     chatRequestType,
@@ -124,6 +125,7 @@ export const webworker = (props: RuntimeProps) => {
             onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),
             onDidCloseTextDocument: handler => lspConnection.onDidCloseTextDocument(handler),
             onExecuteCommand: lspServer.setExecuteCommandHandler,
+            onSemanticTokens: handler => lspConnection.onRequest(SemanticTokensRequest.type, handler),
             workspace: {
                 getConfiguration: section => lspConnection.workspace.getConfiguration(section),
                 onDidChangeWorkspaceFolders: handler =>

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -38,7 +38,7 @@ export * from '../protocol/lsp'
 
 export type PartialServerCapabilities<T = any> = Pick<
     ServerCapabilities<T>,
-    'completionProvider' | 'hoverProvider' | 'executeCommandProvider'
+    'completionProvider' | 'hoverProvider' | 'executeCommandProvider' | 'semanticTokensProvider'
 >
 export type PartialInitializeResult<T = any> = {
     capabilities: PartialServerCapabilities<T>

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -28,6 +28,8 @@ import {
     RequestHandler,
     ServerCapabilities,
     TextEdit,
+    SemanticTokensParams,
+    SemanticTokens,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -80,6 +82,7 @@ export type Lsp = {
     sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => Promise<void>
     onHover: (handler: RequestHandler<HoverParams, Hover | null | undefined, void>) => void
     onExecuteCommand: (handler: RequestHandler<ExecuteCommandParams, any | undefined | null, void>) => void
+    onSemanticTokens: (handler: RequestHandler<SemanticTokensParams, SemanticTokens | null, void>) => void
     workspace: {
         getConfiguration: (section: string) => Promise<any>
         onDidChangeWorkspaceFolders: (handler: NotificationHandler<DidChangeWorkspaceFoldersParams>) => void

--- a/runtimes/testing/TestFeatures.ts
+++ b/runtimes/testing/TestFeatures.ts
@@ -9,6 +9,7 @@ import {
     ExecuteCommandParams,
     HoverParams,
     InlineCompletionParams,
+    SemanticTokensParams,
     TextDocument,
 } from '../protocol'
 
@@ -71,6 +72,10 @@ export class TestFeatures {
 
     async doCompletion(params: CompletionParams, token: CancellationToken) {
         return this.lsp.onCompletion.args[0]?.[0](params, token)
+    }
+
+    async doSemanticTokens(params: SemanticTokensParams, token: CancellationToken) {
+        return this.lsp.onSemanticTokens.args[0]?.[0](params, token)
     }
 
     async doFormat(params: DocumentFormattingParams, token: CancellationToken) {


### PR DESCRIPTION
## Problem

The current type Lsp doesn't have the capability to respond to request `textDocument/semanticTokens/full` sent by client. 

## Solution

This PR adds `semanticTokensProvider` to ServerCapabilities and register onSemanticTokens request handler. Then the runtime can use the handler to respond to the request `textDocument/semanticTokens/full`. This will enable the server to support SemanticTokens over LSP.

Tested the change on VSCode using the client `aws-lsp-partiql` in https://github.com/aws/language-servers.
![image](https://github.com/aws/language-server-runtimes/assets/122423248/238fa3cb-85b5-40b4-9e59-ad7b775f739a)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
