### PR TITLE
UpdateCredentialsParams requires nested 'data' fields for encrypted credentials

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -293,9 +293,10 @@ export const standalone = (props: RuntimeProps) => {
                                         encryptionKey
                                     )
                                 }
-                                if (result.updateCredentialsParams.data) {
+                                if (result.updateCredentialsParams.data && !result.updateCredentialsParams.encrypted) {
                                     result.updateCredentialsParams.data = await encryptObjectWithKey(
-                                        result.updateCredentialsParams.data,
+                                        // decodeCredentialsRequestToken expects nested 'data' fields
+                                        { data: result.updateCredentialsParams.data },
                                         encryptionKey
                                     )
                                     result.updateCredentialsParams.encrypted = true


### PR DESCRIPTION
UpdateCredentialsParams requires nested 'data' fields for encrypted credentials.  The standalone encryption needs to insert the extra data field nesting.

## Details
[decodeCredentialsRequestToken](https://github.com/aws/language-server-runtimes/blob/f1be234d5b336d76dc8b72517ca38a71b3818322/runtimes/runtimes/auth/auth.ts#L153) is used by the Auth update call to decrypt the token. It expects the encrypted `payload` (i.e. the return value from `encryptObjectWithKey`) to contain a `data` property. `request.data` was already dereferenced a few lines above and passed into `jwtDecrypt`.

[encryptObjectWithKey](https://github.com/aws/language-server-runtimes/blob/f1be234d5b336d76dc8b72517ca38a71b3818322/runtimes/runtimes/auth/standalone/encryption.ts#L93) is used in several places in the code base, including in [standalone](https://github.com/aws/language-server-runtimes/blob/f1be234d5b336d76dc8b72517ca38a71b3818322/runtimes/runtimes/standalone.ts#L288) for the purposes of encrypting the token. It encrypts what it receives without transformation and that is the ciphertext returned. Other places used such as chat don't do any wrapping in `{ data: ... }` like what is expected for `UpdateCredentialsParams`.

There is an impedance mismatch in the type union of [UpdateCredentialsParams.data](https://github.com/aws/language-server-runtimes/blob/f1be234d5b336d76dc8b72517ca38a71b3818322/types/auth.ts#L21) that is not obvious (to the coder or TypeScript) as the encrypted value is just a string. Notice `BearerCredentials` defined above in the code doesn't have the data field, it just goes straight to the token field.

It's unclear if the extra data field is intentional in only this one use case of encryption or if it was an oversight. Either way, existing code in destinations supplies this format, so it can't be changed easily now.

This cannot be fixed in language-servers.  `BearerCredentials` can't be passed as the unencrypted analog and expect language-server-runtimes to do the right thing as the code stands now. The nested data field needs to be added, but TypeScript won't allow it or it has to be kludged with an as `unknown as BearerCredentials` which is asking for trouble down the road.

This requires the encryption statement in standalone to add the extra data field.  This will also work correctly for `IamCredentials` should they be used in the future.