### PR TITLE
Add GetSsoTokenResult.updateCredentialsParams to avoid decrypt/recrtypt in destinations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,17 @@
 {
     "configurations": [
         {
+            "name": "Attach to AWS Documents Language Server",
+            "type": "node",
+            "request": "attach",
+            "port": 6012, // Hard defined in the vscode client activation.ts
+            "outFiles": ["${workspaceFolder}/**/out/**/*.js"],
+            "restart": {
+                "maxAttempts": 10,
+                "delay": 1000
+            }
+        },
+        {
             "type": "node",
             "request": "launch",
             "preLaunchTask": "watch",

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -1,4 +1,10 @@
-import { LSPErrorCodes, ProtocolNotificationType, ProtocolRequestType, ResponseError } from './lsp'
+import {
+    LSPErrorCodes,
+    ProtocolNotificationType,
+    ProtocolRequestType,
+    ResponseError,
+    UpdateCredentialsParams,
+} from './lsp'
 
 // Errors
 export const AwsErrorCodes = {
@@ -169,6 +175,7 @@ export interface SsoToken {
 
 export interface GetSsoTokenResult {
     ssoToken: SsoToken
+    updateCredentialsParams: UpdateCredentialsParams
 }
 
 // Potential error codes: E_UNKNOWN | E_TIMEOUT | E_ENCRYPTION_REQUIRED | E_INVALID_TOKEN

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -287,10 +287,19 @@ export const standalone = (props: RuntimeProps) => {
 
                             // Encrypt SsoToken.accessToken before sending to client
                             if (result && !(result instanceof Error) && encryptionKey) {
-                                result.ssoToken.accessToken = await encryptObjectWithKey(
-                                    result.ssoToken.accessToken,
-                                    encryptionKey
-                                )
+                                if (result.ssoToken.accessToken) {
+                                    result.ssoToken.accessToken = await encryptObjectWithKey(
+                                        result.ssoToken.accessToken,
+                                        encryptionKey
+                                    )
+                                }
+                                if (result.updateCredentialsParams.data) {
+                                    result.updateCredentialsParams.data = await encryptObjectWithKey(
+                                        result.updateCredentialsParams.data,
+                                        encryptionKey
+                                    )
+                                    result.updateCredentialsParams.encrypted = true
+                                }
                             }
 
                             return result


### PR DESCRIPTION
For the purposes of calling the Auth.update method in Flare with the results of GetSsoToken, destinations would need to decrypt the accessToken returned and reformat it for Auth.update.  While the ssoToken field is intended for extension and use of a token directly in a destination, there is value in avoiding decrypt/recrypt for destinations that need to call Auth.update.

This PR adds GetSsoTokenResult.updateCredentialsParams to provide the params a destination may provide to the Auth.update API without requiring any tranformation or work from the destination.  This is similar to the LSP ExecuteCommand pattern allowing servers to provide the appropriate arguments to a command so a client can just return what it received without need for additional detail or work.