### PR TITLE
Upgrade runtimes version to 0.2.13

### DIFF
--- a/runtimes/CHANGELOG.md
+++ b/runtimes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.13] - 2024-08-16
+
+- Add support for window/showDocument, window/showMessage and window/showMessageRequest LSP handler
+
 ## [0.2.12] - 2024-07-19
 
 - Add onSignatureHelp request handler

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.12",
+    "version": "0.2.13",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",


### PR DESCRIPTION
## Description

Release Language Server Runtimes v0.2.13

### Changes

- Add support for window/showDocument, window/showMessage and window/showMessageRequest LSP handler

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
