### PR TITLE
Revert "Bump vscode-languageserver-textdocument from 1.0.11 to 1.0.12"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2187,9 +2187,9 @@
             }
         },
         "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+            "integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
         },
         "node_modules/vscode-languageserver-types": {
             "version": "3.17.5",
@@ -2369,7 +2369,7 @@
             "version": "0.0.6",
             "license": "Apache-2.0",
             "dependencies": {
-                "vscode-languageserver-textdocument": "^1.0.12",
+                "vscode-languageserver-textdocument": "^1.0.11",
                 "vscode-languageserver-types": "^3.17.5"
             }
         }

--- a/types/package.json
+++ b/types/package.json
@@ -18,7 +18,7 @@
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
     "dependencies": {
-        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-textdocument": "^1.0.11",
         "vscode-languageserver-types": "^3.17.5"
     }
 }


### PR DESCRIPTION
This reverts commit 8e89e418896d21b9898f44962361f56c47c3cce3.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
