### PR TITLE
Add example of service injection in the runtime

### DIFF
--- a/runtimes/examples/buildConfigurationWithServices.ts
+++ b/runtimes/examples/buildConfigurationWithServices.ts
@@ -1,0 +1,19 @@
+/**
+ * This is example configuration of creating a bundle with only custom AuthManagementService injected into standalone runtime.
+ * This setup produces a server, that only handles AuthManagement LSP requests.
+ */
+
+import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
+import { standalone } from '@aws/language-server-runtimes/runtimes/standalone'
+import { createAuthManagementService } from '../testing/TestAuthManagementService'
+
+const props: RuntimeProps = {
+    version: '0.1.0',
+    servers: [], // Bundle does not contain any reusable Server implementations
+    name: 'Example Auth Management Server Bundle',
+    services: {
+        // Inject custom AuthManagementService implementation in the build.
+        auth: createAuthManagementService,
+    },
+}
+standalone(props)

--- a/runtimes/protocol/authManagement.ts
+++ b/runtimes/protocol/authManagement.ts
@@ -1,0 +1,22 @@
+import { ProtocolRequestType } from './lsp'
+
+export type ListProfilesParams = {}
+export type ListProfilesResult = {
+    profiles?: any[]
+    ssoSessions?: any[]
+}
+export type ListProfilesError = {}
+export const listProfilesRequestType = new ProtocolRequestType<
+    ListProfilesParams,
+    ListProfilesResult,
+    never,
+    ListProfilesError,
+    void
+>('aws/auth/profiles')
+
+// TODO: define rest of protocol here
+// updateProfile
+// getSsoToken
+// invalidateSsoToken
+// updateSsoTokenManagement
+// ssoTokenChanged

--- a/runtimes/runtimes/runtime.ts
+++ b/runtimes/runtimes/runtime.ts
@@ -1,4 +1,5 @@
 import { Server } from '../server-interface'
+import { AuthManagmentServiceHandlerFactory } from './services/authManagementService'
 
 /**
  * Properties used for runtime initialisation
@@ -16,4 +17,12 @@ export type RuntimeProps = {
      * Name of the server used inside the runtime
      */
     name: string
+    /**
+     * Implementation handlers for runtimes services, providing features that are isolated from Server implementations
+     * Services allow to inject specific implemenations of a functionality that mush be served by only one implementation
+     * and can not be broadcasted to multiple implementations.
+     */
+    services?: {
+        auth?: AuthManagmentServiceHandlerFactory
+    }
 }

--- a/runtimes/runtimes/runtime.ts
+++ b/runtimes/runtimes/runtime.ts
@@ -1,5 +1,5 @@
 import { Server } from '../server-interface'
-import { AuthManagmentServiceHandlerFactory } from './services/authManagementService'
+import { AuthManagmentServiceHandlerFactory } from './services/authManagement'
 
 /**
  * Properties used for runtime initialisation

--- a/runtimes/runtimes/services/authManagement.ts
+++ b/runtimes/runtimes/services/authManagement.ts
@@ -20,7 +20,7 @@ export type AuthManagmentServiceHandlerFactory = () => {
 /**
  * Service registers LSP method handlers and binds them to registered Service implementation handlers.
  */
-export class AuthManagementService {
+export class AuthManagement {
     constructor(
         private readonly connection: Connection,
         private readonly handlersFactory: AuthManagmentServiceHandlerFactory,

--- a/runtimes/runtimes/services/authManagementService.ts
+++ b/runtimes/runtimes/services/authManagementService.ts
@@ -1,0 +1,47 @@
+import { Connection } from 'vscode-languageserver'
+import { CredentialsEncoding } from '../auth/standalone/encryption'
+import {
+    ListProfilesError,
+    ListProfilesParams,
+    ListProfilesResult,
+    listProfilesRequestType,
+} from '../../protocol/authManagement'
+
+export type AuthManagmentServiceHandlerFactory = () => {
+    listProfiles: (params: ListProfilesParams) => ListProfilesResult | ListProfilesError
+    // TODO: define the rest of the handlers
+    updateProfile: () => void
+    getSsoToken: () => void
+    invalidateSsoToken: () => void
+    updateSsoTokenManagement: () => void
+    ssoTokenChanged: () => void
+}
+
+/**
+ * Service registers LSP method handlers and binds them to registered Service implementation handlers.
+ */
+export class AuthManagementService {
+    constructor(
+        private readonly connection: Connection,
+        private readonly handlersFactory: AuthManagmentServiceHandlerFactory,
+        key?: string,
+        encoding?: CredentialsEncoding
+    ) {
+        // Working with encoding messages will be encapsulated in the runtime Service.
+
+        this.registerHandlers()
+    }
+
+    private registerHandlers() {
+        const handlers = this.handlersFactory()
+
+        this.connection.onRequest(listProfilesRequestType, handlers.listProfiles)
+
+        // TODO: register rest of handlers here
+        // updateProfile
+        // getSsoToken
+        // invalidateSsoToken
+        // updateSsoTokenManagement
+        // ssoTokenChanged
+    }
+}

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -39,6 +39,7 @@ import * as path from 'path'
 import { LspRouter } from './lsp/router/lspRouter'
 import { LspServer } from './lsp/router/lspServer'
 import { BaseChat } from './chat/baseChat'
+import { AuthManagementService } from './services/authManagementService'
 
 /**
  * The runtime for standalone LSP-based servers.
@@ -72,6 +73,7 @@ export const standalone = (props: RuntimeProps) => {
 
     let auth: Auth
     let chat: Chat
+    let authManagementService: AuthManagementService
     initializeAuth()
 
     // Initialize Auth service
@@ -87,6 +89,16 @@ export const standalone = (props: RuntimeProps) => {
                     auth = new Auth(lspConnection, encryptionDetails.key, encryptionDetails.mode)
                     chat = new EncryptedChat(lspConnection, encryptionDetails.key, encryptionDetails.mode)
                     initializeRuntime(encryptionDetails.key)
+
+                    // Initialize optional services.Auth Service
+                    if (props.services?.auth) {
+                        authManagementService = new AuthManagementService(
+                            lspConnection,
+                            props.services.auth,
+                            encryptionDetails.key,
+                            encryptionDetails.mode
+                        )
+                    }
                 },
                 error => {
                     console.error(error)
@@ -96,6 +108,10 @@ export const standalone = (props: RuntimeProps) => {
         } else {
             lspConnection.console.info('Runtime: Initializing runtime without encryption')
             auth = new Auth(lspConnection)
+
+            if (props.services?.auth) {
+                authManagementService = new AuthManagementService(lspConnection, props.services.auth)
+            }
 
             initializeRuntime()
         }

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -39,7 +39,7 @@ import * as path from 'path'
 import { LspRouter } from './lsp/router/lspRouter'
 import { LspServer } from './lsp/router/lspServer'
 import { BaseChat } from './chat/baseChat'
-import { AuthManagementService } from './services/authManagementService'
+import { AuthManagement } from './services/authManagement'
 
 /**
  * The runtime for standalone LSP-based servers.
@@ -72,8 +72,8 @@ export const standalone = (props: RuntimeProps) => {
     const documentsObserver = observe(lspConnection)
 
     let auth: Auth
+    let authManagement: AuthManagement
     let chat: Chat
-    let authManagementService: AuthManagementService
     initializeAuth()
 
     // Initialize Auth service
@@ -92,7 +92,7 @@ export const standalone = (props: RuntimeProps) => {
 
                     // Initialize optional services.Auth Service
                     if (props.services?.auth) {
-                        authManagementService = new AuthManagementService(
+                        authManagement = new AuthManagement(
                             lspConnection,
                             props.services.auth,
                             encryptionDetails.key,
@@ -110,7 +110,7 @@ export const standalone = (props: RuntimeProps) => {
             auth = new Auth(lspConnection)
 
             if (props.services?.auth) {
-                authManagementService = new AuthManagementService(lspConnection, props.services.auth)
+                authManagement = new AuthManagement(lspConnection, props.services.auth)
             }
 
             initializeRuntime()

--- a/runtimes/testing/TestAuthManagementService.ts
+++ b/runtimes/testing/TestAuthManagementService.ts
@@ -1,0 +1,21 @@
+import { AuthManagmentServiceHandlerFactory } from '../runtimes/services/authManagementService'
+import { ListProfilesParams } from '../protocol/authManagement'
+
+/**
+ * Example of implementation of AuthManagementService.
+ * It implements handlers required to server AuthManagement calls,
+ * proxied from integrating destination by AuthManagementService in ../runtimes/services/authManagementService.ts
+ */
+export const createAuthManagementService: AuthManagmentServiceHandlerFactory = () => ({
+    listProfiles: (_params: ListProfilesParams) => {
+        return {
+            profiles: [],
+            ssoSessions: [],
+        }
+    },
+    updateProfile: () => {},
+    getSsoToken: () => {},
+    invalidateSsoToken: () => {},
+    updateSsoTokenManagement: () => {},
+    ssoTokenChanged: () => {},
+})

--- a/runtimes/testing/TestAuthManagementService.ts
+++ b/runtimes/testing/TestAuthManagementService.ts
@@ -1,4 +1,4 @@
-import { AuthManagmentServiceHandlerFactory } from '../runtimes/services/authManagementService'
+import { AuthManagmentServiceHandlerFactory } from '../runtimes/services/authManagement'
 import { ListProfilesParams } from '../protocol/authManagement'
 
 /**


### PR DESCRIPTION
## Problem

Some of functionality exposed by runtimes must be served only by single handling service. Current handlers injection model allows to inject a set of `Server` interface implementations, each getting access to number of features (`LSP`, `Telemetry`, `Chat`, `Workspace`, etc.). With current model, each server may handle and respond to incoming requests following their own business logic. 

This poses a problem for cases when a protocol extension can properly function only when served by one handling server and must not be interfered by other servers. One example identified in Auth management feature.

## Solution

One identified solution is add second extension point called `services` to the interface of runtimes functions in `RuntimeProps` and accept implementation handlers for predefined set of protocol handlers. Each service in the list will be unique and will be able to serve it's own predefined set of custom LSP requests. LSP requests are defined in and part of `runtimes/protocol`.

Services implementations can be passed to the runtime at build time in BuildConfiguration file. This way, consumer of resulting language server bundle is controlling with functionality they want to inject into their bundle. The decision where to host business logic will be up to developer.

This PR demonstrates PoC implementation of this mechanism for AuthManagement feature.
* Example of build configuration is in `runtimes/examples/buildConfigurationWithServices.ts`
* Example of business logic handler implementation is in `runtimes/testing/TestAuthManagementService.ts`
* Wiring LSP requests to handers is done in https://github.com/aws/language-server-runtimes/pull/201/files#diff-4bede657896036903a4019c3fd2c3fc4d8d2c1bfb0735ff2d58e4baa67db173dR23-R47
* Final Protocol API is TBD

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
