### PR TITLE
Upgrade runtimes version to 0.2.12

### DIFF
--- a/runtimes/CHANGELOG.md
+++ b/runtimes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.12] - 2024-07-19
+
+- Add onSignatureHelp request handler
+- Fix chat runtime to allow "0" to be used as a partial token in chat request 
+
 ## [0.2.11] - 2024-07-15
 
 - Fixed InitializeResult merge logic to account for arrays in the initiliaze handlers

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",


### PR DESCRIPTION
## Problem

Release of new package version: 0.2.12.

## Solution

Release of new package version: 0.2.12.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
