### PR TITLE
Update runtimes to version v0.2.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2343,7 +2343,7 @@
         },
         "runtimes": {
             "name": "@aws/language-server-runtimes",
-            "version": "0.2.22",
+            "version": "0.2.23",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.7",

--- a/runtimes/CHANGELOG.md
+++ b/runtimes/CHANGELOG.md
@@ -1,24 +1,35 @@
 # Changelog
 
+## [0.2.23] - 2024-10-24
+
+### Added
+
+- Add `platform` value to `Runtime` feature injected in every Server (#244)
+
 ## [0.2.22] - 2024-10-24
 
 ### Added
+
 - Add encryption to the accessToken in Identity Management protocol
 
 ### Changed
+
 - Minor updates to `GetSsoToken` request parameters
 
 ### Removed
+
 - Remove unused `onUpdateSsoTokenManagement` in Identity Management protocol
 
 ## [0.2.21] - 2024-10-23
 
 ### Added
+
 - Add `workspace/applyEdit` functionality to the LSP interface
 - Add `writeFile`, `appendFile` and `mkdir` functionality to `workspace.fs`
 - Create `Notification` interface for servers
 
 ### Changed
+
 - Update `@aws/language-server-runtimes-types` dependency from 0.0.6 to 0.0.7
 
 ## [0.2.20] - 2024-10-11

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.22",
+    "version": "0.2.23",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",


### PR DESCRIPTION
## Problem

Release https://github.com/aws/language-server-runtimes/pull/244 to make it available for `language-servers`

## Solution

Release `@aws/language-server-runtimes:v0.2.23` 

## Changelog: 

### Added

- Add `platform` value to `Runtime` feature injected in every Server (#244)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
