### PR TITLE
Extend FS feature with write operations

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -43,7 +43,7 @@ import { RuntimeProps } from './runtime'
 import { observe } from './lsp'
 
 import { access, mkdirSync, existsSync } from 'fs'
-import { readdir, readFile, rm, stat, copyFile } from 'fs/promises'
+import { readdir, readFile, rm, stat, copyFile, writeFile, appendFile, mkdir } from 'fs/promises'
 import * as os from 'os'
 import * as path from 'path'
 import { LspRouter } from './lsp/router/lspRouter'
@@ -191,6 +191,9 @@ export const standalone = (props: RuntimeProps) => {
                 readFile: path => readFile(path, 'utf-8'),
                 remove: dir => rm(dir, { recursive: true, force: true }),
                 isFile: path => stat(path).then(({ isFile }) => isFile()),
+                writeFile: (file, data, options?) => writeFile(file, data, options),
+                appendFile: (path, data, options?) => appendFile(path, data, options),
+                mkdir: (path, options?) => mkdir(path, options),
             },
         }
 

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -191,8 +191,8 @@ export const standalone = (props: RuntimeProps) => {
                 readFile: path => readFile(path, 'utf-8'),
                 remove: dir => rm(dir, { recursive: true, force: true }),
                 isFile: path => stat(path).then(({ isFile }) => isFile()),
-                writeFile: (file, data, options?) => writeFile(file, data, options),
-                appendFile: (path, data, options?) => appendFile(path, data, options),
+                writeFile: (path, data) => writeFile(path, data),
+                appendFile: (path, data) => appendFile(path, data),
                 mkdir: (path, options?) => mkdir(path, options),
             },
         }

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -90,8 +90,8 @@ export const webworker = (props: RuntimeProps) => {
             readdir: _path => Promise.resolve([]),
             isFile: _path => Promise.resolve(false),
             remove: _dir => Promise.resolve(),
-            writeFile: (_file, _data, _options?) => Promise.resolve(),
-            appendFile: (_path, _data, _options?) => Promise.resolve(),
+            writeFile: (_path, _data) => Promise.resolve(),
+            appendFile: (_path, _data) => Promise.resolve(),
             mkdir: (_path, _options?) => Promise.resolve(''),
         },
     }

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -90,6 +90,9 @@ export const webworker = (props: RuntimeProps) => {
             readdir: _path => Promise.resolve([]),
             isFile: _path => Promise.resolve(false),
             remove: _dir => Promise.resolve(),
+            writeFile: (_file, _data, _options?) => Promise.resolve(),
+            appendFile: (_path, _data, _options?) => Promise.resolve(),
+            mkdir: (_path, _options?) => Promise.resolve(''),
         },
     }
 

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -1,4 +1,6 @@
+import { FileHandle } from 'fs/promises'
 import { TextDocument, WorkspaceFolder } from '../protocol'
+import { MakeDirectoryOptions, WriteFileOptions } from 'fs'
 
 // Minimal version of fs.Dirent
 interface Dirent {
@@ -27,5 +29,16 @@ export type Workspace = {
         readFile: (path: string) => Promise<string>
         isFile: (path: string) => Promise<boolean>
         remove: (dir: string) => Promise<void>
+        writeFile: (
+            file: FileHandle | string | Buffer | URL,
+            data: string | NodeJS.ArrayBufferView,
+            options?: WriteFileOptions
+        ) => Promise<void>
+        appendFile: (
+            path: FileHandle | string | Buffer | URL,
+            data: string | Uint8Array,
+            options?: WriteFileOptions
+        ) => Promise<void>
+        mkdir: (path: string | Buffer | URL, options?: MakeDirectoryOptions) => Promise<string | undefined>
     }
 }

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -1,6 +1,4 @@
-import { FileHandle } from 'fs/promises'
 import { TextDocument, WorkspaceFolder } from '../protocol'
-import { MakeDirectoryOptions, WriteFileOptions } from 'fs'
 
 // Minimal version of fs.Dirent
 interface Dirent {
@@ -29,16 +27,8 @@ export type Workspace = {
         readFile: (path: string) => Promise<string>
         isFile: (path: string) => Promise<boolean>
         remove: (dir: string) => Promise<void>
-        writeFile: (
-            file: FileHandle | string | Buffer | URL,
-            data: string | NodeJS.ArrayBufferView,
-            options?: WriteFileOptions
-        ) => Promise<void>
-        appendFile: (
-            path: FileHandle | string | Buffer | URL,
-            data: string | Uint8Array,
-            options?: WriteFileOptions
-        ) => Promise<void>
-        mkdir: (path: string | Buffer | URL, options?: MakeDirectoryOptions) => Promise<string | undefined>
+        writeFile: (path: string, data: string) => Promise<void>
+        appendFile: (path: string, data: string) => Promise<void>
+        mkdir: (path: string, options?: { recursive: boolean }) => Promise<string | undefined>
     }
 }


### PR DESCRIPTION
## Problem
With the addition of the notification protocol #231, the notification server implementation may require the following functions: create a directory, write to a file, append to a file.

## Solution
Extended the workspace `fs` feature with a subset of Node.js file system methods. Currently, the workspace feature is implemented only in the standalone runtime.
Manually tested using a language servers' implementation.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
