### PR TITLE
Add getAllTextDocuments method to Workspace feature

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -138,7 +138,7 @@ export const standalone = (props: RuntimeProps) => {
         // Set up the workspace sync to use the LSP Text Document Sync capability
         const workspace: Workspace = {
             getTextDocument: async uri => documents.get(uri),
-            getAllTextDocuments: () => documents.all(),
+            getAllTextDocuments: async () => documents.all(),
             // Get all workspace folders and return the workspace folder that contains the uri
             getWorkspaceFolder: uri => {
                 const fileUrl = new URL(uri)

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -138,7 +138,7 @@ export const standalone = (props: RuntimeProps) => {
         // Set up the workspace sync to use the LSP Text Document Sync capability
         const workspace: Workspace = {
             getTextDocument: async uri => documents.get(uri),
-            getAllTextDocuments: async () => documents.all(),
+            getAllTextDocuments: () => documents.all(),
             // Get all workspace folders and return the workspace folder that contains the uri
             getWorkspaceFolder: uri => {
                 const fileUrl = new URL(uri)

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -138,6 +138,7 @@ export const standalone = (props: RuntimeProps) => {
         // Set up the workspace sync to use the LSP Text Document Sync capability
         const workspace: Workspace = {
             getTextDocument: async uri => documents.get(uri),
+            getAllTextDocuments: async () => documents.all(),
             // Get all workspace folders and return the workspace folder that contains the uri
             getWorkspaceFolder: uri => {
                 const fileUrl = new URL(uri)

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -75,7 +75,7 @@ export const webworker = (props: RuntimeProps) => {
     // Set up the workspace to use the LSP Text Documents component
     const workspace: Workspace = {
         getTextDocument: async uri => documents.get(uri),
-        getAllTextDocuments: async () => documents.all(),
+        getAllTextDocuments: () => documents.all(),
         getWorkspaceFolder: _uri =>
             lspRouter.clientInitializeParams!.workspaceFolders && lspRouter.clientInitializeParams!.workspaceFolders[0],
         fs: {

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -75,6 +75,7 @@ export const webworker = (props: RuntimeProps) => {
     // Set up the workspace to use the LSP Text Documents component
     const workspace: Workspace = {
         getTextDocument: async uri => documents.get(uri),
+        getAllTextDocuments: async () => documents.all(),
         getWorkspaceFolder: _uri =>
             lspRouter.clientInitializeParams!.workspaceFolders && lspRouter.clientInitializeParams!.workspaceFolders[0],
         fs: {

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -75,7 +75,7 @@ export const webworker = (props: RuntimeProps) => {
     // Set up the workspace to use the LSP Text Documents component
     const workspace: Workspace = {
         getTextDocument: async uri => documents.get(uri),
-        getAllTextDocuments: () => documents.all(),
+        getAllTextDocuments: async () => documents.all(),
         getWorkspaceFolder: _uri =>
             lspRouter.clientInitializeParams!.workspaceFolders && lspRouter.clientInitializeParams!.workspaceFolders[0],
         fs: {

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -16,7 +16,7 @@ interface Dirent {
  */
 export type Workspace = {
     getTextDocument: (uri: string) => Promise<TextDocument | undefined>
-    getAllTextDocuments: () => TextDocument[]
+    getAllTextDocuments: () => Promise<TextDocument[]>
     getWorkspaceFolder: (uri: string) => WorkspaceFolder | null | undefined
     fs: {
         copy: (src: string, dest: string) => Promise<void>

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -16,6 +16,7 @@ interface Dirent {
  */
 export type Workspace = {
     getTextDocument: (uri: string) => Promise<TextDocument | undefined>
+    getAllTextDocuments: () => Promise<TextDocument[]>
     getWorkspaceFolder: (uri: string) => WorkspaceFolder | null | undefined
     fs: {
         copy: (src: string, dest: string) => Promise<void>

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -16,7 +16,7 @@ interface Dirent {
  */
 export type Workspace = {
     getTextDocument: (uri: string) => Promise<TextDocument | undefined>
-    getAllTextDocuments: () => Promise<TextDocument[]>
+    getAllTextDocuments: () => TextDocument[]
     getWorkspaceFolder: (uri: string) => WorkspaceFolder | null | undefined
     fs: {
         copy: (src: string, dest: string) => Promise<void>

--- a/runtimes/testing/TestFeatures.ts
+++ b/runtimes/testing/TestFeatures.ts
@@ -62,6 +62,7 @@ export class TestFeatures {
         this.identityManagement = stubInterface<IdentityManagement>()
 
         this.workspace.getTextDocument.callsFake(async uri => this.documents[uri])
+        this.workspace.getAllTextDocuments.callsFake(async () => Object.values(this.documents))
     }
 
     async start(server: Server) {


### PR DESCRIPTION
## Problem
Workspace feature does not expose function to get all open files in the IDE.

## Solution

Added new method `getAllTextDocuments` which returns all documents managed by LSP server.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
