### PR TITLE
Define new UI contract for copy to clipboard event

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -1,4 +1,9 @@
-import { InsertToCursorPositionParams, ChatOptions } from '@aws/language-server-runtimes-types'
+import {
+    InsertToCursorPositionParams,
+    ChatOptions,
+    CodeSelectionType,
+    ReferenceTrackerInformation,
+} from '@aws/language-server-runtimes-types'
 export { InsertToCursorPositionParams } from '@aws/language-server-runtimes-types'
 
 export type AuthFollowUpType = 'full-auth' | 're-auth' | 'missing_scopes' | 'use-supported-auth'
@@ -12,6 +17,7 @@ export type TriggerType = 'hotkeys' | 'click' | 'contextMenu'
 export const SEND_TO_PROMPT = 'sendToPrompt'
 export const ERROR_MESSAGE = 'errorMessage'
 export const INSERT_TO_CURSOR_POSITION = 'insertToCursorPosition'
+export const COPY_TO_CLIPBOARD = 'copyToClipboard'
 export const AUTH_FOLLOW_UP_CLICKED = 'authFollowUpClicked'
 export const GENERIC_COMMAND = 'genericCommand'
 export const CHAT_OPTIONS = 'chatOptions'
@@ -23,6 +29,7 @@ export type UiMessageCommand =
     | typeof AUTH_FOLLOW_UP_CLICKED
     | typeof GENERIC_COMMAND
     | typeof CHAT_OPTIONS
+    | typeof COPY_TO_CLIPBOARD
 
 export interface UiMessage {
     command: UiMessageCommand
@@ -36,6 +43,7 @@ export type UiMessageParams =
     | ErrorParams
     | SendToPromptParams
     | ChatOptions
+    | CopyCodeToClipboardParams
 
 export interface SendToPromptParams {
     selection: string
@@ -90,4 +98,20 @@ export interface ErrorMessage {
 export interface ChatOptionsMessage {
     command: typeof CHAT_OPTIONS
     params: ChatOptions
+}
+
+export interface CopyCodeToClipboardParams {
+    tabId: string
+    messageId: string
+    code?: string
+    type?: CodeSelectionType
+    referenceTrackerInformation?: ReferenceTrackerInformation[]
+    eventId?: string
+    codeBlockIndex?: number
+    totalCodeBlocks?: number
+}
+
+export interface CopyCodeToClipboardMessage {
+    command: typeof COPY_TO_CLIPBOARD
+    params: CopyCodeToClipboardParams
 }


### PR DESCRIPTION
## Description
Currently there is no chat client ui event that is emitted to destinations to let them know the `copy to clipboard` button was clicked. As a result destinations need to listen to telemetry events and check if a telemetry is coming from copy to clipboard event.  Let's define a new contract that allows chat client to notify destinations about the copy event

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
