### PR TITLE
Accept Client metadata with LSP Initialization and inject standard UserAgent to Server implementations from the Runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 out/
 **/.DS_Store
+**/*.d.ts

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -46,23 +46,10 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
  */
 export interface AWSClientInitializationOptions {
     /**
-     * Custom client branding information.
+     * Custom UserAgent suffix value, computed by client and passed down to Server implementations at startup.
+     * The value can be used by Servers to setup custom user agent headers for HTTP or AWS SDK calls.
      */
-    product?: {
-        name: string
-        version: string
-    }
-    /**
-     * Client host platform information.
-     */
-    platform?: {
-        name: string
-        version: string
-    }
-    /**
-     * Custom Client ID value, set based on client extension internal business logic.
-     */
-    clientId?: string
+    customUserAgentSuffix?: string
 }
 
 /**

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -46,10 +46,29 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
  */
 export interface AWSClientInitializationOptions {
     /**
-     * Custom UserAgent suffix value, computed by client and passed down to Server implementations at startup.
-     * The value can be used by Servers to setup custom user agent headers for HTTP or AWS SDK calls.
+     * Custom client branding information.
      */
-    customUserAgentSuffix?: string
+    product?: {
+        /**
+         * Product name, may contain spaces.
+         */
+        name: string
+        version: string
+    }
+    /**
+     * Client host platform information.
+     */
+    platform?: {
+        /**
+         * Platform name, may contain spaces.
+         */
+        name: string
+        version: string
+    }
+    /**
+     * Custom Client ID value, set based on client extension internal business logic.
+     */
+    clientId?: string
 }
 
 /**

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -1,5 +1,6 @@
 import { _EM } from 'vscode-jsonrpc'
 import {
+    InitializeParams as _InitializeParamsBase,
     InitializeResult as InitializeResultBase,
     ParameterStructures,
     ProgressType,
@@ -37,6 +38,38 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
 
     public constructor(method: string) {
         super(method, ParameterStructures.auto)
+    }
+}
+
+/**
+ * Extra Client information passed during initialization handshake from Client to Server.
+ */
+export interface AWSClientInitializationOptions {
+    /**
+     * Custom client branding information.
+     */
+    product?: {
+        name: string
+        version: string
+    }
+    /**
+     * Custom client host platform information.
+     */
+    platform?: {
+        name: string
+        version: string
+    }
+    clientId?: string
+}
+
+/**
+ * Extended AWS Runtimes InitializeParams interface,
+ * sent from Client to Server as part of [`initialize`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize) request
+ */
+export interface InitializeParams extends _InitializeParamsBase {
+    initializationOptions?: {
+        [key: string]: any
+        aws: AWSClientInitializationOptions
     }
 }
 

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -1,7 +1,7 @@
 import { _EM } from 'vscode-jsonrpc'
 import {
     InitializeParams as _InitializeParamsBase,
-    InitializeResult as InitializeResultBase,
+    InitializeResult as _InitializeResultBase,
     ParameterStructures,
     ProgressType,
     RegistrationType,
@@ -42,36 +42,52 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
 }
 
 /**
- * Custom Client extension information passed during initialization handshake from Client to Server.
+ * Custom Client extension information passed during initialization from Client to Server.
+ * Use to identify extension and pass additional data, not available in standard InitializeParams object.
  */
-export interface AWSClientInfoInitializationOptions {
+export interface ClientExtensionInfo {
     /**
-     * Client extension name, may contain spaces.
+     * Client Extension name, which is used for managing and interacting with AWS Language Server.
+     * May contain spaces.
      */
     name: string
-    version: string
+
     /**
-     * Custom Client ID value, set based on client extension internal business logic.
-     * Can be used to uniquely identify installations of Client extension.
+     * Client extension version.
      */
-    clientId?: string
+    version: string
+
+    /**
+     * Unique extension installation ID, as defined by the client extension.
+     */
+    extensionInstallationId?: string
+
+    /**
+     * Information about a client platform (editor or tool), in which extension runs.
+     * Use to pass additional or customised information, not available from standard InitializeParams.clientInfo field.
+     */
+    clientPlatform?: AWSClientPlatformInfo
 }
 
 /**
- * Information about a Platform or environment.
- * Use it to pass information about IDE or text editor, in which Client extension is running.
+ * Information about the client application, in which Client extension is running.
+ * Standard LSP supports passing information about client environment in InitializeParams.clientInfo field during initialization,
+ * but the values can not be modified by custom extensions.
  */
-export interface AWSPlatformInitializationOptions {
+export interface AWSClientPlatformInfo {
     /**
-     * Platform name, may contain spaces.
+     * Client platform name, defined by client extension in which it is running.
+     * May contain spaces.
      */
     name: string
+    /**
+     * Client platform version.
+     */
     version: string
 }
 
 export interface AWSInitializationOptions {
-    clientInfo?: AWSClientInfoInitializationOptions
-    platformInfo?: AWSPlatformInitializationOptions
+    clientExtensionInfo?: ClientExtensionInfo
 }
 
 /**
@@ -88,7 +104,7 @@ export interface InitializeParams extends _InitializeParamsBase {
 /**
  * Custom AWS Runtimes InitializeResult object interface with extended options.
  */
-export interface InitializeResult extends InitializeResultBase {
+export interface InitializeResult extends _InitializeResultBase {
     /**
      * The server signals custom AWS Runtimes capabilities it supports.
      */

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -42,33 +42,36 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
 }
 
 /**
- * Extra Client information passed during initialization handshake from Client to Server.
+ * Custom Client extension information passed during initialization handshake from Client to Server.
  */
-export interface AWSClientInitializationOptions {
+export interface AWSClientInfoInitializationOptions {
     /**
-     * Custom client branding information.
+     * Client extension name, may contain spaces.
      */
-    product?: {
-        /**
-         * Product name, may contain spaces.
-         */
-        name: string
-        version: string
-    }
-    /**
-     * Client host platform information.
-     */
-    platform?: {
-        /**
-         * Platform name, may contain spaces.
-         */
-        name: string
-        version: string
-    }
+    name: string
+    version: string
     /**
      * Custom Client ID value, set based on client extension internal business logic.
+     * Can be used to uniquely identify installations of Client extension.
      */
     clientId?: string
+}
+
+/**
+ * Information about a Platform or environment.
+ * Use it to pass information about IDE or text editor, in which Client extension is running.
+ */
+export interface AWSPlatformInitializationOptions {
+    /**
+     * Platform name, may contain spaces.
+     */
+    name: string
+    version: string
+}
+
+export interface AWSInitializationOptions {
+    clientInfo?: AWSClientInfoInitializationOptions
+    platformInfo?: AWSPlatformInitializationOptions
 }
 
 /**
@@ -78,7 +81,7 @@ export interface AWSClientInitializationOptions {
 export interface InitializeParams extends _InitializeParamsBase {
     initializationOptions?: {
         [key: string]: any
-        aws: AWSClientInitializationOptions
+        aws: AWSInitializationOptions
     }
 }
 

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -53,12 +53,15 @@ export interface AWSClientInitializationOptions {
         version: string
     }
     /**
-     * Custom client host platform information.
+     * Client host platform information.
      */
     platform?: {
         name: string
         version: string
     }
+    /**
+     * Custom Client ID value, set based on client extension internal business logic.
+     */
     clientId?: string
 }
 

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -42,52 +42,49 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
 }
 
 /**
- * Custom Client extension information passed during initialization from Client to Server.
- * Use to identify extension and pass additional data, not available in standard InitializeParams object.
+ * Extended Client information, passed from client extension to server at initialization.
+ * Use to pass additional information about Client Extension, which connects to Language Server,
+ * when information in default LSP request is not enough.
  */
-export interface ClientExtensionInfo {
+export interface ExtendedClientInfo {
     /**
-     * Client Extension name, which is used for managing and interacting with AWS Language Server.
-     * May contain spaces.
+     * Client environment name. May represent IDE or host platform of the Extension.
      */
     name: string
 
     /**
-     * Client extension version.
+     * Client environment version.
      */
     version: string
 
     /**
-     * Unique extension installation ID, as defined by the client extension.
+     * Information about Client Extension passed during initialization from Client to Server.
+     * Use to identify extension and pass additional data, not available in standard InitializeParams object.
      */
-    extensionInstallationId?: string
+    extension: {
+        /**
+         * Client Extension name, which is used for managing and interacting with AWS Language Server.
+         * May contain spaces.
+         */
+        name: string
+
+        /**
+         * Client extension version.
+         */
+        version: string
+    }
 
     /**
-     * Information about a client platform (editor or tool), in which extension runs.
-     * Use to pass additional or customised information, not available from standard InitializeParams.clientInfo field.
+     * Unique client Id, defined by the client extension.
      */
-    clientPlatform?: AWSClientPlatformInfo
-}
-
-/**
- * Information about the client application, in which Client extension is running.
- * Standard LSP supports passing information about client environment in InitializeParams.clientInfo field during initialization,
- * but the values can not be modified by custom extensions.
- */
-export interface AWSClientPlatformInfo {
-    /**
-     * Client platform name, defined by client extension in which it is running.
-     * May contain spaces.
-     */
-    name: string
-    /**
-     * Client platform version.
-     */
-    version: string
+    clientId?: string
 }
 
 export interface AWSInitializationOptions {
-    clientExtensionInfo?: ClientExtensionInfo
+    /**
+     * Additional clientInfo to extend or override default data passed by LSP Client.
+     */
+    clientInfo?: ExtendedClientInfo
 }
 
 /**

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -262,15 +262,15 @@ describe('LspRouter', () => {
                 const params = {
                     initializationOptions: {
                         aws: {
-                            product: {
+                            clientInfo: {
                                 name: 'Test Client Product',
                                 version: '0.1.2',
+                                clientId: 'test-client-id',
                             },
-                            platform: {
+                            platformInfo: {
                                 name: 'Test Platform',
                                 version: '1.2.3',
                             },
-                            clientId: 'test-client-id',
                         },
                     },
                 } as InitializeParams
@@ -299,8 +299,8 @@ describe('LspRouter', () => {
                 const params = {
                     initializationOptions: {
                         aws: {
-                            product: {},
-                            platform: {},
+                            clientInfo: {},
+                            platformInfo: {},
                         },
                     },
                 } as InitializeParams

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -209,35 +209,7 @@ describe('LspRouter', () => {
                 assert(
                     initializeHandlerStub.calledWith({
                         awsRuntimeMetadata: {
-                            customUserAgent: 'AWS-Language-Servers AWS LSP Standalone/1.0.0',
-                        },
-                    })
-                )
-            })
-
-            it('should append custom client suffix to customUserAgent', async () => {
-                const initializeHandlerStub = sinon.stub().returns({
-                    capabilities: {},
-                })
-                lspRouter.servers.push(
-                    newServer({
-                        initializeHandler: initializeHandlerStub,
-                    })
-                )
-                const params = {
-                    initializationOptions: {
-                        aws: {
-                            customUserAgentSuffix: 'test-suffix/0.1.2',
-                        },
-                    },
-                } as InitializeParams
-                await initializeHandler(params, {} as CancellationToken)
-
-                assert(
-                    initializeHandlerStub.calledWith({
-                        ...params,
-                        awsRuntimeMetadata: {
-                            customUserAgent: 'AWS-Language-Servers AWS LSP Standalone/1.0.0 test-suffix/0.1.2',
+                            customUserAgent: 'AWS-Language-Servers AWS-LSP-Standalone/1.0.0',
                         },
                     })
                 )
@@ -272,7 +244,74 @@ describe('LspRouter', () => {
                 assert(
                     initializeServerHandlerStub.calledWith({
                         awsRuntimeMetadata: {
-                            customUserAgent: 'AWS-Language-Servers AWS LSP Standalone',
+                            customUserAgent: 'AWS-Language-Servers AWS-LSP-Standalone',
+                        },
+                    })
+                )
+            })
+
+            it('should append custom suffix to customUserAgent based on initializationOptions.aws data', async () => {
+                const initializeHandlerStub = sinon.stub().returns({
+                    capabilities: {},
+                })
+                lspRouter.servers.push(
+                    newServer({
+                        initializeHandler: initializeHandlerStub,
+                    })
+                )
+                const params = {
+                    initializationOptions: {
+                        aws: {
+                            product: {
+                                name: 'Test Client Product',
+                                version: '0.1.2',
+                            },
+                            platform: {
+                                name: 'Test Platform',
+                                version: '1.2.3',
+                            },
+                            clientId: 'test-client-id',
+                        },
+                    },
+                } as InitializeParams
+                await initializeHandler(params, {} as CancellationToken)
+
+                assert(
+                    initializeHandlerStub.calledWith({
+                        ...params,
+                        awsRuntimeMetadata: {
+                            customUserAgent:
+                                'AWS-Language-Servers AWS-LSP-Standalone/1.0.0 Test-Client-Product/0.1.2 Test-Platform/1.2.3 ClientId/test-client-id',
+                        },
+                    })
+                )
+            })
+
+            it('should fallback to UNKNOWN value, when product or platform fields are missing', async () => {
+                const initializeHandlerStub = sinon.stub().returns({
+                    capabilities: {},
+                })
+                lspRouter.servers.push(
+                    newServer({
+                        initializeHandler: initializeHandlerStub,
+                    })
+                )
+                const params = {
+                    initializationOptions: {
+                        aws: {
+                            product: {},
+                            platform: {},
+                        },
+                    },
+                } as InitializeParams
+                await initializeHandler(params, {} as CancellationToken)
+
+                assert(
+                    initializeHandlerStub.calledWith({
+                        ...params,
+                        awsRuntimeMetadata: {
+                            customUserAgent:
+                                'AWS-Language-Servers AWS-LSP-Standalone/1.0.0 UNKNOWN/UNKNOWN UNKNOWN/UNKNOWN',
                         },
                     })
                 )

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -1,5 +1,6 @@
 import {
-    AWSClientInitializationOptions,
+    AWSClientInfoInitializationOptions,
+    AWSInitializationOptions,
     CancellationToken,
     ExecuteCommandParams,
     InitializeError,
@@ -81,7 +82,7 @@ export class LspRouter {
         }
     }
 
-    getUserAgent = (opts: AWSClientInitializationOptions = {}): string => {
+    getUserAgent = (opts?: AWSInitializationOptions): string => {
         const format = (s: string) => s.replace(/\s/g, '-')
 
         const items: String[] = []
@@ -99,18 +100,18 @@ export class LspRouter {
         // Compute client-specific suffix
         // Missing required data fields are replaced with 'UNKNOWN' token
         // Whitespaces in product.name and platform.name are replaced to '-'
-        const { product, platform, clientId } = opts
+        const { clientInfo: client, platformInfo: platform } = opts || {}
 
-        if (product) {
-            items.push(`${product.name ? format(product.name) : 'UNKNOWN'}/${product.version || 'UNKNOWN'}`)
+        if (client) {
+            items.push(`${client.name ? format(client.name) : 'UNKNOWN'}/${client.version || 'UNKNOWN'}`)
         }
 
         if (platform) {
             items.push(`${platform.name ? format(platform.name) : 'UNKNOWN'}/${platform.version || 'UNKNOWN'}`)
         }
 
-        if (clientId) {
-            items.push(`ClientId/${clientId}`)
+        if (client?.clientId) {
+            items.push(`ClientId/${client?.clientId}`)
         }
 
         return items.join(' ')

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -50,7 +50,6 @@ export class LspRouter {
                 s.initialize(
                     {
                         ...params,
-                        // Inject Runtimes-computed metadata, shareable by all servers.
                         awsRuntimeMetadata: {
                             customUserAgent: this.getUserAgent(params.initializationOptions?.aws),
                         },
@@ -82,29 +81,18 @@ export class LspRouter {
         }
     }
 
-    getUserAgent = (params?: AWSClientInitializationOptions): string => {
+    getUserAgent = (opts: AWSClientInitializationOptions = {}): string => {
         const items: String[] = []
 
         // Standard prefix for all Language Server Runtimes artifacts
         items.push(USER_AGENT_PREFIX)
 
-        // Fields, specific to runtime artifact
-        items.push(`${this.name}/${this.version}`)
+        // Fields specific to runtime artifact
+        items.push(`${this.name || 'UNKNOWN'}/${this.version || 'UNKNOWN'}`)
 
         // Compute client-specific suffix
-        const { product, platform, clientId } = params || {}
-
-        if (product?.name && product?.version) {
-            items.push(`${product.name}/${product.version}`)
-        }
-
-        if (platform?.name && platform?.version) {
-            items.push(`${platform.name}/${platform.version}`)
-        }
-
-        if (clientId) {
-            items.push(`CliendId/${clientId}`)
-        }
+        const { customUserAgentSuffix = '' } = opts
+        items.push(customUserAgentSuffix)
 
         return items.join(' ')
     }

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -82,6 +82,8 @@ export class LspRouter {
     }
 
     getUserAgent = (opts: AWSClientInitializationOptions = {}): string => {
+        const format = (s: string) => s.replace(/\s/g, '-')
+
         const items: String[] = []
 
         // Standard prefix for all Language Server Runtimes artifacts
@@ -89,14 +91,26 @@ export class LspRouter {
 
         // Fields specific to runtime artifact
         if (this.version) {
-            items.push(`${this.name}/${this.version}`)
+            items.push(`${format(this.name)}/${this.version}`)
         } else {
-            items.push(`${this.name}`)
+            items.push(format(this.name))
         }
 
         // Compute client-specific suffix
-        if (opts.customUserAgentSuffix) {
-            items.push(opts.customUserAgentSuffix)
+        // Missing required data fields are replaced with 'UNKNOWN' token
+        // Whitespaces in product.name and platform.name are replaced to '-'
+        const { product, platform, clientId } = opts
+
+        if (product) {
+            items.push(`${product.name ? format(product.name) : 'UNKNOWN'}/${product.version || 'UNKNOWN'}`)
+        }
+
+        if (platform) {
+            items.push(`${platform.name ? format(platform.name) : 'UNKNOWN'}/${platform.version || 'UNKNOWN'}`)
+        }
+
+        if (clientId) {
+            items.push(`ClientId/${clientId}`)
         }
 
         return items.join(' ')

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -12,7 +12,7 @@ import { Connection } from 'vscode-languageserver/node'
 import { LspServer } from './lspServer'
 import { mergeObjects } from './util'
 
-const USER_AGENT_PREFIX = 'AWS-LS-Runtime'
+const USER_AGENT_PREFIX = 'AWS-Language-Servers'
 
 export class LspRouter {
     public clientInitializeParams?: InitializeParams
@@ -88,11 +88,16 @@ export class LspRouter {
         items.push(USER_AGENT_PREFIX)
 
         // Fields specific to runtime artifact
-        items.push(`${this.name || 'UNKNOWN'}/${this.version || 'UNKNOWN'}`)
+        if (this.version) {
+            items.push(`${this.name}/${this.version}`)
+        } else {
+            items.push(`${this.name}`)
+        }
 
         // Compute client-specific suffix
-        const { customUserAgentSuffix = '' } = opts
-        items.push(customUserAgentSuffix)
+        if (opts.customUserAgentSuffix) {
+            items.push(opts.customUserAgentSuffix)
+        }
 
         return items.join(' ')
     }

--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -2,11 +2,10 @@ import {
     CancellationToken,
     ExecuteCommandParams,
     InitializeError,
-    InitializeParams,
     RequestHandler,
     ResponseError,
 } from '../../../protocol'
-import { PartialInitializeResult, PartialServerCapabilities } from '../../../server-interface/lsp'
+import { InitializeParams, PartialInitializeResult, PartialServerCapabilities } from '../../../server-interface/lsp'
 import { asPromise } from './util'
 
 export class LspServer {

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -12,7 +12,7 @@ import {
     Hover,
     HoverParams,
     InitializeError,
-    InitializeParams,
+    InitializeParams as _ProtocolInitializeParams,
     InitializedParams,
     InlineCompletionItem,
     InlineCompletionItemWithReferences,
@@ -55,6 +55,21 @@ export type PartialInitializeResult<T = any> = {
     capabilities: PartialServerCapabilities<T>
     awsServerCapabilities?: {
         chatOptions?: ChatOptions
+    }
+}
+
+/**
+ * Extended InitializeParams passed to Capability Server implementation from Language Server Runtime.
+ * Custom runtime metadata is mixed in to the data passed down from the client and is extended with shared data,
+ * standardized in runtime implementation and shared by all servers.
+ */
+export interface InitializeParams extends _ProtocolInitializeParams {
+    awsRuntimeMetadata?: {
+        /**
+         * Custom UserAgent value computed by the Runtime. Standard for all servers.
+         * Suitable for setting predictable UserAgent for HTTP requests or configuring AWS SDK calls.
+         */
+        customUserAgent?: string
     }
 }
 

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -58,18 +58,12 @@ export type PartialInitializeResult<T = any> = {
     }
 }
 
-/**
- * Extended InitializeParams passed to Capability Server implementation from Language Server Runtime.
- * Custom runtime metadata is mixed in to the data passed down from the client,
- * standardized by runtimes implementation and shared with all servers.
- */
 export interface InitializeParams extends _ProtocolInitializeParams {
     awsRuntimeMetadata?: {
-        /**
-         * Custom UserAgent value, computed by the Runtime.
-         * Suitable for setting predictable UserAgent for HTTP requests or configuring AWS SDK calls.
-         */
-        customUserAgent?: string
+        serverInfo?: {
+            name: string
+            version?: string
+        }
     }
 }
 

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -60,13 +60,13 @@ export type PartialInitializeResult<T = any> = {
 
 /**
  * Extended InitializeParams passed to Capability Server implementation from Language Server Runtime.
- * Custom runtime metadata is mixed in to the data passed down from the client and is extended with shared data,
- * standardized in runtime implementation and shared by all servers.
+ * Custom runtime metadata is mixed in to the data passed down from the client,
+ * standardized by runtimes implementation and shared with all servers.
  */
 export interface InitializeParams extends _ProtocolInitializeParams {
     awsRuntimeMetadata?: {
         /**
-         * Custom UserAgent value computed by the Runtime. Standard for all servers.
+         * Custom UserAgent value, computed by the Runtime.
          * Suitable for setting predictable UserAgent for HTTP requests or configuring AWS SDK calls.
          */
         customUserAgent?: string


### PR DESCRIPTION
## Problem

Currently Server implementations don't have access to actual information about client host environment, which can be used to construct detailed metadata. Such data can be used in cases, when connected clients and host environments need to be unambiguously identified, for example to attach granular UserAgent header for HTTP calls or AWS SDK calls done by the server.

## Solution
* Extended Language Server Protocol `InitializeParams` sent from LSP Client to the Runtime. This PR proposes to use unspecified standard `initializationOptions` field, and extend it with custom `aws` property, which isolates data for AWS Runtimes.
* Extended `InitializeParams` params passed from the Runtime to Server implementation, defined in `server-interface/lsp` interface.
* When Server's initialize method is called at startup, new `awsRuntimeMetadata` field is added, with interface specific for Runtimes. `customUserAgent` value is computed using data passed in new `initializationOptions.aws` and passed down each Server at initialization.
* Since userAgent field is highly specific for each language server implementation, we leave computation of the value based of available fields up to Server implementation

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
