### PR TITLE
Update runtimes version to 0.2.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2343,7 +2343,7 @@
         },
         "runtimes": {
             "name": "@aws/language-server-runtimes",
-            "version": "0.2.26",
+            "version": "0.2.27",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.7",

--- a/runtimes/CHANGELOG.md
+++ b/runtimes/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.27] - 2024-11-15
+
+### Changed
+- Identity Management: Put SSO token inside the 'data' field for encrypted credentials as required by Auth
+
+### Removed
+- Identity Management: Removed implicit sso:account:access scope in aws-lsp-identity. Removing unnecessary option from UpdateProfile
+
 ## [0.2.26] - 2024-11-13
 
 ### Added

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes",
-    "version": "0.2.26",
+    "version": "0.2.27",
     "description": "Runtimes to host Language Servers for AWS",
     "files": [
         "out",


### PR DESCRIPTION
## Notes
Releasing runtimes 0.2.27

### Changed
- Identity Management: Put SSO token inside the 'data' field for encrypted credentials as required by Auth

### Removed
- Identity Management: Removed implicit sso:account:access scope in aws-lsp-identity. Removing unnecessary option from UpdateProfile



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
