### PR TITLE
Add listProfiles and updateProfile with ProfileService and store

### DIFF
--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -1,5 +1,6 @@
-import { ProtocolNotificationType, ProtocolRequestType } from './lsp'
+import { LSPErrorCodes, ProtocolNotificationType, ProtocolRequestType, ResponseError } from './lsp'
 
+// Errors
 export type E_UNKNOWN = 'E_UNKNOWN'
 export type E_TIMEOUT = 'E_TIMEOUT'
 export type E_RUNTIME_NOT_SUPPORTED = 'E_RUNTIME_NOT_SUPPORTED'
@@ -9,49 +10,99 @@ export type E_CANNOT_WRITE_SHARED_CONFIG = 'E_CANNOT_WRITE_SHARED_CONFIG'
 export type E_CANNOT_READ_SSO_CACHE = 'E_CANNOT_READ_SSO_CACHE'
 export type E_CANNOT_WRITE_SSO_CACHE = 'E_CANNOT_WRITE_SSO_CACHE'
 export type E_PROFILE_NOT_FOUND = 'E_PROFILE_NOT_FOUND'
+export type E_CANNOT_CREATE_PROFILE = 'E_CANNOT_CREATE_PROFILE'
 export type E_CANNOT_OVERWRITE_PROFILE = 'E_CANNOT_OVERWRITE_PROFILE'
 export type E_INVALID_PROFILE = 'E_INVALID_PROFILE'
 export type E_SSO_SESSION_NOT_FOUND = 'E_SSO_SESSION_NOT_FOUND'
+export type E_CANNOT_CREATE_SSO_SESSION = 'E_CANNOT_CREATE_SSO_SESSION'
 export type E_CANNOT_OVERWRITE_SSO_SESSION = 'E_CANNOT_OVERWRITE_SSO_SESSION'
 export type E_INVALID_SSO_SESSION = 'E_INVALID_SSO_SESSION'
 export type E_INVALID_TOKEN = 'E_INVALID_TOKEN'
 
-export type ListProfilesParams = {}
-export type SsoTokenProfileKind = 'SsoToken'
+export const AwsErrorCodes = {
+    E_UNKNOWN: 'E_UNKNOWN',
+    E_TIMEOUT: 'E_TIMEOUT',
+    E_RUNTIME_NOT_SUPPORTED: 'E_RUNTIME_NOT_SUPPORTED',
+    E_ENCRYPTION_REQUIRED: 'E_ENCRYPTION_REQUIRED',
+    E_CANNOT_READ_SHARED_CONFIG: 'E_CANNOT_READ_SHARED_CONFIG',
+    E_CANNOT_WRITE_SHARED_CONFIG: 'E_CANNOT_WRITE_SHARED_CONFIG',
+    E_CANNOT_READ_SSO_CACHE: 'E_CANNOT_READ_SSO_CACHE',
+    E_CANNOT_WRITE_SSO_CACHE: 'E_CANNOT_WRITE_SSO_CACHE',
+    E_PROFILE_NOT_FOUND: 'E_PROFILE_NOT_FOUND',
+    E_CANNOT_CREATE_PROFILE: 'E_CANNOT_CREATE_PROFILE',
+    E_CANNOT_OVERWRITE_PROFILE: 'E_CANNOT_OVERWRITE_PROFILE',
+    E_INVALID_PROFILE: 'E_INVALID_PROFILE',
+    E_SSO_SESSION_NOT_FOUND: 'E_SSO_SESSION_NOT_FOUND',
+    E_CANNOT_CREATE_SSO_SESSION: 'E_CANNOT_CREATE_SSO_SESSION',
+    E_CANNOT_OVERWRITE_SSO_SESSION: 'E_CANNOT_OVERWRITE_SSO_SESSION',
+    E_INVALID_SSO_SESSION: 'E_INVALID_SSO_SESSION',
+    E_INVALID_TOKEN: 'E_INVALID_TOKEN',
+} as const
 
-export type ProfileKind = SsoTokenProfileKind
+export interface AwsResponseErrorData {
+    awsErrorCode: string
+}
+
+export class AwsResponseError<D extends AwsResponseErrorData> extends ResponseError<D> {
+    constructor(messageOrError: unknown, data: D, code: number = LSPErrorCodes.RequestFailed) {
+        super(code, (messageOrError as object)?.toString(), data)
+    }
+}
+
+// listProfiles
+export type ProfileKind = 'Unknown' | 'SsoTokenProfile'
 
 export const ProfileKind = {
-    SsoToken: 'SsoToken',
+    SsoTokenProfile: 'SsoTokenProfile',
+    Unknown: 'Unknown',
 } as const
 
 export interface Section {
     name: string
 }
 
-export interface Profile extends Section {
-    readonly kind: ProfileKind
-    region?: string
+// Profile and SsoSession use 'settings' property as namescope for their settings to avoid future
+// name conflicts with 'kind' and 'name' properties as well as making some setting iteration operations
+// easier.
+
+export interface Profile {
+    kind: ProfileKind
+    name: string
+    settings: {
+        region?: string
+        sso_session?: string
+    }
 }
 
-export interface SsoTokenProfile extends Profile {
-    readonly kind: SsoTokenProfileKind
-    ssoSessionName: string
+export interface SsoSession {
+    name: string
+    settings: {
+        sso_start_url: string
+        sso_region: string
+        sso_registration_scopes?: string[]
+    }
 }
 
-export interface SsoSession extends Section {
-    ssoStartUrl: string
-    ssoRegion: string
-    ssoRegistrationScopes?: string[]
+export type ListProfilesParams = {
+    // Intentionally left blank
 }
 
 export interface ListProfilesResult {
-    profiles?: (Profile | SsoTokenProfile)[]
-    ssoSessions?: SsoSession[]
+    profiles: Profile[]
+    ssoSessions: SsoSession[]
 }
-export interface ListProfilesError {
-    errorCode: E_UNKNOWN | E_TIMEOUT | E_RUNTIME_NOT_SUPPORTED | E_CANNOT_READ_SHARED_CONFIG
+
+export interface ListProfilesErrorData extends AwsResponseErrorData {
+    awsErrorCode: E_UNKNOWN | E_TIMEOUT | E_RUNTIME_NOT_SUPPORTED | E_CANNOT_READ_SHARED_CONFIG
 }
+
+export class ListProfilesError extends AwsResponseError<ListProfilesErrorData> {
+    constructor(messageOrError: unknown, data: ListProfilesErrorData, code: number = LSPErrorCodes.RequestFailed) {
+        super(messageOrError, data, code)
+        Object.setPrototypeOf(this, new.target.prototype)
+    }
+}
+
 export const listProfilesRequestType = new ProtocolRequestType<
     ListProfilesParams,
     ListProfilesResult,
@@ -62,13 +113,19 @@ export const listProfilesRequestType = new ProtocolRequestType<
 
 // updateProfile
 export interface UpdateProfileOptions {
-    createNonexistentProfile?: boolean // default is true
-    createNonexistentSsoSession?: boolean // default is true
-    updateSharedSsoSession?: boolean // default is false
+    createNonexistentProfile?: boolean
+    createNonexistentSsoSession?: boolean
+    updateSharedSsoSession?: boolean
 }
 
+export const updateProfileOptionsDefaults = {
+    createNonexistentProfile: true,
+    createNonexistentSsoSession: true,
+    updateSharedSsoSession: false,
+} satisfies UpdateProfileOptions
+
 export interface UpdateProfileParams {
-    profile: SsoTokenProfile // | OtherProfile types may be supported in the future
+    profile: Profile
     ssoSession?: SsoSession
     options?: UpdateProfileOptions
 }
@@ -76,20 +133,30 @@ export interface UpdateProfileParams {
 export interface UpdateProfileResult {
     // Intentionally left blank
 }
-export interface UpdateProfileError {
-    errorCode:
+
+export interface UpdateProfileErrorData extends AwsResponseErrorData {
+    awsErrorCode:
         | E_UNKNOWN
         | E_TIMEOUT
         | E_RUNTIME_NOT_SUPPORTED
         | E_CANNOT_READ_SHARED_CONFIG
         | E_CANNOT_WRITE_SHARED_CONFIG
+        | E_CANNOT_CREATE_PROFILE
         | E_CANNOT_OVERWRITE_PROFILE
+        | E_CANNOT_CREATE_SSO_SESSION
         | E_CANNOT_OVERWRITE_SSO_SESSION
         | E_INVALID_PROFILE
         | E_INVALID_SSO_SESSION
 }
 
-export const updateProfilesRequestType = new ProtocolRequestType<
+export class UpdateProfileError extends AwsResponseError<UpdateProfileErrorData> {
+    constructor(messageOrError: unknown, data: UpdateProfileErrorData, code: number = LSPErrorCodes.RequestFailed) {
+        super(messageOrError, data, code)
+        Object.setPrototypeOf(this, new.target.prototype)
+    }
+}
+
+export const updateProfileRequestType = new ProtocolRequestType<
     UpdateProfileParams,
     UpdateProfileResult,
     never,

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -50,7 +50,7 @@ import {
     invalidateSsoTokenRequestType,
     listProfilesRequestType,
     ssoTokenChangedRequestType,
-    updateProfilesRequestType,
+    updateProfileRequestType,
     updateSsoTokenManagementRequestType,
 } from '../protocol/identity-management'
 
@@ -253,7 +253,7 @@ export const standalone = (props: RuntimeProps) => {
 
             const identityManagement: IdentityManagement = {
                 onListProfiles: handler => lspConnection.onRequest(listProfilesRequestType, handler),
-                onUpdateProfile: handler => lspConnection.onRequest(updateProfilesRequestType, handler),
+                onUpdateProfile: handler => lspConnection.onRequest(updateProfileRequestType, handler),
                 onGetSsoToken: handler => lspConnection.onRequest(getSsoTokenRequestType, handler),
                 onInvalidateSsoToken: handler => lspConnection.onRequest(invalidateSsoTokenRequestType, handler),
                 onUpdateSsoTokenManagement: handler =>

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -43,7 +43,7 @@ import {
     invalidateSsoTokenRequestType,
     listProfilesRequestType,
     ssoTokenChangedRequestType,
-    updateProfilesRequestType,
+    updateProfileRequestType,
     updateSsoTokenManagementRequestType,
 } from '../protocol/identity-management'
 import { IdentityManagement } from '../server-interface/identity-management'
@@ -164,7 +164,7 @@ export const webworker = (props: RuntimeProps) => {
 
         const identityManagement: IdentityManagement = {
             onListProfiles: handler => lspConnection.onRequest(listProfilesRequestType, handler),
-            onUpdateProfile: handler => lspConnection.onRequest(updateProfilesRequestType, handler),
+            onUpdateProfile: handler => lspConnection.onRequest(updateProfileRequestType, handler),
             onGetSsoToken: handler => lspConnection.onRequest(getSsoTokenRequestType, handler),
             onInvalidateSsoToken: handler => lspConnection.onRequest(invalidateSsoTokenRequestType, handler),
             onUpdateSsoTokenManagement: handler =>


### PR DESCRIPTION
Minor protocol changes needed for complementary PR with same name in language-servers repo.

1. Added AwsErrorCodes as base for other errors to support passing application (not JSON-RPC) error codes back to the destination to be able to filter errors more effectively.
2. Updated errors and added options parameter/type for listProfiles and updateProfiles
3. Fixed spelling of `updateProfilesRequestType` to `updateProfileRequestType` to be consistent with other updateProfile names 