### PR TITLE
Add window showMessage and showDocument LSP features to runtimes

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -13,6 +13,7 @@ import {
     SemanticTokensRequest,
     ShowMessageNotification,
     ShowMessageRequest,
+    ShowDocumentRequest,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -208,6 +209,7 @@ export const standalone = (props: RuntimeProps) => {
                 window: {
                     showMessage: params => lspConnection.sendNotification(ShowMessageNotification.method, params),
                     showMessageRequest: params => lspConnection.sendRequest(ShowMessageRequest.method, params),
+                    showDocument: params => lspConnection.sendRequest(ShowDocumentRequest.method, params),
                 },
                 publishDiagnostics: params =>
                     lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -11,6 +11,8 @@ import {
     TextDocument,
     telemetryNotificationType,
     SemanticTokensRequest,
+    ShowMessageNotification,
+    ShowMessageRequest,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -202,6 +204,10 @@ export const standalone = (props: RuntimeProps) => {
                     getConfiguration: section => lspConnection.workspace.getConfiguration(section),
                     onDidChangeWorkspaceFolders: handler =>
                         lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler),
+                },
+                window: {
+                    showMessage: params => lspConnection.sendNotification(ShowMessageNotification.method, params),
+                    showMessageRequest: params => lspConnection.sendRequest(ShowMessageRequest.method, params),
                 },
                 publishDiagnostics: params =>
                     lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -28,6 +28,7 @@ import {
     tabRemoveNotificationType,
     ShowMessageNotification,
     ShowMessageRequest,
+    ShowDocumentRequest,
 } from '../protocol'
 import { BrowserMessageReader, BrowserMessageWriter, createConnection } from 'vscode-languageserver/browser'
 import { Chat, Logging, Lsp, Telemetry, Workspace } from '../server-interface'
@@ -136,6 +137,7 @@ export const webworker = (props: RuntimeProps) => {
             window: {
                 showMessage: params => lspConnection.sendNotification(ShowMessageNotification.method, params),
                 showMessageRequest: params => lspConnection.sendRequest(ShowMessageRequest.method, params),
+                showDocument: params => lspConnection.sendRequest(ShowDocumentRequest.method, params),
             },
             publishDiagnostics: params => lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),
             sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -26,6 +26,8 @@ import {
     tabChangeNotificationType,
     tabAddNotificationType,
     tabRemoveNotificationType,
+    ShowMessageNotification,
+    ShowMessageRequest,
 } from '../protocol'
 import { BrowserMessageReader, BrowserMessageWriter, createConnection } from 'vscode-languageserver/browser'
 import { Chat, Logging, Lsp, Telemetry, Workspace } from '../server-interface'
@@ -130,6 +132,10 @@ export const webworker = (props: RuntimeProps) => {
                 getConfiguration: section => lspConnection.workspace.getConfiguration(section),
                 onDidChangeWorkspaceFolders: handler =>
                     lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler),
+            },
+            window: {
+                showMessage: params => lspConnection.sendNotification(ShowMessageNotification.method, params),
+                showMessageRequest: params => lspConnection.sendRequest(ShowMessageRequest.method, params),
             },
             publishDiagnostics: params => lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),
             sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -35,6 +35,8 @@ import {
     ShowMessageParams,
     ShowMessageRequestParams,
     MessageActionItem,
+    ShowDocumentParams,
+    ShowDocumentResult,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -100,6 +102,7 @@ export type Lsp = {
     window: {
         showMessage: (params: ShowMessageParams) => Promise<void>
         showMessageRequest: (params: ShowMessageRequestParams) => Promise<MessageActionItem | null>
+        showDocument: (params: ShowDocumentParams) => Promise<ShowDocumentResult>
     }
     extensions: {
         onInlineCompletionWithReferences: (

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -32,6 +32,9 @@ import {
     SemanticTokens,
     SignatureHelp,
     SignatureHelpParams,
+    ShowMessageParams,
+    ShowMessageRequestParams,
+    MessageActionItem,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -93,6 +96,10 @@ export type Lsp = {
     workspace: {
         getConfiguration: (section: string) => Promise<any>
         onDidChangeWorkspaceFolders: (handler: NotificationHandler<DidChangeWorkspaceFoldersParams>) => void
+    }
+    window: {
+        showMessage: (params: ShowMessageParams) => Promise<void>
+        showMessageRequest: (params: ShowMessageRequestParams) => Promise<MessageActionItem | null>
     }
     extensions: {
         onInlineCompletionWithReferences: (


### PR DESCRIPTION
## Problem
Runtimes don't support Window showMessage features.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

Added support and bindings for 3 Window LSP features:
* `window/showMessage` notification ([spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessage))
* `window/showMessageRequest` request ([spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessageRequest))
* `window/showDocument` request ([spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument))

Adding bindings for these features allows Capability servers to request displaying UI flows in host clients natively. This allows to implement UX flows. whenever required by Capability business logic.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
