### PR TITLE
Enable unit test launch configurations for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "watch",
+            "name": "Unit Tests",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "args": ["${workspaceRoot}/**/out/**/*.test.js"],
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "preLaunchTask": "watch",
+            "name": "Unit Tests (Current File)",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "args": ["${workspaceRoot}/**/out/**/${fileBasenameNoExtension}.js"],
+            "cwd": "${workspaceRoot}"
+        }    
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "compile",
+            "group": "build",
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "never"
+            },
+            "problemMatcher": ["$tsc"]
+        },
+        {
+            "label": "watch",
+            "type": "npm",
+            "script": "watch",
+            "isBackground": true,
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "never"
+            },
+            "problemMatcher": ["$tsc-watch"]
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "prepare": "husky install .husky",
         "test": "npm run test --workspaces --if-present",
         "preversion": "npm run test",
-        "version": "npm run compile && git add -A ."
+        "version": "npm run compile && git add -A .",
+        "watch": "tsc --build --watch"
     },
     "devDependencies": {
         "@types/mocha": "^10.0.7",

--- a/types/package.json
+++ b/types/package.json
@@ -2,7 +2,7 @@
     "name": "@aws/language-server-runtimes-types",
     "version": "0.0.6",
     "description": "Type definitions in Language Servers and Runtimes for AWS",
-    "main": "index.js",
+    "main": "out/index.js",
     "scripts": {
         "clean": "rm -rf out/",
         "compile": "tsc --build",


### PR DESCRIPTION
## Problem
No convenient way to run unit tests from VS Code to simplify test debugging.  types package had invalid package.json defined "main" script.

## Solution
Fixed "main" script in types package to be out/index.js rather than just index.js.  Setup .vscode files and watch script similar to that in language-servers repo.  Now unit tests can be launched from VS Code.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
