### PR TITLE
Upgrade runtimes version to 0.2.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2340,7 +2340,7 @@
         },
         "runtimes": {
             "name": "@aws/language-server-runtimes",
-            "version": "0.2.9",
+            "version": "0.2.10",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.6",

--- a/runtimes/CHANGELOG.md
+++ b/runtimes/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.2.10] - 2024-07-01
+
+- Added support for `textDocument/semanticTokens/full` [LSP feature](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokens_fullRequest)
 
 ## [0.2.9] - 2024-07-01
 

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",


### PR DESCRIPTION
Release v0.2.10
- https://github.com/aws/language-server-runtimes/pull/156

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
