### PR TITLE
Use token from AWS Secret Manager in publish to npm workflow

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -7,11 +7,27 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::935785792371:role/GithubNpmPublishAction
+          role-session-name: language-server-runtimes-github
+          aws-region: us-east-1
+      - name: Get npm access token
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            npmjs/github_automation
+          parse-json-secrets: true
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
@@ -22,4 +38,4 @@ jobs:
       - run: npm run compile
       - run: npm run pub --workspace ${{ inputs.workspace }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ env.NPMJS_GITHUB_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## Problem
Github action for publishing to npm is using secrets stored in repository secrets.

## Solution
Use AWS Secrets Manager in team-owned service account to store npm tokens.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
