### PR TITLE
Extend FS with an ability to get server-specific data folder

### DIFF
--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -83,6 +83,7 @@ export interface ExtendedClientInfo {
 export interface AWSInitializationOptions {
     /**
      * Additional clientInfo to extend or override default data passed by LSP Client.
+     * This information may be used to generate client-specific data folder path if clientDataFolder is not specified.
      */
     clientInfo?: ExtendedClientInfo
     /**

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -86,6 +86,7 @@ export const webworker = (props: RuntimeProps) => {
             exists: _path => Promise.resolve(false),
             getFileSize: _path => Promise.resolve({ size: 0 }),
             getTempDirPath: () => '/tmp',
+            getServerDataFolder: _serverName => '',
             readFile: _path => Promise.resolve(''),
             readdir: _path => Promise.resolve([]),
             isFile: _path => Promise.resolve(false),

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -22,6 +22,7 @@ export type Workspace = {
         copy: (src: string, dest: string) => Promise<void>
         exists: (path: string) => Promise<boolean>
         getFileSize: (path: string) => Promise<{ size: number }>
+        getServerDataFolder: (serverName: string) => string
         getTempDirPath: () => string
         readdir: (path: string) => Promise<Dirent[]>
         readFile: (path: string) => Promise<string>


### PR DESCRIPTION
## Problem
Language servers will require the ability to store server-specific data persistently. With the addition of filesystem write operations in #234, there is now a need for a method in the workspace interface that can provide a dedicated application data folder for given server.

## Solution
Extended the Workspace feature with a new `clientDataFolder` method to retrieve the server data folder path. This method takes into account: the operating system, the `InitializeParams` and the server name. If a `clientDataFolder` is specified in `InitializeParams`, it returns this path concatenated with the server name.
Otherwise, it determines the appropriate application data directory based on operating system standards. Within this directory, it constructs path based on LSP `clientInfo` or AWS `clientInfo` parameter from `InitializeParams`. Finally, a server-specific part is appended to the path.

This approach ensures that each language server has its own dedicated space for storing data.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
