### PR TITLE
Pass partial result token in chat request through to allow "0" to be used

### DIFF
--- a/runtimes/runtimes/chat/encryptedChat.ts
+++ b/runtimes/runtimes/chat/encryptedChat.ts
@@ -74,9 +74,7 @@ export class EncryptedChat extends BaseChat {
                     }
 
                     // Preserve the partial result token
-                    if (request.partialResultToken) {
-                        decryptedRequest.partialResultToken = request.partialResultToken
-                    }
+                    decryptedRequest.partialResultToken = request.partialResultToken
 
                     // Call the handler with decrypted params
                     const response = await handler(decryptedRequest, cancellationToken)


### PR DESCRIPTION
## Problem
The progress completion handler in VS always start the token as 0 then increment after each request. The very first request will not have partial result because `0` is falsey. 

## Solution

`partialResultToken` can be both numbers and strings, so it is reasonable to expect that `0` should work as a token. I think this handler can just include the partial result token and let the chat handler figure out what to do with it. Alternatively, we can just check whether it is undefined.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
