### PR TITLE
Renamed dataDirectory field to a more descriptive name

### DIFF
--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -225,9 +225,11 @@ Complete Identity Management parameter and result interfaces can be found in [id
 
 ### Notification
 
-The notification feature can be used to send custom customer-facing notifications to clients. Notifications can contain actions, like show URL, but also followup actions, like request customer acknowledgement. When customer reacts to followup actions, asyncronous notification can be sent from client to server to notify server about this.
+The notification feature can be used to send custom customer-facing notifications to clients. Notifications can contain actions, like show URL, but also followup actions, like request customer acknowledgement. When customer reacts to followup actions, asynchronous notification can be sent from client to server to notify server about this.
 
 Notifications should be used in rare / exceptional cases that require customer attention (like some change happened or action recommended), but are not blocking the main flow. Clients can decide to throttle notifications, if too many are sent.
+
+Consider using LSP [ShowMessage notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessage) instead, if your notification does not require actions or followup actions.
 
 #### Feature Specification
 

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -86,12 +86,16 @@ export interface AWSInitializationOptions {
      */
     clientInfo?: ExtendedClientInfo
     /**
-     * Client data directory, used as an application data directory to store LSP server-specific data.
-     * LSP servers are expected to use the directory for storing their configuration files,
-     * temporary data, and user-specific settings.
-     * The directory is extected to maintain data across updates and re-installations.
+     * Client data folder, used as an application data folder to store LSP server-specific data.
+     * LSP servers are expected to use the folder for storing their configuration files,
+     * temporary data, and user-specific settings. Servers should create subfolder
+     * within the client data folder for storing server-specific data.
+     *
+     * The folder is expected to be created by client, separate folder per application
+     * (e.g. multiple IDEs on a client machine should not share the same folder),
+     * and is extected to maintain data across updates and re-installations.
      */
-    dataDirectory?: string
+    clientDataFolder?: string
 }
 
 /**


### PR DESCRIPTION
## Problem

`dataDirectory` requires more descripitive and consistent name.

## Solution

- Renamed field in InitializeParams to a more descriptive and consistent name based on [feedback](https://github.com/aws/language-server-runtimes/pull/231#discussion_r1803524400). It's a breaking change, but the field is unused yet.
- Improved comments

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
