### PR TITLE
Add onSignatureHelp Request Handler

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -214,6 +214,7 @@ export const standalone = (props: RuntimeProps) => {
                     return lspConnection.sendProgress(type, token, value)
                 },
                 onHover: handler => lspConnection.onHover(handler),
+                onSignatureHelp: handler => lspConnection.onSignatureHelp(handler),
                 extensions: {
                     onInlineCompletionWithReferences: handler =>
                         lspConnection.onRequest(inlineCompletionWithReferencesRequestType, handler),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -136,6 +136,7 @@ export const webworker = (props: RuntimeProps) => {
                 return lspConnection.sendProgress(type, token, value)
             },
             onHover: handler => lspConnection.onHover(handler),
+            onSignatureHelp: handler => lspConnection.onSignatureHelp(handler),
             extensions: {
                 onInlineCompletionWithReferences: handler =>
                     lspConnection.onRequest(inlineCompletionWithReferencesRequestType, handler),

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -30,6 +30,8 @@ import {
     TextEdit,
     SemanticTokensParams,
     SemanticTokens,
+    SignatureHelp,
+    SignatureHelpParams,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -38,7 +40,11 @@ export * from '../protocol/lsp'
 
 export type PartialServerCapabilities<T = any> = Pick<
     ServerCapabilities<T>,
-    'completionProvider' | 'hoverProvider' | 'executeCommandProvider' | 'semanticTokensProvider'
+    | 'completionProvider'
+    | 'hoverProvider'
+    | 'executeCommandProvider'
+    | 'semanticTokensProvider'
+    | 'signatureHelpProvider'
 >
 export type PartialInitializeResult<T = any> = {
     capabilities: PartialServerCapabilities<T>
@@ -83,6 +89,7 @@ export type Lsp = {
     onHover: (handler: RequestHandler<HoverParams, Hover | null | undefined, void>) => void
     onExecuteCommand: (handler: RequestHandler<ExecuteCommandParams, any | undefined | null, void>) => void
     onSemanticTokens: (handler: RequestHandler<SemanticTokensParams, SemanticTokens | null, void>) => void
+    onSignatureHelp: (handler: RequestHandler<SignatureHelpParams, SignatureHelp | null | undefined, void>) => void
     workspace: {
         getConfiguration: (section: string) => Promise<any>
         onDidChangeWorkspaceFolders: (handler: NotificationHandler<DidChangeWorkspaceFoldersParams>) => void

--- a/runtimes/testing/TestFeatures.ts
+++ b/runtimes/testing/TestFeatures.ts
@@ -11,6 +11,7 @@ import {
     InlineCompletionParams,
     SemanticTokensParams,
     TextDocument,
+    SignatureHelpParams,
 } from '../protocol'
 
 /**
@@ -84,6 +85,10 @@ export class TestFeatures {
 
     async doHover(params: HoverParams, token: CancellationToken) {
         return this.lsp.onHover.args[0]?.[0](params, token)
+    }
+
+    async doSignatureHelp(params: SignatureHelpParams, token: CancellationToken) {
+        return this.lsp.onSignatureHelp.args[0]?.[0](params, token)
     }
 
     async doInlineCompletionWithReferences(


### PR DESCRIPTION
## Problem
The current type Lsp doesn't have the capability to respond to request [textDocument/signatureHelp](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_signatureHelp) sent by client.

## Solution
This PR adds signatureHelpProvider to ServerCapabilities and register onSignatureHelp request handler. Then the runtime can use the handler to respond to the request `textDocument/signatureHelp`. This will enable the server to support Signature Help over LSP.

Tested the change on VSCode using the client aws-lsp-partiql in https://github.com/aws/language-servers.

<img src="https://github.com/user-attachments/assets/ba6b7d99-d7e7-476c-8ebf-0e41cd16211b" height="450">

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
