### PR TITLE
Update runtimes version to 0.2.14

### DIFF
--- a/runtimes/CHANGELOG.md
+++ b/runtimes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.14] - 2024-08-30
+
+- Extend LSP InitializeParams with custom `initializationInfo.aws` object to accept more custom data from client
+- Add new `Runtime` Feature, passed from runtime to Server impementation during initialization
+
 ## [0.2.13] - 2024-08-16
 
 - Add support for window/showDocument, window/showMessage and window/showMessageRequest LSP handler

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.13",
+    "version": "0.2.14",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",


### PR DESCRIPTION
## Description

Release Language Server Runtimes v0.2.14

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
