### PR TITLE
Remove ensureSsoAccountAccessScope from UpdateProfileOptions as sso:a…

### DIFF
--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -96,14 +96,12 @@ export const listProfilesRequestType = new ProtocolRequestType<
 export interface UpdateProfileOptions {
     createNonexistentProfile?: boolean
     createNonexistentSsoSession?: boolean
-    ensureSsoAccountAccessScope?: boolean
     updateSharedSsoSession?: boolean
 }
 
 export const updateProfileOptionsDefaults = {
     createNonexistentProfile: true,
     createNonexistentSsoSession: true,
-    ensureSsoAccountAccessScope: true,
     updateSharedSsoSession: false,
 } satisfies UpdateProfileOptions
 


### PR DESCRIPTION
Removing implicit sso:account:access scope in aws-lsp-identity.  Removing unnecessary option from UpdateProfile.