### PR TITLE
Add `workspace/applyEdit` functionality to LSP interface & extend chat types  

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 echo [pre-commit] formatting staged files...
 npm run format-staged
 echo [pre-commit] done formatting staged files

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -216,6 +216,7 @@ export const standalone = (props: RuntimeProps) => {
                 onExecuteCommand: lspServer.setExecuteCommandHandler,
                 onSemanticTokens: handler => lspConnection.onRequest(SemanticTokensRequest.type, handler),
                 workspace: {
+                    applyWorkspaceEdit: params => lspConnection.workspace.applyEdit(params),
                     getConfiguration: section => lspConnection.workspace.getConfiguration(section),
                     onDidChangeWorkspaceFolders: handler =>
                         lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -137,6 +137,7 @@ export const webworker = (props: RuntimeProps) => {
             onExecuteCommand: lspServer.setExecuteCommandHandler,
             onSemanticTokens: handler => lspConnection.onRequest(SemanticTokensRequest.type, handler),
             workspace: {
+                applyWorkspaceEdit: params => lspConnection.workspace.applyEdit(params),
                 getConfiguration: section => lspConnection.workspace.getConfiguration(section),
                 onDidChangeWorkspaceFolders: handler =>
                     lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler),

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -40,6 +40,8 @@ import {
     ShowDocumentParams,
     ShowDocumentResult,
     LSPAny,
+    ApplyWorkspaceEditParams,
+    ApplyWorkspaceEditResult,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -103,6 +105,7 @@ export type Lsp = {
     workspace: {
         getConfiguration: (section: string) => Promise<any>
         onDidChangeWorkspaceFolders: (handler: NotificationHandler<DidChangeWorkspaceFoldersParams>) => void
+        applyWorkspaceEdit: (params: ApplyWorkspaceEditParams) => Promise<ApplyWorkspaceEditResult>
     }
     window: {
         showMessage: (params: ShowMessageParams) => Promise<void>

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -121,11 +121,12 @@ export interface QuickActions {
 
 /**
  * Registration options regarding chat data
- * Currently only contains the available quick actions provided by a server
- * Can be extended in the future (e.g with default tab data)
+ * Currently contains the available quick actions provided by a server
+ * and the default tab data to be shown to the user in the chat UI
  */
 export interface ChatOptions {
     quickActions?: QuickActions
+    defaultTabData?: ChatResult
 }
 
 export interface QuickActionParams extends PartialResultParams {

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -162,6 +162,8 @@ export interface TabRemoveParams extends TabEventParams {}
 export interface InsertToCursorPositionParams {
     tabId: string
     messageId: string
+    cursorPosition?: Position
+    textDocument?: TextDocumentIdentifier
     code?: string
     type?: CodeSelectionType
     referenceTrackerInformation?: ReferenceTrackerInformation[]


### PR DESCRIPTION
## Description
This PR introduces multiple changes:
1. Adds `workspace/applyEdit` functionality to the LSP interface. This will allow servers to make edits on the open text editors
2. Extends `insertToCursorPosition` params with two new fields: `cursorPosition` and `textDocument` (This will allow us to also get rid of some custom protocol changes done on the chat server https://github.com/aws/language-servers/pull/354/files#diff-fa30a0e5c15807fd776dbebef889da3272befc9c83e6ea90037cb74536e4647b also see the PR description: https://github.com/aws/language-servers/pull/354#issue-2378741043) 
3. Extends chat options with `defaultTabData` This can be used by servers to define the default tab data that is shown on the chat UI. Servers will be able to specify the chat message that should be shown by default as well as the default followup messages that should be shown


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
