### PR TITLE
Identity protocol updates and encrypt GetSsoToken.accessToken

### DIFF
--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -199,9 +199,10 @@ export const invalidateSsoTokenRequestType = new ProtocolRequestType<
 >('aws/identity/invalidateSsoToken')
 
 // ssoTokenChanged
+export type Expired = 'Expired'
 export type Refreshed = 'Refreshed'
 
-export type SsoTokenChangedKind = Refreshed
+export type SsoTokenChangedKind = Refreshed | Expired
 
 export const SsoTokenChangedKind = {
     Expired: 'Expired',

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -48,7 +48,6 @@ import {
     listProfilesRequestType,
     ssoTokenChangedRequestType,
     updateProfileRequestType,
-    updateSsoTokenManagementRequestType,
 } from '../protocol/identity-management'
 import { IdentityManagement } from '../server-interface/identity-management'
 
@@ -177,8 +176,6 @@ export const webworker = (props: RuntimeProps) => {
             onUpdateProfile: handler => lspConnection.onRequest(updateProfileRequestType, handler),
             onGetSsoToken: handler => lspConnection.onRequest(getSsoTokenRequestType, handler),
             onInvalidateSsoToken: handler => lspConnection.onRequest(invalidateSsoTokenRequestType, handler),
-            onUpdateSsoTokenManagement: handler =>
-                lspConnection.onRequest(updateSsoTokenManagementRequestType, handler),
             sendSsoTokenChanged: params => lspConnection.sendNotification(ssoTokenChangedRequestType, params),
         }
 

--- a/runtimes/server-interface/identity-management.ts
+++ b/runtimes/server-interface/identity-management.ts
@@ -9,8 +9,6 @@ import {
     SsoTokenChangedParams,
     UpdateProfileParams,
     UpdateProfileResult,
-    UpdateSsoTokenManagementParams,
-    UpdateSsoTokenManagementResult,
 } from '../protocol/identity-management'
 import { RequestHandler } from '../protocol'
 
@@ -31,14 +29,6 @@ export type IdentityManagement = {
 
     onInvalidateSsoToken: (
         handler: RequestHandler<InvalidateSsoTokenParams, InvalidateSsoTokenResult | undefined | null, AwsResponseError>
-    ) => void
-
-    onUpdateSsoTokenManagement: (
-        handler: RequestHandler<
-            UpdateSsoTokenManagementParams,
-            UpdateSsoTokenManagementResult | undefined | null,
-            AwsResponseError
-        >
     ) => void
 
     sendSsoTokenChanged: (params: SsoTokenChangedParams) => void


### PR DESCRIPTION
This PR contains several updates for GetSsoToken, removes UpdateSsoTokenManagment and the Created & Invalidated events from SsoTokenChanged.  The latter two may be added back in the future if and when they are needed.

1. Added AwsErrorCodes and ordered alphabetically to help organize increasingly long list.
2. Moved clientName to GetSsoTokenParams from "source".
3. Add ssoRegistrationScopes to AWS Builder ID source.
4. Updated onGetSsoToken in standalone and webworker to encrypt accessToken before sending to client.