### PR TITLE
Routing for notifications

### DIFF
--- a/runtimes/runtimes/encoding.test.ts
+++ b/runtimes/runtimes/encoding.test.ts
@@ -1,0 +1,27 @@
+import assert from 'assert'
+import { WebBase64Encoding } from './encoding'
+import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
+
+describe('WebBase64Encoding', () => {
+    const wdw = <WindowOrWorkerGlobalScope>{}
+    const encoding = new WebBase64Encoding(wdw)
+
+    it('encodes and decodes string', () => {
+        const val = 'server1__1'
+        const encodedVal = 'xxxx'
+        wdw.btoa = sinon.stub().withArgs(val).returns(encodedVal)
+        wdw.atob = sinon.stub().withArgs(encodedVal).returns(val)
+        const valAfterEncoding = encoding.decode(encoding.encode(val))
+        assert.equal(valAfterEncoding, val)
+    })
+
+    it('encodes and decodes unicode', () => {
+        const val = 'Σ'
+        const convertedVal = 'Î£'
+        const encodedVal = 'xxxx'
+        wdw.btoa = sinon.stub().withArgs(convertedVal).returns(encodedVal)
+        wdw.atob = sinon.stub().withArgs(encodedVal).returns(convertedVal)
+        const valAfterEncoding = encoding.decode(encoding.encode(val))
+        assert.equal(valAfterEncoding, val)
+    })
+})

--- a/runtimes/runtimes/encoding.ts
+++ b/runtimes/runtimes/encoding.ts
@@ -1,0 +1,34 @@
+export interface Encoding {
+    decode(value: string): string
+    encode(value: string): string
+}
+
+export class WebBase64Encoding implements Encoding {
+    constructor(private window: WindowOrWorkerGlobalScope) {}
+
+    decode(value: string): string {
+        if (!value) {
+            return value
+        }
+        const decoded = this.window.atob(value)
+        // to support Unicode chars
+        return decodeURIComponent(
+            Array.from(decoded)
+                .map(char => {
+                    return '%' + ('00' + char.charCodeAt(0).toString(16)).slice(-2)
+                })
+                .join('')
+        )
+    }
+
+    encode(value: string): string {
+        if (!value) {
+            return value
+        }
+        // to support Unicode chars
+        const converted = encodeURIComponent(value).replace(/%([0-9A-F]{2})/g, (_, arg) => {
+            return String.fromCharCode(parseInt(arg, 16))
+        })
+        return this.window.btoa(converted)
+    }
+}

--- a/runtimes/runtimes/encoding.ts
+++ b/runtimes/runtimes/encoding.ts
@@ -3,30 +3,26 @@ export interface Encoding {
     encode(value: string): string
 }
 
+const HEX_PAD: string = '00'
+const HEX_REGEX: RegExp = /%([0-9A-F]{2})/g
 export class WebBase64Encoding implements Encoding {
     constructor(private window: WindowOrWorkerGlobalScope) {}
 
     decode(value: string): string {
-        if (!value) {
-            return value
-        }
         const decoded = this.window.atob(value)
         // to support Unicode chars
         return decodeURIComponent(
             Array.from(decoded)
                 .map(char => {
-                    return '%' + ('00' + char.charCodeAt(0).toString(16)).slice(-2)
+                    return '%' + (HEX_PAD + char.charCodeAt(0).toString(16)).slice(-2)
                 })
                 .join('')
         )
     }
 
     encode(value: string): string {
-        if (!value) {
-            return value
-        }
         // to support Unicode chars
-        const converted = encodeURIComponent(value).replace(/%([0-9A-F]{2})/g, (_, arg) => {
+        const converted = encodeURIComponent(value).replace(HEX_REGEX, (_, arg) => {
             return String.fromCharCode(parseInt(arg, 16))
         })
         return this.window.btoa(converted)

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -19,14 +19,7 @@ import { LspServer } from './lspServer'
 describe('LspRouter', () => {
     const sandbox = sinon.createSandbox()
 
-    const lspConnection = <Connection>{
-        onInitialize: (handler: any) => {},
-        onInitialized: (handler: any) => {},
-        onExecuteCommand: (handler: any) => {},
-        onRequest: (handler: any) => {},
-        onDidChangeConfiguration: (handler: any) => {},
-    }
-
+    const lspConnection = stubLspConnection()
     let executeCommandHandler: RequestHandler<ExecuteCommandParams, any | undefined | null, void>
     let initializeHandler: RequestHandler<InitializeParams, PartialInitializeResult, InitializeError>
 
@@ -59,24 +52,6 @@ describe('LspRouter', () => {
             const initParam = {} as InitializeParams
             initializeHandler(initParam, {} as CancellationToken)
             assert(lspRouter.clientInitializeParams === initParam)
-        })
-
-        it('should set clientSupportsShowNotification from InitializeParam', () => {
-            assert.equal(lspRouter.clientSupportsNotifications, false)
-
-            const initParam = {
-                initializationOptions: {
-                    aws: {
-                        awsClientCapabilities: {
-                            window: {
-                                notifications: true,
-                            },
-                        },
-                    },
-                },
-            } as InitializeParams
-            initializeHandler(initParam, {} as CancellationToken)
-            assert.equal(lspRouter.clientSupportsNotifications, true)
         })
 
         it('should return the default response when no handlers are registered', async () => {
@@ -397,6 +372,16 @@ describe('LspRouter', () => {
         })
     })
 
+    function stubLspConnection() {
+        return <Connection>{
+            onInitialize: (handler: any) => {},
+            onInitialized: (handler: any) => {},
+            onExecuteCommand: (handler: any) => {},
+            onRequest: (handler: any) => {},
+            onDidChangeConfiguration: (handler: any) => {},
+        }
+    }
+
     function newServer({
         didChangeConfigurationHandler,
         executeCommandHandler,
@@ -410,7 +395,7 @@ describe('LspRouter', () => {
         initializeHandler?: any
         initializedHandler?: any
     }) {
-        const server = new LspServer()
+        const server = new LspServer(stubLspConnection())
         server.setDidChangeConfigurationHandler(didChangeConfigurationHandler)
         server.setExecuteCommandHandler(executeCommandHandler)
         server.setServerConfigurationHandler(getServerConfigurationHandler)

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -62,7 +62,7 @@ describe('LspRouter', () => {
         })
 
         it('should set clientSupportsShowNotification from InitializeParam', () => {
-            assert.equal(lspRouter.clientSupportsShowNotification, false)
+            assert.equal(lspRouter.clientSupportsNotifications, false)
 
             const initParam = {
                 initializationOptions: {
@@ -76,7 +76,7 @@ describe('LspRouter', () => {
                 },
             } as InitializeParams
             initializeHandler(initParam, {} as CancellationToken)
-            assert.equal(lspRouter.clientSupportsShowNotification, true)
+            assert.equal(lspRouter.clientSupportsNotifications, true)
         })
 
         it('should return the default response when no handlers are registered', async () => {
@@ -353,7 +353,7 @@ describe('LspRouter', () => {
             }
 
             const params: GetConfigurationFromServerParams = { section: 'test' }
-            const result = await lspRouter.handleGetConfigurationFromServer(params, {} as CancellationToken)
+            const result = await lspRouter.getConfigurationFromServer(params, {} as CancellationToken)
             assert.strictEqual(result, 'server2')
         })
 
@@ -392,7 +392,7 @@ describe('LspRouter', () => {
             }
 
             const params: GetConfigurationFromServerParams = { section: 'something' }
-            const result = await lspRouter.handleGetConfigurationFromServer(params, {} as CancellationToken)
+            const result = await lspRouter.getConfigurationFromServer(params, {} as CancellationToken)
             assert.strictEqual(result, undefined)
         })
     })

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -5,6 +5,9 @@ import {
     GetConfigurationFromServerParams,
     InitializeError,
     InitializeResult,
+    MessageType,
+    NotificationFollowupParams,
+    NotificationParams,
     RequestHandler,
     ResponseError,
     TextDocumentSyncKind,
@@ -15,11 +18,21 @@ import assert from 'assert'
 import sinon from 'sinon'
 import { PartialInitializeResult, InitializeParams } from '../../../server-interface/lsp'
 import { LspServer } from './lspServer'
+import { Logging } from '../../../server-interface'
+import { Encoding } from '../../encoding'
 
 describe('LspRouter', () => {
     const sandbox = sinon.createSandbox()
 
+    const encoding: Encoding = {
+        encode: (value: string) => value,
+        decode: (value: string) => value,
+    }
+    const logging = <Logging>{
+        log: sandbox.stub(),
+    }
     const lspConnection = stubLspConnection()
+
     let executeCommandHandler: RequestHandler<ExecuteCommandParams, any | undefined | null, void>
     let initializeHandler: RequestHandler<InitializeParams, PartialInitializeResult, InitializeError>
 
@@ -372,12 +385,106 @@ describe('LspRouter', () => {
         })
     })
 
+    describe('notifications', () => {
+        const initHandler = () => {
+            return {
+                serverInfo: {
+                    name: 'Notification Server',
+                },
+            }
+        }
+        const initParam = {
+            initializationOptions: {
+                aws: {
+                    awsClientCapabilities: {
+                        window: {
+                            notifications: true,
+                        },
+                    },
+                },
+            },
+        }
+        const notificationParams: NotificationParams = {
+            id: 'id-1',
+            type: MessageType.Info,
+            content: {
+                text: 'Update happened',
+            },
+        }
+
+        it('should send notification if notifications are supported and server name is defined', async () => {
+            const notificationSpy = sandbox.spy()
+            const lspConn = <Connection>{}
+            lspConn.sendNotification = notificationSpy
+
+            const server = newServer({ lspConnection: lspConn, initializeHandler: initHandler })
+            await server.initialize(initParam as InitializeParams, {} as CancellationToken)
+
+            server.notification.showNotification(notificationParams)
+
+            assert(notificationSpy.calledOnce)
+        })
+
+        it('should not send notification if server name is not defined', async () => {
+            const notificationSpy = sandbox.spy()
+            const lspConn = <Connection>{}
+            lspConn.sendNotification = notificationSpy
+
+            const server = newServer({
+                lspConnection: lspConn,
+                initializeHandler: () => {
+                    // no server name defined
+                },
+            })
+            await server.initialize(initParam as InitializeParams, {} as CancellationToken)
+
+            server.notification.showNotification(notificationParams)
+
+            assert(notificationSpy.notCalled)
+        })
+
+        it('should not send notification if not supported by client', async () => {
+            const notificationSpy = sandbox.spy()
+            const lspConn = <Connection>{}
+            lspConn.sendNotification = notificationSpy
+
+            const server = newServer({ lspConnection: lspConn, initializeHandler: initHandler })
+            await server.initialize({} as InitializeParams, {} as CancellationToken)
+
+            server.notification.showNotification(notificationParams)
+
+            assert(notificationSpy.notCalled)
+        })
+
+        it('should send followup to source server by matching server name in id', async () => {
+            const lspConn = <Connection>{}
+
+            const server = newServer({ lspConnection: lspConn, initializeHandler: initHandler })
+            await server.initialize(initParam as InitializeParams, {} as CancellationToken)
+            lspRouter.servers = [server]
+
+            const notificationFollowupSpy = sandbox.spy()
+            server.notification.onNotificationFollowup(notificationFollowupSpy)
+
+            const notificationFollowup: NotificationFollowupParams = {
+                source: {
+                    id: '{"serverName":"Notification Server", "id":"1"}',
+                },
+                action: 'Acknowledge',
+            }
+            lspRouter.onNotificationFollowup(notificationFollowup)
+
+            assert(notificationFollowupSpy.calledOnce)
+        })
+    })
+
     function stubLspConnection() {
         return <Connection>{
             onInitialize: (handler: any) => {},
             onInitialized: (handler: any) => {},
             onExecuteCommand: (handler: any) => {},
             onRequest: (handler: any) => {},
+            onNotification: (handler: any) => {},
             onDidChangeConfiguration: (handler: any) => {},
         }
     }
@@ -388,14 +495,16 @@ describe('LspRouter', () => {
         getServerConfigurationHandler,
         initializeHandler,
         initializedHandler,
+        lspConnection,
     }: {
         didChangeConfigurationHandler?: any
         executeCommandHandler?: any
         getServerConfigurationHandler?: any
         initializeHandler?: any
         initializedHandler?: any
+        lspConnection?: Connection
     }) {
-        const server = new LspServer(stubLspConnection())
+        const server = new LspServer(lspConnection || stubLspConnection(), encoding, logging)
         server.setDidChangeConfigurationHandler(didChangeConfigurationHandler)
         server.setExecuteCommandHandler(executeCommandHandler)
         server.setServerConfigurationHandler(getServerConfigurationHandler)

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -34,13 +34,6 @@ export class LspRouter {
         lspConnection.onRequest(getConfigurationFromServerRequestType, this.getConfigurationFromServer)
     }
 
-    public get clientSupportsNotifications() {
-        return (
-            this.clientInitializeParams?.initializationOptions?.aws.awsClientCapabilities?.window?.notifications ??
-            false
-        )
-    }
-
     initialize = async (
         params: InitializeParams,
         token: CancellationToken

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -12,6 +12,8 @@ import {
     InitializeResult,
     ResponseError,
     TextDocumentSyncKind,
+    notificationFollowupRequestType,
+    NotificationFollowupParams,
 } from '../../../protocol'
 import { Connection } from 'vscode-languageserver/node'
 import { LspServer } from './lspServer'
@@ -32,6 +34,7 @@ export class LspRouter {
         lspConnection.onInitialize(this.initialize)
         lspConnection.onInitialized(this.onInitialized)
         lspConnection.onRequest(getConfigurationFromServerRequestType, this.getConfigurationFromServer)
+        lspConnection.onNotification(notificationFollowupRequestType, this.onNotificationFollowup)
     }
 
     initialize = async (
@@ -108,6 +111,10 @@ export class LspRouter {
         }
 
         this.routeNotificationToAllServers((server, params) => server.sendInitializedNotification(params), params)
+    }
+
+    onNotificationFollowup = (params: NotificationFollowupParams): void => {
+        this.routeNotificationToAllServers((server, params) => server.sendNotificationFollowup(params), params)
     }
 
     private async routeRequestToFirstCapableServer<P, R>(

--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -9,12 +9,15 @@ import {
     RequestHandler,
     ResponseError,
     showNotificationRequestType,
-    notificationFollowupRequestType,
+    NotificationFollowupParams,
+    NotificationParams,
 } from '../../../protocol'
 import { InitializeParams, PartialInitializeResult, PartialServerCapabilities } from '../../../server-interface/lsp'
-import { Notification } from '../../../server-interface'
+import { Logging, Notification } from '../../../server-interface'
 import { asPromise } from './util'
 import { Connection } from 'vscode-languageserver/node'
+import { RouterByServerName } from './routerByServerName'
+import { Encoding } from '../../encoding'
 
 export class LspServer {
     readonly notification: Notification
@@ -24,20 +27,34 @@ export class LspServer {
     private getServerConfigurationHandler?: RequestHandler<GetConfigurationFromServerParams, any, void>
     private initializeHandler?: RequestHandler<InitializeParams, PartialInitializeResult, InitializeError>
     private initializedHandler?: NotificationHandler<InitializedParams>
-    private serverCapabilities?: PartialServerCapabilities
-    private awsServerCapabilities?: PartialInitializeResult['awsServerCapabilities']
-    private clientSupportsNotifications?: boolean
 
-    constructor(private lspConnection: Connection) {
+    private clientSupportsNotifications?: boolean
+    private initializeResult?: PartialInitializeResult
+
+    private notificationRouter?: RouterByServerName<NotificationParams, NotificationFollowupParams>
+    private notificationFollowupHandler?: NotificationHandler<NotificationFollowupParams>
+
+    constructor(
+        private lspConnection: Connection,
+        private encoding: Encoding,
+        private logger: Logging
+    ) {
         this.notification = {
-            showNotification: params =>
-                this.clientSupportsNotifications ??
-                this.lspConnection.sendNotification(showNotificationRequestType.method, params),
-            onNotificationFollowup: handler =>
-                this.lspConnection.onNotification(notificationFollowupRequestType.method, handler),
+            showNotification: params => {
+                if (this.clientSupportsNotifications) {
+                    if (!this.notificationRouter) {
+                        this.logger.log(`Notifications are not supported: serverInfo is not defined`)
+                    }
+                    this.notificationRouter?.send(
+                        params => this.lspConnection.sendNotification(showNotificationRequestType.method, params),
+                        params
+                    )
+                }
+            },
+            onNotificationFollowup: handler => {
+                this.notificationFollowupHandler = handler
+            },
         }
-        // TODO: start defining routing logic for the events above
-        // TODO: tests for notification routing
     }
 
     // TODO: Remove those handler setters below
@@ -80,8 +97,10 @@ export class LspServer {
 
         const initializeResult = await asPromise(this.initializeHandler(params, token))
         if (!(initializeResult instanceof ResponseError)) {
-            this.serverCapabilities = initializeResult.capabilities
-            this.awsServerCapabilities = initializeResult.awsServerCapabilities
+            this.initializeResult = initializeResult
+            if (initializeResult?.serverInfo) {
+                this.notificationRouter = new RouterByServerName(initializeResult.serverInfo.name, this.encoding)
+            }
         }
 
         return initializeResult
@@ -92,7 +111,7 @@ export class LspServer {
         token: CancellationToken
     ): Promise<[boolean, any | undefined | null]> => {
         if (
-            this.serverCapabilities?.executeCommandProvider?.commands.some(c => c === params.command) &&
+            this.initializeResult?.capabilities?.executeCommandProvider?.commands.some(c => c === params.command) &&
             this.executeCommandHandler
         ) {
             const result = await asPromise(this.executeCommandHandler(params, token))
@@ -107,7 +126,9 @@ export class LspServer {
         token: CancellationToken
     ): Promise<[boolean, any | undefined | null]> => {
         if (
-            this.awsServerCapabilities?.configurationProvider?.sections.some(c => c === params.section) &&
+            this.initializeResult?.awsServerCapabilities?.configurationProvider?.sections.some(
+                c => c === params.section
+            ) &&
             this.getServerConfigurationHandler
         ) {
             const result = await asPromise(this.getServerConfigurationHandler(params, token))
@@ -118,14 +139,16 @@ export class LspServer {
     }
 
     public sendDidChangeConfigurationNotification = (params: DidChangeConfigurationParams): void => {
-        if (this.didChangeConfigurationHandler) {
-            this.didChangeConfigurationHandler(params)
-        }
+        this.didChangeConfigurationHandler?.(params)
     }
 
     public sendInitializedNotification = (params: InitializedParams): void => {
-        if (this.initializedHandler) {
-            this.initializedHandler(params)
+        this.initializedHandler?.(params)
+    }
+
+    public sendNotificationFollowup = (params: NotificationFollowupParams): void => {
+        if (this.notificationFollowupHandler && this.notificationRouter) {
+            this.notificationRouter.processFollowup(this.notificationFollowupHandler, params)
         }
     }
 }

--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -57,7 +57,6 @@ export class LspServer {
         }
     }
 
-    // TODO: Remove those handler setters below
     public setInitializedHandler = (handler: NotificationHandler<InitializedParams>): void => {
         this.initializedHandler = handler
     }

--- a/runtimes/runtimes/lsp/router/routerByServerName.test.ts
+++ b/runtimes/runtimes/lsp/router/routerByServerName.test.ts
@@ -1,0 +1,61 @@
+import sinon, { assert } from 'sinon'
+import { Encoding } from '../../encoding'
+import { EventIdentifier, FollowupIdentifier } from '../../../protocol'
+import { RouterByServerName } from './routerByServerName'
+
+describe('RouterByServerName', () => {
+    const encoding = <Encoding>{
+        encode: value => Buffer.from(value).toString('base64'),
+        decode: value => Buffer.from(value, 'base64').toString('utf-8'),
+    }
+    const serverName = 'Server_XXX'
+
+    let router: RouterByServerName<Partial<EventIdentifier>, FollowupIdentifier>
+
+    beforeEach(() => {
+        router = new RouterByServerName<Partial<EventIdentifier>, FollowupIdentifier>(serverName, encoding)
+    })
+
+    describe('send', () => {
+        it('attaches serverName to id if id is defined', () => {
+            const sendSpy = sinon.spy()
+            router.send(sendSpy, { id: '123' })
+
+            const expectedEncodedId = encoding.encode('{"serverName":"Server_XXX","id":"123"}')
+            assert.calledWithMatch(sendSpy, { id: expectedEncodedId })
+        })
+        it('uses original params if id is not defined', () => {
+            const sendSpy = sinon.spy()
+            router.send(sendSpy, {})
+            assert.calledWith(sendSpy, {})
+        })
+    })
+    describe('processFollowup', () => {
+        it('calls followup handler if id contains serverName', () => {
+            const followupHandlerSpy = sinon.spy()
+            const params = {
+                source: {
+                    id: encoding.encode('{"serverName":"Server_XXX", "id":"123"}'),
+                },
+            }
+            router.processFollowup(followupHandlerSpy, params)
+            assert.calledOnce(followupHandlerSpy)
+        })
+        it('does not call followup handler if id does not contain serverName', () => {
+            const followupHandlerSpy = sinon.spy()
+            const params = { source: { id: 'A' } }
+            router.processFollowup(followupHandlerSpy, params)
+            assert.notCalled(followupHandlerSpy)
+        })
+        it('does not call followup handler if id contains different serverName', () => {
+            const followupHandlerSpy = sinon.spy()
+            const params = {
+                source: {
+                    id: encoding.encode('{"serverName":"Fake", "id":"123"}'),
+                },
+            }
+            router.processFollowup(followupHandlerSpy, params)
+            assert.notCalled(followupHandlerSpy)
+        })
+    })
+})

--- a/runtimes/runtimes/lsp/router/routerByServerName.test.ts
+++ b/runtimes/runtimes/lsp/router/routerByServerName.test.ts
@@ -31,7 +31,7 @@ describe('RouterByServerName', () => {
         })
     })
     describe('processFollowup', () => {
-        it('calls followup handler if id contains serverName', () => {
+        it('calls followup handler if id contains serverName and removes serverName from id', () => {
             const followupHandlerSpy = sinon.spy()
             const params = {
                 source: {
@@ -39,7 +39,7 @@ describe('RouterByServerName', () => {
                 },
             }
             router.processFollowup(followupHandlerSpy, params)
-            assert.calledOnce(followupHandlerSpy)
+            assert.calledOnceWithMatch(followupHandlerSpy, { source: { id: '123' } })
         })
         it('does not call followup handler if id does not contain serverName', () => {
             const followupHandlerSpy = sinon.spy()

--- a/runtimes/runtimes/lsp/router/routerByServerName.ts
+++ b/runtimes/runtimes/lsp/router/routerByServerName.ts
@@ -1,0 +1,55 @@
+import { EventIdentifier, FollowupIdentifier, NotificationHandler } from '../../../protocol'
+import { Encoding } from '../../encoding'
+
+type NotificationId = {
+    serverName: string
+    id: string
+}
+
+export class RouterByServerName<P extends Partial<EventIdentifier>, F extends FollowupIdentifier> {
+    constructor(
+        private serverName: string,
+        private encoding: Encoding
+    ) {}
+
+    send(sendHandler: (params: P) => Promise<void>, params: P) {
+        const attachServerName = (): P => {
+            const idObject = {
+                serverName: this.serverName,
+                id: params.id!,
+            }
+            const id = this.encoding.encode(JSON.stringify(idObject))
+            return {
+                ...params,
+                id,
+            }
+        }
+
+        const sendParams = params.id ? attachServerName() : params
+        sendHandler(sendParams)
+    }
+
+    processFollowup(followupHandler: NotificationHandler<F>, params: F) {
+        if (!params.source.id) {
+            return
+        }
+
+        const id = this.encoding.decode(params.source.id)
+        if (this.parseServerName(id) === this.serverName) {
+            params = {
+                ...params,
+                id,
+            }
+            followupHandler(params)
+        }
+    }
+
+    private parseServerName(idJson: string): string | null {
+        try {
+            const { serverName } = JSON.parse(idJson) as NotificationId
+            return serverName
+        } catch (e) {
+            return null
+        }
+    }
+}

--- a/runtimes/runtimes/lsp/router/routerByServerName.ts
+++ b/runtimes/runtimes/lsp/router/routerByServerName.ts
@@ -34,20 +34,22 @@ export class RouterByServerName<P extends Partial<EventIdentifier>, F extends Fo
             return
         }
 
-        const id = this.encoding.decode(params.source.id)
-        if (this.parseServerName(id) === this.serverName) {
+        const sourceId = this.encoding.decode(params.source.id)
+        const id = this.parseServerName(sourceId)
+        if (id?.serverName === this.serverName) {
             params = {
                 ...params,
-                id,
+                source: {
+                    id: id.id,
+                },
             }
             followupHandler(params)
         }
     }
 
-    private parseServerName(idJson: string): string | null {
+    private parseServerName(idJson: string): NotificationId | null {
         try {
-            const { serverName } = JSON.parse(idJson) as NotificationId
-            return serverName
+            return JSON.parse(idJson) as NotificationId
         } catch (e) {
             return null
         }

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -200,7 +200,7 @@ export const standalone = (props: RuntimeProps) => {
 
         const notification: Notification = {
             showNotification: params =>
-                lspRouter.clientSupportsShowNotification ??
+                lspRouter.clientSupportsNotifications ??
                 lspConnection.sendNotification(showNotificationRequestType.method, params),
             onNotificationFollowup: handler =>
                 lspConnection.onNotification(notificationFollowupRequestType.method, handler),

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -56,6 +56,7 @@ import { LspServer } from './lsp/router/lspServer'
 import { BaseChat } from './chat/baseChat'
 import { checkAWSConfigFile } from './util/sharedConfigFile'
 import { getServerDataDirPath } from './util/serverDataDirPath'
+import { Encoding } from './encoding'
 
 // Honor shared aws config file
 if (checkAWSConfigFile()) {
@@ -233,6 +234,11 @@ export const standalone = (props: RuntimeProps) => {
             platform: os.platform(),
         }
 
+        const encoding: Encoding = {
+            encode: value => Buffer.from(value).toString('base64'),
+            decode: value => Buffer.from(value, 'base64').toString('utf-8'),
+        }
+
         // Create router that will be routing LSP events from the client to server(s)
         const lspRouter = new LspRouter(lspConnection, props.name, props.version)
 
@@ -240,7 +246,7 @@ export const standalone = (props: RuntimeProps) => {
         const disposables = props.servers.map(s => {
             // Create LSP server representation that holds internal server state
             // and processes LSP event handlers
-            const lspServer = new LspServer(lspConnection)
+            const lspServer = new LspServer(lspConnection, encoding, logging)
             lspRouter.servers.push(lspServer)
 
             // Set up LSP events handlers per server

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -115,7 +115,7 @@ export const webworker = (props: RuntimeProps) => {
 
     const notification: Notification = {
         showNotification: params =>
-            lspRouter.clientSupportsShowNotification ??
+            lspRouter.clientSupportsNotifications ??
             lspConnection.sendNotification(showNotificationRequestType.method, params),
         onNotificationFollowup: handler =>
             lspConnection.onNotification(notificationFollowupRequestType.method, handler),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -113,12 +113,12 @@ export const webworker = (props: RuntimeProps) => {
         onFollowUpClicked: handler => lspConnection.onNotification(followUpClickNotificationType.method, handler),
     }
 
-    const notification: Notification = {
-        showNotification: params =>
-            lspRouter.clientSupportsNotifications ??
-            lspConnection.sendNotification(showNotificationRequestType.method, params),
-        onNotificationFollowup: handler =>
-            lspConnection.onNotification(notificationFollowupRequestType.method, handler),
+    const identityManagement: IdentityManagement = {
+        onListProfiles: handler => lspConnection.onRequest(listProfilesRequestType, handler),
+        onUpdateProfile: handler => lspConnection.onRequest(updateProfileRequestType, handler),
+        onGetSsoToken: handler => lspConnection.onRequest(getSsoTokenRequestType, handler),
+        onInvalidateSsoToken: handler => lspConnection.onRequest(invalidateSsoTokenRequestType, handler),
+        sendSsoTokenChanged: params => lspConnection.sendNotification(ssoTokenChangedRequestType, params),
     }
 
     // Set up auth without encryption
@@ -136,7 +136,7 @@ export const webworker = (props: RuntimeProps) => {
     const disposables = props.servers.map(s => {
         // Create server representation, processing LSP event handlers, in runtimes
         // and add it to the LSP router
-        const lspServer = new LspServer()
+        const lspServer = new LspServer(lspConnection)
         lspRouter.servers.push(lspServer)
 
         // Set up LSP events handlers per server
@@ -179,14 +179,6 @@ export const webworker = (props: RuntimeProps) => {
             },
         }
 
-        const identityManagement: IdentityManagement = {
-            onListProfiles: handler => lspConnection.onRequest(listProfilesRequestType, handler),
-            onUpdateProfile: handler => lspConnection.onRequest(updateProfileRequestType, handler),
-            onGetSsoToken: handler => lspConnection.onRequest(getSsoTokenRequestType, handler),
-            onInvalidateSsoToken: handler => lspConnection.onRequest(invalidateSsoTokenRequestType, handler),
-            sendSsoTokenChanged: params => lspConnection.sendNotification(ssoTokenChangedRequestType, params),
-        }
-
         return s({
             chat,
             credentialsProvider,
@@ -196,7 +188,7 @@ export const webworker = (props: RuntimeProps) => {
             logging,
             runtime,
             identityManagement,
-            notification,
+            notification: lspServer.notification,
         })
     })
 

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -28,10 +28,6 @@ import {
     ShowMessageNotification,
     ShowMessageRequest,
     ShowDocumentRequest,
-
-    // Notification
-    showNotificationRequestType,
-    notificationFollowupRequestType,
 } from '../protocol'
 import { BrowserMessageReader, BrowserMessageWriter, createConnection } from 'vscode-languageserver/browser'
 import { Chat, Logging, Lsp, Runtime, Telemetry, Workspace, Notification } from '../server-interface'
@@ -50,6 +46,7 @@ import {
     updateProfileRequestType,
 } from '../protocol/identity-management'
 import { IdentityManagement } from '../server-interface/identity-management'
+import { Encoding, WebBase64Encoding } from './encoding'
 
 declare const self: WindowOrWorkerGlobalScope
 
@@ -132,11 +129,13 @@ export const webworker = (props: RuntimeProps) => {
         platform: 'browser',
     }
 
+    const encoding = new WebBase64Encoding(self)
+
     // Initialize every Server
     const disposables = props.servers.map(s => {
         // Create server representation, processing LSP event handlers, in runtimes
         // and add it to the LSP router
-        const lspServer = new LspServer(lspConnection)
+        const lspServer = new LspServer(lspConnection, encoding, logging)
         lspRouter.servers.push(lspServer)
 
         // Set up LSP events handlers per server

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -60,7 +60,7 @@ export type PartialServerCapabilities<T = any> = Pick<
 export type PartialInitializeResult<T = any> = {
     /**
      * Information about the server respresented by @type {Server}.
-     * serverInfo is used to differentiate servers internally in the system and is not exposed to the client.
+     * serverInfo is used to differentiate servers internally in the system and is not exposed to a client.
      */
     serverInfo?: {
         /**

--- a/runtimes/server-interface/notification.ts
+++ b/runtimes/server-interface/notification.ts
@@ -1,5 +1,10 @@
 import { NotificationParams, NotificationFollowupParams, NotificationHandler } from '../protocol'
 
+/*
+ * The notification feature interface. To use the feature:
+ * - Server must define "serverInfo" in initialize result of @type {PartialInitializeResult}.
+ * - Notifications must contain id in @type {NotificationParams}
+ */
 export type Notification = {
     showNotification: (params: NotificationParams) => void
     onNotificationFollowup: (handler: NotificationHandler<NotificationFollowupParams>) => void


### PR DESCRIPTION
## Problem

Notification followup events from client need to be routed to the server of origin.

## Solution

- Routing of notification followup events based on `serverName` + `id`, `id` fields is restored for followup events
- Encoding for web runtime supporting Unicode (should not be directly needed for routing functionality, but I wanted it supported from the very beginning for consistency with NodeJs version)
- Some refactoring in router by adding helper methods to make routing strategy used more explicit
- Unit tests
- Testing in test vscode client - result can be seen here: https://github.com/aws/language-servers/pull/622

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
