### PR TITLE
Update chat-client-ui-types version to 0.0.8

### DIFF
--- a/chat-client-ui-types/CHANGELOG.md
+++ b/chat-client-ui-types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## [0.0.8] - 2024-10-22
+
+### Updated
+- Update `@aws/language-server-runtimes-types` dependency from 0.0.6 to 0.0.7
+
 ## [0.0.7] - 2024-10-14
 
 ### Added

--- a/chat-client-ui-types/package.json
+++ b/chat-client-ui-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/chat-client-ui-types",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "Type definitions for Chat UIs in Language Servers and Runtimes for AWS",
     "main": "./out/index.js",
     "scripts": {
@@ -18,6 +18,6 @@
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
     "dependencies": {
-        "@aws/language-server-runtimes-types": "^0.0.6"
+        "@aws/language-server-runtimes-types": "^0.0.7"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,19 +32,10 @@
         },
         "chat-client-ui-types": {
             "name": "@aws/chat-client-ui-types",
-            "version": "0.0.7",
+            "version": "0.0.8",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.0.6"
-            }
-        },
-        "chat-client-ui-types/node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.6.tgz",
-            "integrity": "sha512-z+j+iAhU3eK/Zmm+A9gSW0EOMIZxSAWHtf9QklLSqx4Hul7CiRu8NVxPTQFb6T38AG8hBCFlWWPpAcsqzQCyBA==",
-            "dependencies": {
-                "vscode-languageserver-textdocument": "^1.0.11",
-                "vscode-languageserver-types": "^3.17.5"
+                "@aws/language-server-runtimes-types": "^0.0.7"
             }
         },
         "node_modules/@aws/chat-client-ui-types": {


### PR DESCRIPTION
## Description
Update chat-client-ui-types version to 0.0.8

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
