### PR TITLE
Add routing to initialized and didChangeConfiguration notifications

### DIFF
--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -1,8 +1,11 @@
 import {
     CancellationToken,
+    DidChangeConfigurationParams,
     ExecuteCommandParams,
     GetConfigurationFromServerParams,
+    InitializedParams,
     InitializeError,
+    NotificationHandler,
     RequestHandler,
     ResponseError,
 } from '../../../protocol'
@@ -10,11 +13,21 @@ import { InitializeParams, PartialInitializeResult, PartialServerCapabilities } 
 import { asPromise } from './util'
 
 export class LspServer {
-    private initializeHandler?: RequestHandler<InitializeParams, PartialInitializeResult, InitializeError>
+    private didChangeConfigurationHandler?: NotificationHandler<DidChangeConfigurationParams>
     private executeCommandHandler?: RequestHandler<ExecuteCommandParams, any | undefined | null, void>
     private getServerConfigurationHandler?: RequestHandler<GetConfigurationFromServerParams, any, void>
+    private initializeHandler?: RequestHandler<InitializeParams, PartialInitializeResult, InitializeError>
+    private initializedHandler?: NotificationHandler<InitializedParams>
     private serverCapabilities?: PartialServerCapabilities
     private awsServerCapabilities?: PartialInitializeResult['awsServerCapabilities']
+
+    public setInitializedHandler = (handler: NotificationHandler<InitializedParams>): void => {
+        this.initializedHandler = handler
+    }
+
+    public setDidChangeConfigurationHandler = (handler: NotificationHandler<DidChangeConfigurationParams>): void => {
+        this.didChangeConfigurationHandler = handler
+    }
 
     public setInitializeHandler = (
         handler: RequestHandler<InitializeParams, PartialInitializeResult, InitializeError>
@@ -79,5 +92,17 @@ export class LspServer {
         }
 
         return [false, undefined]
+    }
+
+    public sendDidChangeConfigurationNotification = (params: DidChangeConfigurationParams): void => {
+        if (this.didChangeConfigurationHandler) {
+            this.didChangeConfigurationHandler(params)
+        }
+    }
+
+    public sendInitializedNotification = (params: InitializedParams): void => {
+        if (this.initializedHandler) {
+            this.initializedHandler(params)
+        }
     }
 }

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -1,8 +1,6 @@
 import { TextDocuments } from 'vscode-languageserver'
 import {
-    DidChangeConfigurationNotification,
     DidChangeWorkspaceFoldersNotification,
-    getConfigurationFromServerRequestType,
     ProgressToken,
     ProgressType,
     PublishDiagnosticsNotification,
@@ -207,18 +205,10 @@ export const standalone = (props: RuntimeProps) => {
             // Set up LSP events handlers per server
             const lsp: Lsp = {
                 addInitializer: lspServer.setInitializeHandler,
-                onInitialized: handler =>
-                    lspConnection.onInitialized(p => {
-                        const workspaceCapabilities = lspRouter.clientInitializeParams?.capabilities.workspace
-                        if (workspaceCapabilities?.didChangeConfiguration?.dynamicRegistration) {
-                            // Ask the client to notify the server on configuration changes
-                            lspConnection.client.register(DidChangeConfigurationNotification.type, undefined)
-                        }
-                        handler(p)
-                    }),
+                onInitialized: lspServer.setInitializedHandler,
                 onCompletion: handler => lspConnection.onCompletion(handler),
                 onInlineCompletion: handler => lspConnection.onRequest(inlineCompletionRequestType, handler),
-                didChangeConfiguration: handler => lspConnection.onDidChangeConfiguration(handler),
+                didChangeConfiguration: lspServer.setDidChangeConfigurationHandler,
                 onDidFormatDocument: handler => lspConnection.onDocumentFormatting(handler),
                 onDidOpenTextDocument: handler => documentsObserver.callbacks.onDidOpenTextDocument(handler),
                 onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),


### PR DESCRIPTION
## Description

- Added routing for `didChangeConfiguration` and `initialized` notifications so that all servers in a bundle will get the notifications instead of the last server that registered a handler 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
