### PR TITLE
Align the FS interface with Node.js FS

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -167,7 +167,7 @@ export const standalone = (props: RuntimeProps) => {
             },
             fs: {
                 copyFile: (src, dest, options?) => {
-                    if (options?.ensureDir !== false) {
+                    if (options?.ensureDir === true) {
                         const destDir = path.dirname(dest)
                         if (!existsSync(destDir)) {
                             mkdirSync(destDir, { recursive: true })

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -50,8 +50,8 @@ import { RuntimeProps } from './runtime'
 
 import { observe } from './lsp'
 
-import { access, mkdirSync, existsSync } from 'fs'
-import { readdir, readFile, rm, stat, copyFile, writeFile, appendFile, mkdir } from 'fs/promises'
+import { mkdirSync, existsSync } from 'fs'
+import { access, readdir, readFile, rm, stat, copyFile, writeFile, appendFile, mkdir } from 'fs/promises'
 import * as os from 'os'
 import * as path from 'path'
 import { LspRouter } from './lsp/router/lspRouter'
@@ -166,7 +166,7 @@ export const standalone = (props: RuntimeProps) => {
                 }
             },
             fs: {
-                copy: (src, dest) => {
+                copyFileWithCreateDir: (src, dest) => {
                     const destDir = path.dirname(dest)
                     if (!existsSync(destDir)) {
                         mkdirSync(destDir, { recursive: true })
@@ -174,12 +174,9 @@ export const standalone = (props: RuntimeProps) => {
                     return copyFile(src, dest)
                 },
                 exists: path =>
-                    new Promise(resolve => {
-                        access(path, err => {
-                            if (!err) resolve(true)
-                            resolve(false)
-                        })
-                    }),
+                    access(path)
+                        .then(() => true)
+                        .catch(() => false),
                 getFileSize: path => stat(path),
                 getServerDataDirPath: serverName => getServerDataDirPath(serverName, lspRouter.clientInitializeParams),
                 getTempDirPath: () =>
@@ -190,7 +187,7 @@ export const standalone = (props: RuntimeProps) => {
                     ),
                 readdir: path => readdir(path, { withFileTypes: true }),
                 readFile: path => readFile(path, 'utf-8'),
-                remove: dir => rm(dir, { recursive: true, force: true }),
+                rm: (dir, options?) => rm(dir, options),
                 isFile: path => stat(path).then(({ isFile }) => isFile()),
                 writeFile: (path, data) => writeFile(path, data),
                 appendFile: (path, data) => appendFile(path, data),

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -166,8 +166,8 @@ export const standalone = (props: RuntimeProps) => {
                 }
             },
             fs: {
-                copy: (src, dest, ensureDir = true) => {
-                    if (ensureDir) {
+                copyFile: (src, dest, options?) => {
+                    if (options?.ensureDir !== false) {
                         const destDir = path.dirname(dest)
                         if (!existsSync(destDir)) {
                             mkdirSync(destDir, { recursive: true })

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -166,10 +166,12 @@ export const standalone = (props: RuntimeProps) => {
                 }
             },
             fs: {
-                copyFileWithCreateDir: (src, dest) => {
-                    const destDir = path.dirname(dest)
-                    if (!existsSync(destDir)) {
-                        mkdirSync(destDir, { recursive: true })
+                copy: (src, dest, ensureDir = true) => {
+                    if (ensureDir) {
+                        const destDir = path.dirname(dest)
+                        if (!existsSync(destDir)) {
+                            mkdirSync(destDir, { recursive: true })
+                        }
                     }
                     return copyFile(src, dest)
                 },

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -186,7 +186,8 @@ export const standalone = (props: RuntimeProps) => {
                         'aws-language-servers'
                     ),
                 readdir: path => readdir(path, { withFileTypes: true }),
-                readFile: path => readFile(path, 'utf-8'),
+                readFile: (path, options?) =>
+                    readFile(path, { encoding: (options?.encoding || 'utf-8') as BufferEncoding }),
                 rm: (dir, options?) => rm(dir, options),
                 isFile: path => stat(path).then(({ isFile }) => isFile()),
                 writeFile: (path, data) => writeFile(path, data),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -81,7 +81,7 @@ export const webworker = (props: RuntimeProps) => {
         getWorkspaceFolder: _uri =>
             lspRouter.clientInitializeParams!.workspaceFolders && lspRouter.clientInitializeParams!.workspaceFolders[0],
         fs: {
-            copyFileWithCreateDir: (_src, _dest) => Promise.resolve(),
+            copy: (_src, _dest, _ensureDir?) => Promise.resolve(),
             exists: _path => Promise.resolve(false),
             getFileSize: _path => Promise.resolve({ size: 0 }),
             getServerDataDirPath: _serverName => '',

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -86,7 +86,7 @@ export const webworker = (props: RuntimeProps) => {
             getFileSize: _path => Promise.resolve({ size: 0 }),
             getServerDataDirPath: _serverName => '',
             getTempDirPath: () => '/tmp',
-            readFile: _path => Promise.resolve(''),
+            readFile: (_path, _options?) => Promise.resolve(''),
             readdir: _path => Promise.resolve([]),
             isFile: _path => Promise.resolve(false),
             rm: (_dir, _options?) => Promise.resolve(),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -81,7 +81,7 @@ export const webworker = (props: RuntimeProps) => {
         getWorkspaceFolder: _uri =>
             lspRouter.clientInitializeParams!.workspaceFolders && lspRouter.clientInitializeParams!.workspaceFolders[0],
         fs: {
-            copy: (_src, _dest) => Promise.resolve(),
+            copyFileWithCreateDir: (_src, _dest) => Promise.resolve(),
             exists: _path => Promise.resolve(false),
             getFileSize: _path => Promise.resolve({ size: 0 }),
             getServerDataDirPath: _serverName => '',
@@ -89,7 +89,7 @@ export const webworker = (props: RuntimeProps) => {
             readFile: _path => Promise.resolve(''),
             readdir: _path => Promise.resolve([]),
             isFile: _path => Promise.resolve(false),
-            remove: _dir => Promise.resolve(),
+            rm: (_dir, _options?) => Promise.resolve(),
             writeFile: (_path, _data) => Promise.resolve(),
             appendFile: (_path, _data) => Promise.resolve(),
             mkdir: (_path, _options?) => Promise.resolve(''),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -81,7 +81,7 @@ export const webworker = (props: RuntimeProps) => {
         getWorkspaceFolder: _uri =>
             lspRouter.clientInitializeParams!.workspaceFolders && lspRouter.clientInitializeParams!.workspaceFolders[0],
         fs: {
-            copy: (_src, _dest, _ensureDir?) => Promise.resolve(),
+            copyFile: (_src, _dest, _options?) => Promise.resolve(),
             exists: _path => Promise.resolve(false),
             getFileSize: _path => Promise.resolve({ size: 0 }),
             getServerDataDirPath: _serverName => '',

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -19,7 +19,14 @@ export type Workspace = {
     getAllTextDocuments: () => Promise<TextDocument[]>
     getWorkspaceFolder: (uri: string) => WorkspaceFolder | null | undefined
     fs: {
-        copyFileWithCreateDir: (src: string, dest: string) => Promise<void>
+        /**
+         * Copies a file from src to dest. Dest is overwritten if it already exists.
+         * @param {string} src - The source path.
+         * @param {string} dest - The destination path.
+         * @param {boolean} ensureDir - Whether to create the destination directory if it doesn't exist, defaults to true.
+         * @returns A promise that resolves when the copy operation is complete.
+         */
+        copy: (src: string, dest: string, ensureDir?: boolean) => Promise<void>
         exists: (path: string) => Promise<boolean>
         getFileSize: (path: string) => Promise<{ size: number }>
         getServerDataDirPath: (serverName: string) => string

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -33,9 +33,10 @@ export type Workspace = {
         /**
          * Reads the entire contents of a file.
          * @param {string} path - The path to the file.
+         * @param {string} [options.encoding] - The encoding to use when reading the file, defaults to 'utf-8'.
          * @returns A promise that resolves to the contents of the file as a string.
          */
-        readFile: (path: string) => Promise<string>
+        readFile: (path: string, options?: { encoding: string }) => Promise<string>
         isFile: (path: string) => Promise<boolean>
         rm: (dir: string, options?: { recursive: boolean; force: boolean }) => Promise<void>
         writeFile: (path: string, data: string) => Promise<void>

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -23,10 +23,10 @@ export type Workspace = {
          * Copies a file from src to dest. Dest is overwritten if it already exists.
          * @param {string} src - The source path.
          * @param {string} dest - The destination path.
-         * @param {boolean} ensureDir - Whether to create the destination directory if it doesn't exist, defaults to true.
+         * @param {boolean} [options.ensureDir] - Whether to create the destination directory if it doesn't exist, defaults to true.
          * @returns A promise that resolves when the copy operation is complete.
          */
-        copy: (src: string, dest: string, ensureDir?: boolean) => Promise<void>
+        copyFile: (src: string, dest: string, options?: { ensureDir?: boolean }) => Promise<void>
         exists: (path: string) => Promise<boolean>
         getFileSize: (path: string) => Promise<{ size: number }>
         getServerDataDirPath: (serverName: string) => string

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -23,7 +23,7 @@ export type Workspace = {
          * Copies a file from src to dest. Dest is overwritten if it already exists.
          * @param {string} src - The source path.
          * @param {string} dest - The destination path.
-         * @param {boolean} [options.ensureDir] - Whether to create the destination directory if it doesn't exist, defaults to true.
+         * @param {boolean} [options.ensureDir] - Whether to create the destination directory if it doesn't exist, defaults to false.
          * @returns A promise that resolves when the copy operation is complete.
          */
         copyFile: (src: string, dest: string, options?: { ensureDir?: boolean }) => Promise<void>

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -43,11 +43,11 @@ export type Workspace = {
          * @param {string} [options.encoding] - The encoding to use when reading the file, defaults to 'utf-8'.
          * @returns A promise that resolves to the contents of the file as a string.
          */
-        readFile: (path: string, options?: { encoding: string }) => Promise<string>
+        readFile: (path: string, options?: { encoding?: string }) => Promise<string>
         isFile: (path: string) => Promise<boolean>
-        rm: (dir: string, options?: { recursive: boolean; force: boolean }) => Promise<void>
+        rm: (dir: string, options?: { recursive?: boolean; force?: boolean }) => Promise<void>
         writeFile: (path: string, data: string) => Promise<void>
         appendFile: (path: string, data: string) => Promise<void>
-        mkdir: (path: string, options?: { recursive: boolean }) => Promise<string | undefined>
+        mkdir: (path: string, options?: { recursive?: boolean }) => Promise<string | undefined>
     }
 }

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -19,15 +19,25 @@ export type Workspace = {
     getAllTextDocuments: () => Promise<TextDocument[]>
     getWorkspaceFolder: (uri: string) => WorkspaceFolder | null | undefined
     fs: {
-        copy: (src: string, dest: string) => Promise<void>
+        copyFileWithCreateDir: (src: string, dest: string) => Promise<void>
         exists: (path: string) => Promise<boolean>
         getFileSize: (path: string) => Promise<{ size: number }>
         getServerDataDirPath: (serverName: string) => string
         getTempDirPath: () => string
+        /**
+         * Reads the contents of a directory.
+         * @param {string} path - The path to the directory.
+         * @returns A promise that resolves to an array of Dirent objects.
+         */
         readdir: (path: string) => Promise<Dirent[]>
+        /**
+         * Reads the entire contents of a file.
+         * @param {string} path - The path to the file.
+         * @returns A promise that resolves to the contents of the file as a string.
+         */
         readFile: (path: string) => Promise<string>
         isFile: (path: string) => Promise<boolean>
-        remove: (dir: string) => Promise<void>
+        rm: (dir: string, options?: { recursive: boolean; force: boolean }) => Promise<void>
         writeFile: (path: string, data: string) => Promise<void>
         appendFile: (path: string, data: string) => Promise<void>
         mkdir: (path: string, options?: { recursive: boolean }) => Promise<string | undefined>


### PR DESCRIPTION
## Problem
Currently, in the standalone Workspace file system, there are some unreasonable default options passed to the Node.js fs functions, which can be confusing to the developers and produce unexpected results.

## Solution
Changed the interface to align with the Node.js interface or documented it explicitly.
* The `remove` method is renamed to `rm`, and default options now align with the default Node.js behavior. Users will need to specify `force` and `recursive` options themselves.
* Both `readFile` and `readdir` methods pass options that aren't default, but their execution should be as expected by users, as these options change the return type. Added comments to additionally mark this.
* The `copy` method renamed to `copyFile` and `options.ensureDir` param to better describe its behavior along with docs comments.
* The `exists` method is changed to use the promise-based API. Now, promise wrapping is unnecessary and it works in the same way.


These are backward-incompatible changes. I'll be adding necessary changes to the language servers to align with this new interface.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
