### PR TITLE
Notification interface supports dynamic registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "check:formatting": "prettier --check .",
         "fix:prettier": "prettier . --write",
         "format-staged": "npx pretty-quick --staged",
-        "prepare": "husky install .husky",
+        "prepare": "husky .husky",
         "test": "npm run test --workspaces --if-present",
         "preversion": "npm run test",
         "version": "npm run compile && git add -A .",

--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -225,7 +225,7 @@ Complete Identity Management parameter and result interfaces can be found in [id
 
 ### Notification
 
-The notification feature can be used to send custom customer-facing notifications to clients. Notifications can contain actions, like show URL, but also followup actions, like request customer acknowledgement. When customer reacts to followup actions, asynchronous notification can be sent from client to server to notify server about this.
+The notification feature can be used to send custom customer-facing notifications to clients. Notifications can contain actions, like show URL, but also followup actions, like request customer acknowledgement. When customer reacts to followup actions, asynchronous notification is expected to be sent from client to server to notify server about this.
 
 Notifications should be used in rare / exceptional cases that require customer attention (like some change happened or action recommended), but are not blocking the main flow. Clients can decide to throttle notifications, if too many are sent.
 

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -97,6 +97,14 @@ export interface AWSInitializationOptions {
      * and is extected to maintain data across updates and re-installations.
      */
     clientDataFolder?: string
+    /**
+     * The client signals AWS capabilities it supports.
+     */
+    awsClientCapabilities?: {
+        window?: {
+            showNotification?: boolean
+        }
+    }
 }
 
 /**

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -102,7 +102,7 @@ export interface AWSInitializationOptions {
      */
     awsClientCapabilities?: {
         window?: {
-            showNotification?: boolean
+            notifications?: boolean
         }
     }
 }

--- a/runtimes/protocol/notification.ts
+++ b/runtimes/protocol/notification.ts
@@ -1,5 +1,13 @@
 import { MessageType, ProtocolNotificationType } from './lsp'
 
+export interface EventIdentifier {
+    readonly id: string
+}
+
+export interface FollowupIdentifier {
+    readonly source: EventIdentifier
+}
+
 export interface NotificationContent {
     readonly text: string
     readonly title?: string
@@ -39,16 +47,14 @@ export interface AcknowledgeRequestAction extends NotificationAction {
     readonly type: typeof FollowupNotificationActionType.Acknowledge
 }
 
-export interface NotificationParams {
-    readonly id?: string
+export interface NotificationParams extends Partial<EventIdentifier> {
     readonly type: MessageType
     readonly content: NotificationContent
     readonly actions?: NotificationAction[]
 }
 
-export interface NotificationFollowupParams {
-    readonly id: string
-    readonly actions: FollowupNotificationActionType[]
+export interface NotificationFollowupParams extends FollowupIdentifier {
+    readonly action: FollowupNotificationActionType
 }
 
 /**
@@ -62,7 +68,10 @@ export const showNotificationRequestType = new ProtocolNotificationType<Notifica
 /**
  * notificationFollowupRequestType defines the custom method that the language client
  * sends to the server to provide asynchronous customer followup to notification shown.
- * This method is optional per notification, as not all notifications require followup.
+ * This method is expected to be used only for notification that require followup.
+ *
+ * Client is responsible for passing `id` of source notification that triggered the followup notification
+ * in the parameters.
  */
 export const notificationFollowupRequestType = new ProtocolNotificationType<NotificationFollowupParams, void>(
     'aws/window/notificationFollowup'

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -69,7 +69,7 @@ describe('LspRouter', () => {
                     aws: {
                         awsClientCapabilities: {
                             window: {
-                                showNotification: true,
+                                notifications: true,
                             },
                         },
                     },

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -61,6 +61,24 @@ describe('LspRouter', () => {
             assert(lspRouter.clientInitializeParams === initParam)
         })
 
+        it('should set clientSupportsShowNotification from InitializeParam', () => {
+            assert.equal(lspRouter.clientSupportsShowNotification, false)
+
+            const initParam = {
+                initializationOptions: {
+                    aws: {
+                        awsClientCapabilities: {
+                            window: {
+                                showNotification: true,
+                            },
+                        },
+                    },
+                },
+            } as InitializeParams
+            initializeHandler(initParam, {} as CancellationToken)
+            assert.equal(lspRouter.clientSupportsShowNotification, true)
+        })
+
         it('should return the default response when no handlers are registered', async () => {
             const result = await initializeHandler({} as InitializeParams, {} as CancellationToken)
 

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -36,7 +36,7 @@ export class LspRouter {
 
     public get clientSupportsShowNotification() {
         return (
-            this.clientInitializeParams?.initializationOptions?.aws.awsClientCapabilities?.window?.showNotification ??
+            this.clientInitializeParams?.initializationOptions?.aws.awsClientCapabilities?.window?.notifications ??
             false
         )
     }
@@ -49,9 +49,9 @@ export class LspRouter {
 
         let responsesList = await Promise.all(this.servers.map(s => s.initialize(params, token)))
         responsesList = responsesList.filter(r => r != undefined)
-        const errors = responsesList.find(el => el instanceof ResponseError)
-        if (errors) {
-            return errors as ResponseError<InitializeError>
+        const responseError = responsesList.find(el => el instanceof ResponseError)
+        if (responseError) {
+            return responseError as ResponseError<InitializeError>
         }
         const dupServerNames = findDuplicates(responsesList.map(r => (r as PartialInitializeResult).serverInfo?.name))
         if (dupServerNames) {

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -32,6 +32,13 @@ export class LspRouter {
         lspConnection.onRequest(getConfigurationFromServerRequestType, this.handleGetConfigurationFromServer)
     }
 
+    public get clientSupportsShowNotification() {
+        return (
+            this.clientInitializeParams?.initializationOptions?.aws.awsClientCapabilities?.window?.showNotification ??
+            false
+        )
+    }
+
     initialize = async (
         params: InitializeParams,
         token: CancellationToken

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -2,6 +2,7 @@ import {
     CancellationToken,
     DidChangeConfigurationNotification,
     DidChangeConfigurationParams,
+    ErrorCodes,
     ExecuteCommandParams,
     GetConfigurationFromServerParams,
     getConfigurationFromServerRequestType,
@@ -14,7 +15,8 @@ import {
 } from '../../../protocol'
 import { Connection } from 'vscode-languageserver/node'
 import { LspServer } from './lspServer'
-import { mergeObjects } from './util'
+import { findDuplicates, mergeObjects } from './util'
+import { PartialInitializeResult } from '../../../server-interface'
 
 export class LspRouter {
     public clientInitializeParams?: InitializeParams
@@ -44,6 +46,22 @@ export class LspRouter {
         token: CancellationToken
     ): Promise<InitializeResult | ResponseError<InitializeError>> => {
         this.clientInitializeParams = params
+
+        let responsesList = await Promise.all(this.servers.map(s => s.initialize(params, token)))
+        responsesList = responsesList.filter(r => r != undefined)
+        const errors = responsesList.find(el => el instanceof ResponseError)
+        if (errors) {
+            return errors as ResponseError<InitializeError>
+        }
+        const dupServerNames = findDuplicates(responsesList.map(r => (r as PartialInitializeResult).serverInfo?.name))
+        if (dupServerNames) {
+            return new ResponseError(
+                ErrorCodes.InternalError,
+                `Duplicate servers defined: ${dupServerNames.join(', ')}`
+            )
+        }
+
+        const resultList = responsesList as InitializeResult[]
         const defaultResponse: InitializeResult = {
             serverInfo: {
                 name: this.name,
@@ -56,12 +74,6 @@ export class LspRouter {
                 },
             },
         }
-        let responsesList = await Promise.all(this.servers.map(s => s.initialize(params, token)))
-        responsesList = responsesList.filter(r => r != undefined)
-        if (responsesList.some(el => el instanceof ResponseError)) {
-            return responsesList.find(el => el instanceof ResponseError) as ResponseError<InitializeError>
-        }
-        const resultList = responsesList as InitializeResult[]
         resultList.unshift(defaultResponse)
 
         return resultList.reduceRight((acc, curr) => {

--- a/runtimes/runtimes/lsp/router/util.ts
+++ b/runtimes/runtimes/lsp/router/util.ts
@@ -57,7 +57,11 @@ export function findDuplicates<T>(array: T[]): T[] | undefined {
     const dups = array
         .filter(a => a !== undefined)
         .filter(function (a) {
-            return seen.size === seen.add(a).size
+            if (seen.has(a)) {
+                return true
+            }
+            seen.add(a)
+            return false
         })
     return dups.length > 0 ? dups : undefined
 }

--- a/runtimes/runtimes/lsp/router/util.ts
+++ b/runtimes/runtimes/lsp/router/util.ts
@@ -51,3 +51,13 @@ export function mergeObjects(obj1: any, obj2: any) {
     }
     return merged
 }
+
+export function findDuplicates<T>(array: T[]): T[] | undefined {
+    const seen = new Set<T>()
+    const dups = array
+        .filter(a => a !== undefined)
+        .filter(function (a) {
+            return seen.size === seen.add(a).size
+        })
+    return dups.length > 0 ? dups : undefined
+}

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -199,7 +199,9 @@ export const standalone = (props: RuntimeProps) => {
         }
 
         const notification: Notification = {
-            showNotification: params => lspConnection.sendNotification(showNotificationRequestType.method, params),
+            showNotification: params =>
+                lspRouter.clientSupportsShowNotification ??
+                lspConnection.sendNotification(showNotificationRequestType.method, params),
             onNotificationFollowup: handler =>
                 lspConnection.onNotification(notificationFollowupRequestType.method, handler),
         }

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -114,7 +114,9 @@ export const webworker = (props: RuntimeProps) => {
     }
 
     const notification: Notification = {
-        showNotification: params => lspConnection.sendNotification(showNotificationRequestType.method, params),
+        showNotification: params =>
+            lspRouter.clientSupportsShowNotification ??
+            lspConnection.sendNotification(showNotificationRequestType.method, params),
         onNotificationFollowup: handler =>
             lspConnection.onNotification(notificationFollowupRequestType.method, handler),
     }

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -58,6 +58,17 @@ export type PartialServerCapabilities<T = any> = Pick<
     | 'signatureHelpProvider'
 >
 export type PartialInitializeResult<T = any> = {
+    /**
+     * Information about the server respresented by @type {Server}.
+     * serverInfo is used to differentiate servers internally in the system and is not exposed to the client.
+     */
+    serverInfo?: {
+        /**
+         * The name is expect to be unique per server. It also has to be persistent/durable
+         * across sessions and versions of application.
+         */
+        name: string
+    }
     capabilities: PartialServerCapabilities<T>
     awsServerCapabilities?: {
         chatOptions?: ChatOptions


### PR DESCRIPTION
## Problem

Notification protocol should be an optional capability for clients - it should support dynamic registration via client capabilities.

## Solution

This change introduces `showNotification as a client capability. Client has to explicitly opt in to receive notifications.

In addition, the following changes were introduced:
- notification followup has to be sent per action (array was replaced with single action)
- server interface supports setting server name
- server name is checked for unique value in runtime

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
