### PR TITLE
Return response error unencrypted

### DIFF
--- a/runtimes/runtimes/chat/encryptedChat.ts
+++ b/runtimes/runtimes/chat/encryptedChat.ts
@@ -81,8 +81,8 @@ export class EncryptedChat extends BaseChat {
                     // Call the handler with decrypted params
                     const response = await handler(decryptedRequest, cancellationToken)
 
-                    // If response is null or undefined, return it as is
-                    if (!response) {
+                    // If response is null, undefined or a response error, return it as is
+                    if (!response || response instanceof ResponseError) {
                         return response
                     }
 


### PR DESCRIPTION
## Problem
The library that handles to protocol need to be able to intercept `ResponseError` and returns corresponding exceptions. Since the handler results that are of `ResponseError` are encrypted, errors are not being thrown on Toolkit side.

## Solution

Check if result is an instance of `ResponseError`

## Testing

Verified that it works E2E in VS

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
