### PR TITLE
Runtimes: pass runtime platform to Server implementation

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -16,10 +16,7 @@ import {
     showNotificationRequestType,
     notificationFollowupRequestType,
     CancellationToken,
-    HandlerResult,
-    AwsResponseError,
     GetSsoTokenParams,
-    GetSsoTokenResult,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -61,8 +58,6 @@ import { LspRouter } from './lsp/router/lspRouter'
 import { LspServer } from './lsp/router/lspServer'
 import { BaseChat } from './chat/baseChat'
 import { checkAWSConfigFile } from './util/sharedConfigFile'
-import runtime from 'jose/dist/types/util/runtime'
-import { async } from 'rxjs'
 
 // Honor shared aws config file
 if (checkAWSConfigFile()) {
@@ -214,6 +209,7 @@ export const standalone = (props: RuntimeProps) => {
                 name: props.name,
                 version: props.version,
             },
+            platform: os.platform(),
         }
 
         // Create router that will be routing LSP events from the client to server(s)

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -126,6 +126,7 @@ export const webworker = (props: RuntimeProps) => {
             name: props.name,
             version: props.version,
         },
+        platform: 'browser',
     }
 
     // Initialize every Server

--- a/runtimes/server-interface/runtime.ts
+++ b/runtimes/server-interface/runtime.ts
@@ -3,6 +3,8 @@ export type ServerInfo = {
     version?: string
 }
 
+export type Platform = NodeJS.Platform | 'browser'
+
 /**
  * The Runtime feature interface.
  */
@@ -11,4 +13,10 @@ export interface Runtime {
      * Information about runtime server, set in runtime props at build time.
      */
     serverInfo: ServerInfo
+
+    /**
+     * Platform where the runtime is running.
+     * Set to NodeJS.Platform for standalone and 'browser' for webworker runtime.
+     */
+    platform: Platform
 }


### PR DESCRIPTION
## Problem
Servers might need to know value of platform in which they currently running. To avoid them computing this value in their business logic, we can send predictable value from the runtime itself.

Needed for https://github.com/aws/language-servers/pull/505

## Solution
Pass new `platform` field in `Runtime` feature to every `Server`.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
