### PR TITLE
Update chat-client-ui-types version to 0.0.7

### DIFF
--- a/chat-client-ui-types/CHANGELOG.md
+++ b/chat-client-ui-types/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.0.7] - 2024-10-14
+
+### Added
+- `COPY_TO_CLIPBOARD` contract to send notification about copy events from the UI to destinations
+
 ## [0.0.6] - 2024-06-20
 
 - Introduce `CHAT_OPTIONS` contract to allow sending chat options like available quick actions to the UI

--- a/chat-client-ui-types/package.json
+++ b/chat-client-ui-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/chat-client-ui-types",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "Type definitions for Chat UIs in Language Servers and Runtimes for AWS",
     "main": "./out/index.js",
     "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         },
         "chat-client-ui-types": {
             "name": "@aws/chat-client-ui-types",
-            "version": "0.0.6",
+            "version": "0.0.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.6"


### PR DESCRIPTION
## Description

Releasing new version of `chat-client-ui-types`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
