### PR TITLE
Honor shared aws config file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2340,7 +2340,7 @@
         },
         "runtimes": {
             "name": "@aws/language-server-runtimes",
-            "version": "0.2.13",
+            "version": "0.2.15",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.6",

--- a/runtimes/CHANGELOG.md
+++ b/runtimes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.15] - 2024-09-06
+
+- Honor shared aws config file in the standalone runtime
+
 ## [0.2.14] - 2024-08-30
 
 - Extend LSP InitializeParams with custom `initializationInfo.aws` object to accept more custom data from client

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.14",
+    "version": "0.2.15",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -39,6 +39,12 @@ import * as path from 'path'
 import { LspRouter } from './lsp/router/lspRouter'
 import { LspServer } from './lsp/router/lspServer'
 import { BaseChat } from './chat/baseChat'
+import { checkAWSConfigFile } from './util/sharedConfigFile'
+
+// Honor shared aws config file
+if (checkAWSConfigFile()) {
+    process.env.AWS_SDK_LOAD_CONFIG = '1'
+}
 
 /**
  * The runtime for standalone LSP-based servers.

--- a/runtimes/runtimes/util/sharedConfigFile.ts
+++ b/runtimes/runtimes/util/sharedConfigFile.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The implementation is inspired by https://github.com/aws/aws-toolkit-vscode/blob/2c8d6667ec45f747db25f456a524e50242ff454b/packages/core/src/auth/credentials/sharedCredentialsFile.ts#L44
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+export function checkAWSConfigFile(): boolean {
+    const awsConfigFile = process.env.AWS_CONFIG_FILE
+    if (awsConfigFile) {
+        return fs.existsSync(awsConfigFile)
+    } else {
+        const homedir = os.homedir()
+        const defaultConfigPath = path.join(homedir, '.aws', 'config')
+        return fs.existsSync(defaultConfigPath)
+    }
+}


### PR DESCRIPTION
## Problem
The shared aws config isn't honored by JS SDK by default. 
If a customer has CA certificate bundle set in the config then it will be ignored by the JS SDK inside the LSP server which can lead to failures.

## Solution
Setting `AWS_SDK_LOAD_CONFIG` environment variable in the standalone runtime so that the shared config is honored by default.
However, if we set this environment variable unconditionally the process will fail if there is no shared config on the file system. That's why we need to first check if the file exists. 
Also, SDK will check `AWS_CONFIG_FILE` environment variable that can override the default location. 

This solution inspired by https://github.com/aws/aws-toolkit-vscode/blob/2c8d6667ec45f747db25f456a524e50242ff454b/packages/core/src/auth/credentials/sharedCredentialsFile.ts#L44

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
