### PR TITLE
Update runtimes version to 0.2.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2343,7 +2343,7 @@
         },
         "runtimes": {
             "name": "@aws/language-server-runtimes",
-            "version": "0.2.18",
+            "version": "0.2.19",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.6",

--- a/runtimes/CHANGELOG.md
+++ b/runtimes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.19] - 2024-10-09
+
+- Update Identity Management protocol definition
+- Export Identity Management interfaces in `server-interface`
+
 ## [0.2.18] - 2024-09-25
 
 - Extend LSP interface with `getAvailableServerConfigurations` that allows clients to request available server configuration values

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.18",
+    "version": "0.2.19",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",


### PR DESCRIPTION
## Release @aws/language-server-runtimes v0.2.19

Release latest changes in Identity Management feature

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
