### PR TITLE
Fix InitilizeResult merge logic

### DIFF
--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -98,12 +98,15 @@ describe('LspRouter', () => {
                 return {
                     capabilities: {
                         completionProvider: { resolveProvider: true },
+                        executeCommandProvider: { commands: ['log', 'test'] },
                     },
                 }
             }
             const handler2 = () => {
                 return Promise.resolve({
-                    capabilities: {},
+                    capabilities: {
+                        executeCommandProvider: { commands: ['run'] },
+                    },
                     extraField: 'extraValue',
                 })
             }
@@ -124,6 +127,7 @@ describe('LspRouter', () => {
                         change: TextDocumentSyncKind.Incremental,
                     },
                     completionProvider: { resolveProvider: true },
+                    executeCommandProvider: { commands: ['run', 'log', 'test'] },
                 },
                 extraField: 'extraValue',
             }

--- a/runtimes/runtimes/lsp/router/util.ts
+++ b/runtimes/runtimes/lsp/router/util.ts
@@ -25,11 +25,13 @@ export function asPromise(value: any): Promise<any> {
 }
 
 export function mergeObjects(obj1: any, obj2: any) {
-    const merged: any = {}
+    let merged: any = {}
 
     for (let key in obj1) {
         if (obj1.hasOwnProperty(key)) {
-            if (typeof obj1[key] === 'object' && typeof obj2[key] === 'object') {
+            if (Array.isArray(obj1) && Array.isArray(obj2)) {
+                merged = [...new Set([...obj1, ...obj2])]
+            } else if (typeof obj1[key] === 'object' && typeof obj2[key] === 'object') {
                 merged[key] = mergeObjects(obj1[key], obj2[key])
             } else {
                 merged[key] = obj1[key]
@@ -41,7 +43,9 @@ export function mergeObjects(obj1: any, obj2: any) {
     }
 
     for (let key in obj2) {
-        if (obj2.hasOwnProperty(key) && !obj1.hasOwnProperty(key)) {
+        if (Array.isArray(obj1) && Array.isArray(obj2)) {
+            continue
+        } else if (obj2.hasOwnProperty(key) && !obj1.hasOwnProperty(key)) {
             merged[key] = obj2[key]
         }
     }


### PR DESCRIPTION
## Problem
Servers couldn't run when multiple executeCommandProviders are given

## Solution
Add conditional to InitializeResult merge logic when values are arrays
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
