### PR TITLE
Add Github Actions to automate publishing of packages to npm

### DIFF
--- a/.github/workflows/publish-chat-types.yaml
+++ b/.github/workflows/publish-chat-types.yaml
@@ -1,4 +1,4 @@
-name: Publish Types Package to npmjs
+name: Publish Chat Client UI Types Package to npmjs
 
 on:
   push:

--- a/.github/workflows/publish-chat-types.yaml
+++ b/.github/workflows/publish-chat-types.yaml
@@ -1,0 +1,13 @@
+name: Publish Types Package to npmjs
+
+on:
+  push:
+    tags:
+      - 'chat-client-ui-types/v**'
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish-to-npm.yaml
+    with:
+      workspace: 'chat-client-ui-types'
+    secrets: inherit

--- a/.github/workflows/publish-runtimes.yaml
+++ b/.github/workflows/publish-runtimes.yaml
@@ -1,4 +1,4 @@
-name: Publish Types Package to npmjs
+name: Publish Runtimes Package to npmjs
 
 on:
   push:

--- a/.github/workflows/publish-runtimes.yaml
+++ b/.github/workflows/publish-runtimes.yaml
@@ -1,0 +1,13 @@
+name: Publish Types Package to npmjs
+
+on:
+  push:
+    tags:
+      - 'language-server-runtimes/v**'
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish-to-npm.yaml
+    with:
+      workspace: 'runtimes'
+    secrets: inherit

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,0 +1,25 @@
+name: Reusable Publish Package to npmjs workflow
+
+on:
+  workflow_call:
+    inputs:
+      workspace:
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@aws'
+      - run: npm ci
+      - run: npm run compile
+      - run: npm run pub --workspace ${{ inputs.workspace }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-types.yaml
+++ b/.github/workflows/publish-types.yaml
@@ -1,0 +1,13 @@
+name: Publish Types Package to npmjs
+
+on:
+  push:
+    tags:
+      - 'language-server-runtimes-types/v**'
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish-to-npm.yaml
+    with:
+      workspace: 'types'
+    secrets: inherit

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ out/
 package-lock.json
 .prettierrc
 .vscode
+.github/workflows/**


### PR DESCRIPTION
## Problem

Publishing packages from Language Server Runtimes monorepo requires manual steps. 

## Solution

Introducing workflows, which allow trigger publishing to npm from Github Action. Workflows will be triggered only when git tag with specific format is created per package we want to release:
* @aws/chat-client-ui-types: `chat-client-ui-types/v**`
* @aws/language-server-runtimes: `language-server-runtimes/v**`
* @aws/language-server-runtimes-types: `language-server-runtimes-types/v**`

Tags can be created using during release process using Github Releases webpage or manually using git CLI. This change also helps to align git tags formats we use.

Workflows will attempt to publish current version of packages, as set in their `package.json`, so proper release process still has to be followed to bump the version and merge release branches into main.

### Testing

Tested in my fork, verified that publishing attempt happens, but fails due to version conflict, which is expected.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
