### PR TITLE
Support more log levels in runtime logging feature

### DIFF
--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -136,11 +136,16 @@ Design TBD
 
 #### Initialization
 
-TBD
+The runtimes by default supports the logging feature, allowing servers to output logs varied by different log levels. 
 
 #### Feature Specification
 
-TBD
+The log level to be set in the runtime for logging can be decided by the client as part of initialize request, which is the first
+request initiated by client to the LSP server. The log level can be updated dynamically even after server start by triggering `workspace/didChangeConfiguration` 
+notification from the client - which prompts the runtime to fetch the new log level to be set from the client through LSP `getConfigurations` request. 
+1. Params in the initialize request: `InitializeParams.initializationOptions.logLevel`
+2. Configuration request params for requesting log level from runtimes to client: ``{section: "aws.logLevel"}`` 
+
 
 ### Chat
 

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -8,6 +8,7 @@ import {
     RequestType,
 } from 'vscode-languageserver-protocol'
 import { ChatOptions } from '@aws/language-server-runtimes-types'
+import { LogLevel } from '../runtimes/util/loggingUtil'
 
 export * from '@aws/language-server-runtimes-types'
 export { TextDocument } from 'vscode-languageserver-textdocument'
@@ -114,6 +115,7 @@ export interface AWSInitializationOptions {
 export interface InitializeParams extends _InitializeParamsBase {
     initializationOptions?: {
         [key: string]: any
+        logLevel?: LogLevel
         aws: AWSInitializationOptions
     }
 }

--- a/runtimes/runtimes/lsp/router/loggingServer.ts
+++ b/runtimes/runtimes/lsp/router/loggingServer.ts
@@ -2,17 +2,17 @@ import { InitializeParams, InitializeResult, Logging } from '../../../server-int
 import { LspServer } from './lspServer'
 import { Connection } from 'vscode-languageserver/node'
 import { Encoding } from '../../encoding'
-import { DEFAULT_LOG_LEVEL, isValidLogLevel, LoggingImplementation, LogLevel } from '../../util/loggingUtil'
+import { DEFAULT_LOG_LEVEL, isValidLogLevel, DefaultLogger, LogLevel } from '../../util/loggingUtil'
 
 export class LoggingServer {
-    private logger: Logging
+    private logger: DefaultLogger
     private lspServer: LspServer
 
     constructor(
         private lspConnection: Connection,
         private encoding: Encoding
     ) {
-        this.logger = new LoggingImplementation(DEFAULT_LOG_LEVEL as LogLevel, this.lspConnection)
+        this.logger = new DefaultLogger(DEFAULT_LOG_LEVEL as LogLevel, this.lspConnection)
         this.lspServer = new LspServer(this.lspConnection, this.encoding, this.logger)
         this.lspServer.setInitializeHandler(async (params: InitializeParams): Promise<InitializeResult> => {
             this.updateLoggingLevel(params.initializationOptions?.logLevel ?? ('log' as LogLevel))

--- a/runtimes/runtimes/lsp/router/loggingServer.ts
+++ b/runtimes/runtimes/lsp/router/loggingServer.ts
@@ -32,6 +32,7 @@ export class LoggingServer {
 
     private updateLoggingLevel(logLevel: LogLevel) {
         this.logger.level = logLevel
+        this.logger.info(`Logging level changed to ${logLevel}`)
     }
 
     public getLoggingObject(): Logging {

--- a/runtimes/runtimes/lsp/router/loggingServer.ts
+++ b/runtimes/runtimes/lsp/router/loggingServer.ts
@@ -1,0 +1,44 @@
+import { InitializeParams, InitializeResult, Logging } from '../../../server-interface'
+import { LspServer } from './lspServer'
+import { Connection } from 'vscode-languageserver/node'
+import { Encoding } from '../../encoding'
+import { DEFAULT_LOG_LEVEL, isValidLogLevel, LoggingImplementation, LogLevel } from '../../util/loggingUtil'
+
+export class LoggingServer {
+    private logger: Logging
+    private lspServer: LspServer
+
+    constructor(
+        private lspConnection: Connection,
+        private encoding: Encoding
+    ) {
+        this.logger = new LoggingImplementation(DEFAULT_LOG_LEVEL as LogLevel, this.lspConnection)
+        this.lspServer = new LspServer(this.lspConnection, this.encoding, this.logger)
+        this.lspServer.setInitializeHandler(async (params: InitializeParams): Promise<InitializeResult> => {
+            this.updateLoggingLevel(params.initializationOptions?.logLevel ?? ('log' as LogLevel))
+            return {
+                capabilities: {},
+            }
+        })
+        this.lspServer.setDidChangeConfigurationHandler(async params => {
+            const logLevelConfig = await lspConnection.workspace.getConfiguration({
+                section: 'aws.logLevel',
+            })
+            if (isValidLogLevel(logLevelConfig)) {
+                this.updateLoggingLevel(logLevelConfig as LogLevel)
+            }
+        })
+    }
+
+    private updateLoggingLevel(logLevel: LogLevel) {
+        this.logger.level = logLevel
+    }
+
+    public getLoggingObject(): Logging {
+        return this.logger
+    }
+
+    public getLspServer(): LspServer {
+        return this.lspServer
+    }
+}

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -29,7 +29,12 @@ describe('LspRouter', () => {
         decode: (value: string) => value,
     }
     const logging = <Logging>{
+        level: 'info',
         log: sandbox.stub(),
+        debug: sandbox.stub(),
+        error: sandbox.stub(),
+        warn: sandbox.stub(),
+        info: sandbox.stub(),
     }
     const lspConnection = stubLspConnection()
 

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -29,7 +29,6 @@ describe('LspRouter', () => {
         decode: (value: string) => value,
     }
     const logging = <Logging>{
-        level: 'info',
         log: sandbox.stub(),
         debug: sandbox.stub(),
         error: sandbox.stub(),

--- a/runtimes/runtimes/standalone.test.ts
+++ b/runtimes/runtimes/standalone.test.ts
@@ -13,7 +13,6 @@ import * as authModule from './auth/auth'
 import * as encryptedChatModule from './chat/encryptedChat'
 import * as baseChatModule from './chat/baseChat'
 import { pathToFileURL } from 'url'
-import * as loggingModule from '../runtimes/util/loggingUtil'
 import { LogLevel } from '../runtimes/util/loggingUtil'
 
 describe('standalone', () => {
@@ -40,7 +39,6 @@ describe('standalone', () => {
         stubConnection = stubInterface<vscodeLanguageServer.Connection>()
         stubConnection.console = stubInterface<vscodeLanguageServer.RemoteConsole>()
         stubConnection.telemetry = stubInterface<vscodeLanguageServer.Telemetry>()
-        sinon.stub(loggingModule, 'getLoggingUtility').resolves(mockLoggingUtility)
         sinon.stub(vscodeLanguageServer, 'createConnection').returns(stubConnection)
 
         lspRouterStub = stubInterface<lspRouterModule.LspRouter>()
@@ -57,14 +55,14 @@ describe('standalone', () => {
         let chatStub: sinon.SinonStubbedInstance<encryptedChatModule.EncryptedChat> & encryptedChatModule.EncryptedChat
         let baseChatStub: sinon.SinonStubbedInstance<baseChatModule.BaseChat> & baseChatModule.BaseChat
 
-        it('should initialize without encryption when no key is present', async () => {
+        it('should initialize without encryption when no key is present', () => {
             sinon.stub(authEncryptionModule, 'shouldWaitForEncryptionKey').returns(false)
             authStub = stubInterface<authModule.Auth>()
             sinon.stub(authModule, 'Auth').returns(authStub)
             baseChatStub = stubInterface<baseChatModule.BaseChat>()
             sinon.stub(baseChatModule, 'BaseChat').returns(baseChatStub)
 
-            await standalone(props)
+            standalone(props)
 
             sinon.assert.calledWithExactly(authModule.Auth as unknown as sinon.SinonStub, stubConnection)
             sinon.assert.calledWithExactly(
@@ -72,7 +70,7 @@ describe('standalone', () => {
                 'Runtime: Initializing runtime without encryption'
             )
             sinon.assert.calledWithExactly(baseChatModule.BaseChat as unknown as sinon.SinonStub, stubConnection)
-            sinon.assert.calledOnce(lspRouterStub.servers.push as sinon.SinonStub)
+            sinon.assert.calledTwice(lspRouterStub.servers.push as sinon.SinonStub)
             sinon.assert.calledOnce(stubConnection.listen)
         })
 
@@ -113,8 +111,7 @@ describe('standalone', () => {
                 encryptionInitialization.key,
                 encryptionInitialization.mode
             )
-            await setTimeout(() => Promise.resolve(), 1000)
-            sinon.assert.calledOnce(lspRouterStub.servers.push as sinon.SinonStub)
+            sinon.assert.calledTwice(lspRouterStub.servers.push as sinon.SinonStub)
             sinon.assert.calledOnce(stubConnection.listen)
         })
     })
@@ -122,8 +119,8 @@ describe('standalone', () => {
     describe('features', () => {
         let features: Features
 
-        beforeEach(async () => {
-            await standalone(props)
+        beforeEach(() => {
+            standalone(props)
             features = stubServer.getCall(0).args[0]
         })
 

--- a/runtimes/runtimes/standalone.test.ts
+++ b/runtimes/runtimes/standalone.test.ts
@@ -113,9 +113,9 @@ describe('standalone', () => {
                 encryptionInitialization.key,
                 encryptionInitialization.mode
             )
-            // TODO: The below one fails as it tries to test async inside async, need to check back later
-            // sinon.assert.calledOnce(lspRouterStub.servers.push as sinon.SinonStub)
-            // sinon.assert.calledOnce(stubConnection.listen)
+            await setTimeout(() => Promise.resolve(), 1000)
+            sinon.assert.calledOnce(lspRouterStub.servers.push as sinon.SinonStub)
+            sinon.assert.calledOnce(stubConnection.listen)
         })
     })
 

--- a/runtimes/runtimes/standalone.test.ts
+++ b/runtimes/runtimes/standalone.test.ts
@@ -13,21 +13,12 @@ import * as authModule from './auth/auth'
 import * as encryptedChatModule from './chat/encryptedChat'
 import * as baseChatModule from './chat/baseChat'
 import { pathToFileURL } from 'url'
-import { LogLevel } from '../runtimes/util/loggingUtil'
 
 describe('standalone', () => {
     let stubServer: sinon.SinonStub
     let props: RuntimeProps
     let stubConnection: sinon.SinonStubbedInstance<vscodeLanguageServer.Connection> & vscodeLanguageServer.Connection
     let lspRouterStub: sinon.SinonStubbedInstance<lspRouterModule.LspRouter> & lspRouterModule.LspRouter
-    const mockLoggingUtility = {
-        debug: sinon.stub(),
-        error: sinon.stub(),
-        info: sinon.stub(),
-        warn: sinon.stub(),
-        log: sinon.stub(),
-        level: 'info' as LogLevel,
-    }
 
     beforeEach(() => {
         stubServer = sinon.stub()

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -59,6 +59,7 @@ import { LspServer } from './lsp/router/lspServer'
 import { BaseChat } from './chat/baseChat'
 import { checkAWSConfigFile } from './util/sharedConfigFile'
 import { getServerDataDirPath } from './util/serverDataDirPath'
+import { getLoggingUtility } from './util/loggingUtil'
 
 // Honor shared aws config file
 if (checkAWSConfigFile()) {
@@ -130,15 +131,9 @@ export const standalone = (props: RuntimeProps) => {
     // TODO: make this dependent on the actual requirements of the
     // capabilities parameter.
 
-    function initializeRuntime(encryptionKey?: string) {
+    async function initializeRuntime(encryptionKey?: string) {
         const documents = new TextDocuments(TextDocument)
-
-        // Set up logging over LSP
-        // TODO: set up Logging once implemented
-        const logging: Logging = {
-            log: message => lspConnection.console.info(`[${new Date().toISOString()}] ${message}`),
-        }
-
+        const logging: Logging = await getLoggingUtility(lspConnection)
         // Set up telemetry over LSP
         const telemetry: Telemetry = {
             emitMetric: metric => lspConnection.telemetry.logEvent(metric),

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -93,7 +93,7 @@ if (checkAWSConfigFile()) {
  * @param props.servers The list of servers to initialize and run
  * @returns
  */
-export const standalone = (props: RuntimeProps) => {
+export const standalone = async (props: RuntimeProps) => {
     handleVersionArgument(props.version)
 
     const lspConnection = createConnection(ProposedFeatures.all)

--- a/runtimes/runtimes/util/loggingUtil.test.ts
+++ b/runtimes/runtimes/util/loggingUtil.test.ts
@@ -55,7 +55,7 @@ describe('LoggingUtil', () => {
     })
 
     describe('LoggingImplementation', () => {
-        it('should test implementation of Logging', async () => {
+        it('should check logging method of configured log level are called', async () => {
             const logging = new LoggingImplementation('warn', mockConnection as Connection)
             assert.strictEqual('warn', logging.level)
             assert.strictEqual('function', typeof logging.error)

--- a/runtimes/runtimes/util/loggingUtil.test.ts
+++ b/runtimes/runtimes/util/loggingUtil.test.ts
@@ -1,19 +1,12 @@
 import { Connection, RemoteConsole } from 'vscode-languageserver/node'
-import { Configuration } from 'vscode-languageserver/lib/common/configuration'
-import { getLoggingUtility, getLogLevel, isLogLevelEnabled, isValidLogLevel, LogLevel } from './loggingUtil'
+import { isLogLevelEnabled, isValidLogLevel, LoggingImplementation, LogLevel } from './loggingUtil'
 import sinon from 'sinon'
 import assert from 'assert'
 
 describe('LoggingUtil', () => {
     let mockConnection: Partial<Connection>
-    let workspaceMock: Pick<Configuration, 'getConfiguration'>
     let consoleMock: Pick<RemoteConsole, 'error' | 'warn' | 'info' | 'log' | 'debug'>
-    let configStub: sinon.SinonStub
     beforeEach(() => {
-        configStub = sinon.stub()
-        workspaceMock = {
-            getConfiguration: configStub,
-        }
         consoleMock = {
             log: sinon.stub(),
             error: sinon.stub(),
@@ -22,7 +15,6 @@ describe('LoggingUtil', () => {
             debug: sinon.stub(),
         }
         mockConnection = {
-            workspace: workspaceMock as any,
             console: consoleMock as any,
         }
     })
@@ -40,7 +32,7 @@ describe('LoggingUtil', () => {
         })
 
         it('should return false for invalid log levels', () => {
-            const invalidLevels = ['trace', 'verbose']
+            const invalidLevels = ['trace', 'verbose', undefined, null]
             invalidLevels.forEach(level => {
                 assert.strictEqual(false, isValidLogLevel(level as LogLevel))
             })
@@ -62,69 +54,24 @@ describe('LoggingUtil', () => {
         })
     })
 
-    describe('getLogLevel', () => {
-        it('should return debug log level', async () => {
-            configStub.resolves('debug')
-            let result = await getLogLevel(mockConnection as Connection)
-            assert.strictEqual('debug', result)
-        })
-
-        it('should return info log level', async () => {
-            configStub.resolves('info')
-            let result = await getLogLevel(mockConnection as Connection)
-            assert.strictEqual('info', result)
-        })
-
-        it('should return log log level', async () => {
-            configStub.resolves('log')
-            let result = await getLogLevel(mockConnection as Connection)
-            assert.strictEqual('log', result)
-        })
-
-        it('should return warn log level', async () => {
-            configStub.resolves('warn')
-            let result = await getLogLevel(mockConnection as Connection)
-            assert.strictEqual('warn', result)
-        })
-
-        it('should return error log level', async () => {
-            configStub.resolves('error')
-            let result = await getLogLevel(mockConnection as Connection)
-            assert.strictEqual('error', result)
-        })
-
-        it('should return default log level when configuration is invalid', async () => {
-            configStub.resolves('random-value')
-            const result = await getLogLevel(mockConnection as Connection)
-            assert.strictEqual('log', result)
-        })
-
-        it('should return default log level when configuration is undefined', async () => {
-            configStub.resolves(undefined)
-            const result = await getLogLevel(mockConnection as Connection)
-            assert.strictEqual('log', result)
-        })
-    })
-
-    describe('getLoggingUtility', () => {
-        it('should return a logging utility', async () => {
-            configStub.resolves('warn')
-            const loggingUtility = await getLoggingUtility(mockConnection as Connection)
-            assert.strictEqual('warn', loggingUtility.level)
-            assert.strictEqual('function', typeof loggingUtility.error)
-            assert.strictEqual('function', typeof loggingUtility.warn)
-            assert.strictEqual('function', typeof loggingUtility.info)
-            assert.strictEqual('function', typeof loggingUtility.log)
-            assert.strictEqual('function', typeof loggingUtility.debug)
-            loggingUtility.error('test error message')
+    describe('LoggingImplementation', () => {
+        it('should test implementation of Logging', async () => {
+            const logging = new LoggingImplementation('warn', mockConnection as Connection)
+            assert.strictEqual('warn', logging.level)
+            assert.strictEqual('function', typeof logging.error)
+            assert.strictEqual('function', typeof logging.warn)
+            assert.strictEqual('function', typeof logging.info)
+            assert.strictEqual('function', typeof logging.log)
+            assert.strictEqual('function', typeof logging.debug)
+            logging.error('test error message')
             sinon.assert.calledOnceWithMatch(mockConnection.console?.error as sinon.SinonStub, 'test error message')
-            loggingUtility.warn('test warn message')
+            logging.warn('test warn message')
             sinon.assert.calledOnceWithMatch(mockConnection.console?.warn as sinon.SinonStub, 'test warn message')
-            loggingUtility.info('test info message')
+            logging.info('test info message')
             sinon.assert.notCalled(mockConnection.console?.info as sinon.SinonStub)
-            loggingUtility.log('test log message')
+            logging.log('test log message')
             sinon.assert.notCalled(mockConnection.console?.log as sinon.SinonStub)
-            loggingUtility.debug('test debug message')
+            logging.debug('test debug message')
             sinon.assert.notCalled(mockConnection.console?.debug as sinon.SinonStub)
         })
     })

--- a/runtimes/runtimes/util/loggingUtil.test.ts
+++ b/runtimes/runtimes/util/loggingUtil.test.ts
@@ -1,5 +1,5 @@
 import { Connection, RemoteConsole } from 'vscode-languageserver/node'
-import { isLogLevelEnabled, isValidLogLevel, LoggingImplementation, LogLevel } from './loggingUtil'
+import { isLogLevelEnabled, isValidLogLevel, DefaultLogger, LogLevel } from './loggingUtil'
 import sinon from 'sinon'
 import assert from 'assert'
 
@@ -54,9 +54,9 @@ describe('LoggingUtil', () => {
         })
     })
 
-    describe('LoggingImplementation', () => {
+    describe('DefaultLogger implementation', () => {
         it('should check logging method of configured log level are called', async () => {
-            const logging = new LoggingImplementation('warn', mockConnection as Connection)
+            const logging = new DefaultLogger('warn', mockConnection as Connection)
             assert.strictEqual('warn', logging.level)
             assert.strictEqual('function', typeof logging.error)
             assert.strictEqual('function', typeof logging.warn)

--- a/runtimes/runtimes/util/loggingUtil.test.ts
+++ b/runtimes/runtimes/util/loggingUtil.test.ts
@@ -1,0 +1,131 @@
+import { Connection, RemoteConsole } from 'vscode-languageserver/node'
+import { Configuration } from 'vscode-languageserver/lib/common/configuration'
+import { getLoggingUtility, getLogLevel, isLogLevelEnabled, isValidLogLevel, LogLevel } from './loggingUtil'
+import sinon from 'sinon'
+import assert from 'assert'
+
+describe('LoggingUtil', () => {
+    let mockConnection: Partial<Connection>
+    let workspaceMock: Pick<Configuration, 'getConfiguration'>
+    let consoleMock: Pick<RemoteConsole, 'error' | 'warn' | 'info' | 'log' | 'debug'>
+    let configStub: sinon.SinonStub
+    beforeEach(() => {
+        configStub = sinon.stub()
+        workspaceMock = {
+            getConfiguration: configStub,
+        }
+        consoleMock = {
+            log: sinon.stub(),
+            error: sinon.stub(),
+            warn: sinon.stub(),
+            info: sinon.stub(),
+            debug: sinon.stub(),
+        }
+        mockConnection = {
+            workspace: workspaceMock as any,
+            console: consoleMock as any,
+        }
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('isValidLogLevel', () => {
+        it('should return true for valid log levels', () => {
+            const validLevels: LogLevel[] = ['error', 'warn', 'info', 'log', 'debug']
+            validLevels.forEach(level => {
+                assert.strictEqual(true, isValidLogLevel(level))
+            })
+        })
+
+        it('should return false for invalid log levels', () => {
+            const invalidLevels = ['trace', 'verbose']
+            invalidLevels.forEach(level => {
+                assert.strictEqual(false, isValidLogLevel(level as LogLevel))
+            })
+        })
+    })
+
+    describe('isLogLevelEnabled', () => {
+        it('should correctly compare log levels based on hierarchy', () => {
+            const testCases = [
+                { level1: 'debug', level2: 'error', expected: true },
+                { level1: 'error', level2: 'debug', expected: false },
+                { level1: 'info', level2: 'warn', expected: true },
+                { level1: 'warn', level2: 'error', expected: true },
+                { level1: 'error', level2: 'error', expected: true },
+            ]
+            testCases.forEach(({ level1, level2, expected }) => {
+                assert.strictEqual(expected, isLogLevelEnabled(level1 as LogLevel, level2 as LogLevel))
+            })
+        })
+    })
+
+    describe('getLogLevel', () => {
+        it('should return debug log level', async () => {
+            configStub.resolves('debug')
+            let result = await getLogLevel(mockConnection as Connection)
+            assert.strictEqual('debug', result)
+        })
+
+        it('should return info log level', async () => {
+            configStub.resolves('info')
+            let result = await getLogLevel(mockConnection as Connection)
+            assert.strictEqual('info', result)
+        })
+
+        it('should return log log level', async () => {
+            configStub.resolves('log')
+            let result = await getLogLevel(mockConnection as Connection)
+            assert.strictEqual('log', result)
+        })
+
+        it('should return warn log level', async () => {
+            configStub.resolves('warn')
+            let result = await getLogLevel(mockConnection as Connection)
+            assert.strictEqual('warn', result)
+        })
+
+        it('should return error log level', async () => {
+            configStub.resolves('error')
+            let result = await getLogLevel(mockConnection as Connection)
+            assert.strictEqual('error', result)
+        })
+
+        it('should return default log level when configuration is invalid', async () => {
+            configStub.resolves('random-value')
+            const result = await getLogLevel(mockConnection as Connection)
+            assert.strictEqual('log', result)
+        })
+
+        it('should return default log level when configuration is undefined', async () => {
+            configStub.resolves(undefined)
+            const result = await getLogLevel(mockConnection as Connection)
+            assert.strictEqual('log', result)
+        })
+    })
+
+    describe('getLoggingUtility', () => {
+        it('should return a logging utility', async () => {
+            configStub.resolves('warn')
+            const loggingUtility = await getLoggingUtility(mockConnection as Connection)
+            assert.strictEqual('warn', loggingUtility.level)
+            assert.strictEqual('function', typeof loggingUtility.error)
+            assert.strictEqual('function', typeof loggingUtility.warn)
+            assert.strictEqual('function', typeof loggingUtility.info)
+            assert.strictEqual('function', typeof loggingUtility.log)
+            assert.strictEqual('function', typeof loggingUtility.debug)
+            loggingUtility.error('test error message')
+            sinon.assert.calledOnceWithMatch(mockConnection.console?.error as sinon.SinonStub, 'test error message')
+            loggingUtility.warn('test warn message')
+            sinon.assert.calledOnceWithMatch(mockConnection.console?.warn as sinon.SinonStub, 'test warn message')
+            loggingUtility.info('test info message')
+            sinon.assert.notCalled(mockConnection.console?.info as sinon.SinonStub)
+            loggingUtility.log('test log message')
+            sinon.assert.notCalled(mockConnection.console?.log as sinon.SinonStub)
+            loggingUtility.debug('test debug message')
+            sinon.assert.notCalled(mockConnection.console?.debug as sinon.SinonStub)
+        })
+    })
+})

--- a/runtimes/runtimes/util/loggingUtil.ts
+++ b/runtimes/runtimes/util/loggingUtil.ts
@@ -1,22 +1,22 @@
 import { Logging } from '../../server-interface'
 import { Connection, MessageType } from 'vscode-languageserver/node'
 
-export type LogLevel = 'error' | 'warn' | 'info' | 'log' | 'debug'
-
-const logLevelMap: Record<LogLevel, number> = {
+const LOG_LEVELS = {
     error: MessageType.Error,
     warn: MessageType.Warning,
     info: MessageType.Info,
     log: MessageType.Log,
     debug: MessageType.Debug,
-}
+} as const
+
+export type LogLevel = keyof typeof LOG_LEVELS
 
 export const isLogLevelEnabled = (l1: LogLevel, l2: LogLevel): boolean => {
-    return logLevelMap[l1] >= logLevelMap[l2]
+    return LOG_LEVELS[l1] >= LOG_LEVELS[l2]
 }
 
 export const isValidLogLevel = (level: LogLevel): boolean => {
-    return ['error', 'warn', 'info', 'log', 'debug'].includes(level)
+    return Object.keys(LOG_LEVELS).includes(level)
 }
 
 export const DEFAULT_LOG_LEVEL: LogLevel = 'log'
@@ -30,29 +30,15 @@ export class LoggingImplementation implements Logging {
         this.lspConnection = connection
     }
 
-    error = (message: string) => {
-        if (isLogLevelEnabled(this.level, 'error')) {
-            this.lspConnection.console.error(`[${new Date().toISOString()}] ${message}`)
+    sendToLog(logLevel: LogLevel, message: string): void {
+        if (isLogLevelEnabled(this.level, logLevel)) {
+            this.lspConnection.console[logLevel](`[${new Date().toISOString()}] ${message}`)
         }
     }
-    warn = (message: string) => {
-        if (isLogLevelEnabled(this.level, 'warn')) {
-            this.lspConnection.console.warn(`[${new Date().toISOString()}] ${message}`)
-        }
-    }
-    info = (message: string) => {
-        if (isLogLevelEnabled(this.level, 'info')) {
-            this.lspConnection.console.info(`[${new Date().toISOString()}] ${message}`)
-        }
-    }
-    log = (message: string) => {
-        if (isLogLevelEnabled(this.level, 'log')) {
-            this.lspConnection.console.log(`[${new Date().toISOString()}] ${message}`)
-        }
-    }
-    debug = (message: string) => {
-        if (isLogLevelEnabled(this.level, 'debug')) {
-            this.lspConnection.console.debug(`[${new Date().toISOString()}] ${message}`)
-        }
-    }
+
+    error = (message: string) => this.sendToLog('error', message)
+    warn = (message: string) => this.sendToLog('warn', message)
+    info = (message: string) => this.sendToLog('info', message)
+    log = (message: string) => this.sendToLog('log', message)
+    debug = (message: string) => this.sendToLog('debug', message)
 }

--- a/runtimes/runtimes/util/loggingUtil.ts
+++ b/runtimes/runtimes/util/loggingUtil.ts
@@ -16,7 +16,7 @@ export const isLogLevelEnabled = (l1: LogLevel, l2: LogLevel): boolean => {
 }
 
 export const isValidLogLevel = (level: LogLevel): boolean => {
-    return level && typeof level === 'string' && ['fatal', 'error', 'warn', 'info', 'log', 'debug'].includes(level)
+    return level && typeof level === 'string' && ['error', 'warn', 'info', 'log', 'debug'].includes(level)
 }
 
 const DEFAULT_LOG_LEVEL: LogLevel = 'log'

--- a/runtimes/runtimes/util/loggingUtil.ts
+++ b/runtimes/runtimes/util/loggingUtil.ts
@@ -1,14 +1,14 @@
 import { Logging } from '../../server-interface'
-import { Connection } from 'vscode-languageserver/node'
+import { Connection, MessageType } from 'vscode-languageserver/node'
 
 export type LogLevel = 'error' | 'warn' | 'info' | 'log' | 'debug'
 
 const logLevelMap: Record<LogLevel, number> = {
-    error: 0,
-    warn: 1,
-    info: 2,
-    log: 3,
-    debug: 4,
+    error: MessageType.Error,
+    warn: MessageType.Warning,
+    info: MessageType.Info,
+    log: MessageType.Log,
+    debug: MessageType.Debug,
 }
 
 export const isLogLevelEnabled = (l1: LogLevel, l2: LogLevel): boolean => {
@@ -16,53 +16,43 @@ export const isLogLevelEnabled = (l1: LogLevel, l2: LogLevel): boolean => {
 }
 
 export const isValidLogLevel = (level: LogLevel): boolean => {
-    return level && typeof level === 'string' && ['error', 'warn', 'info', 'log', 'debug'].includes(level)
+    return ['error', 'warn', 'info', 'log', 'debug'].includes(level)
 }
 
-const DEFAULT_LOG_LEVEL: LogLevel = 'log'
+export const DEFAULT_LOG_LEVEL: LogLevel = 'log'
 
-export const getLogLevel = async (lspConnection: Connection): Promise<LogLevel> => {
-    const logLevelConfig = await lspConnection.workspace.getConfiguration({
-        section: 'logLevel',
-    })
-    return isValidLogLevel(logLevelConfig) ? logLevelConfig : DEFAULT_LOG_LEVEL
-}
+export class LoggingImplementation implements Logging {
+    public level: LogLevel
+    private lspConnection: Connection
 
-export const getLoggingUtility = async (lspConnection: Connection): Promise<Logging> => {
-    let logLevel: LogLevel
-    try {
-        logLevel = await getLogLevel(lspConnection)
-    } catch {
-        logLevel = DEFAULT_LOG_LEVEL
+    constructor(level: LogLevel, connection: Connection) {
+        this.level = level
+        this.lspConnection = connection
     }
 
-    const logging: Logging = {
-        level: logLevel,
-        error: message => {
-            if (isLogLevelEnabled(logLevel, 'error')) {
-                lspConnection.console.error(`[${new Date().toISOString()}] ${message}`)
-            }
-        },
-        warn: message => {
-            if (isLogLevelEnabled(logLevel, 'warn')) {
-                lspConnection.console.warn(`[${new Date().toISOString()}] ${message}`)
-            }
-        },
-        info: message => {
-            if (isLogLevelEnabled(logLevel, 'info')) {
-                lspConnection.console.info(`[${new Date().toISOString()}] ${message}`)
-            }
-        },
-        log: message => {
-            if (isLogLevelEnabled(logLevel, 'log')) {
-                lspConnection.console.log(`[${new Date().toISOString()}] ${message}`)
-            }
-        },
-        debug: message => {
-            if (isLogLevelEnabled(logLevel, 'debug')) {
-                lspConnection.console.debug(`[${new Date().toISOString()}] ${message}`)
-            }
-        },
+    error = (message: string) => {
+        if (isLogLevelEnabled(this.level, 'error')) {
+            this.lspConnection.console.error(`[${new Date().toISOString()}] ${message}`)
+        }
     }
-    return logging
+    warn = (message: string) => {
+        if (isLogLevelEnabled(this.level, 'warn')) {
+            this.lspConnection.console.warn(`[${new Date().toISOString()}] ${message}`)
+        }
+    }
+    info = (message: string) => {
+        if (isLogLevelEnabled(this.level, 'info')) {
+            this.lspConnection.console.info(`[${new Date().toISOString()}] ${message}`)
+        }
+    }
+    log = (message: string) => {
+        if (isLogLevelEnabled(this.level, 'log')) {
+            this.lspConnection.console.log(`[${new Date().toISOString()}] ${message}`)
+        }
+    }
+    debug = (message: string) => {
+        if (isLogLevelEnabled(this.level, 'debug')) {
+            this.lspConnection.console.debug(`[${new Date().toISOString()}] ${message}`)
+        }
+    }
 }

--- a/runtimes/runtimes/util/loggingUtil.ts
+++ b/runtimes/runtimes/util/loggingUtil.ts
@@ -21,7 +21,7 @@ export const isValidLogLevel = (level: LogLevel): boolean => {
 
 export const DEFAULT_LOG_LEVEL: LogLevel = 'log'
 
-export class LoggingImplementation implements Logging {
+export class DefaultLogger implements Logging {
     public level: LogLevel
     private lspConnection: Connection
 

--- a/runtimes/runtimes/util/loggingUtil.ts
+++ b/runtimes/runtimes/util/loggingUtil.ts
@@ -1,0 +1,68 @@
+import { Logging } from '../../server-interface'
+import { Connection } from 'vscode-languageserver/node'
+
+export type LogLevel = 'error' | 'warn' | 'info' | 'log' | 'debug'
+
+const logLevelMap: Record<LogLevel, number> = {
+    error: 0,
+    warn: 1,
+    info: 2,
+    log: 3,
+    debug: 4,
+}
+
+export const isLogLevelEnabled = (l1: LogLevel, l2: LogLevel): boolean => {
+    return logLevelMap[l1] >= logLevelMap[l2]
+}
+
+export const isValidLogLevel = (level: LogLevel): boolean => {
+    return level && typeof level === 'string' && ['fatal', 'error', 'warn', 'info', 'log', 'debug'].includes(level)
+}
+
+const DEFAULT_LOG_LEVEL: LogLevel = 'log'
+
+export const getLogLevel = async (lspConnection: Connection): Promise<LogLevel> => {
+    const logLevelConfig = await lspConnection.workspace.getConfiguration({
+        section: 'logLevel',
+    })
+    return isValidLogLevel(logLevelConfig) ? logLevelConfig : DEFAULT_LOG_LEVEL
+}
+
+export const getLoggingUtility = async (lspConnection: Connection): Promise<Logging> => {
+    let logLevel: LogLevel
+    try {
+        logLevel = await getLogLevel(lspConnection)
+    } catch {
+        logLevel = DEFAULT_LOG_LEVEL
+    }
+
+    const logging: Logging = {
+        level: logLevel,
+        error: message => {
+            if (isLogLevelEnabled(logLevel, 'error')) {
+                lspConnection.console.error(`[${new Date().toISOString()}] ${message}`)
+            }
+        },
+        warn: message => {
+            if (isLogLevelEnabled(logLevel, 'warn')) {
+                lspConnection.console.warn(`[${new Date().toISOString()}] ${message}`)
+            }
+        },
+        info: message => {
+            if (isLogLevelEnabled(logLevel, 'info')) {
+                lspConnection.console.info(`[${new Date().toISOString()}] ${message}`)
+            }
+        },
+        log: message => {
+            if (isLogLevelEnabled(logLevel, 'log')) {
+                lspConnection.console.log(`[${new Date().toISOString()}] ${message}`)
+            }
+        },
+        debug: message => {
+            if (isLogLevelEnabled(logLevel, 'debug')) {
+                lspConnection.console.debug(`[${new Date().toISOString()}] ${message}`)
+            }
+        },
+    }
+    return logging
+}

--- a/runtimes/runtimes/webworker.test.ts
+++ b/runtimes/runtimes/webworker.test.ts
@@ -36,16 +36,16 @@ describe('webworker', () => {
         delete (global as any).self
     })
 
-    it('should initialize lsp connection and start listening', async () => {
-        await webworker(props)
+    it('should initialize lsp connection and start listening', () => {
+        webworker(props)
         sinon.assert.calledOnce(stubConnection.listen)
     })
 
     describe('features', () => {
         let features: Features
 
-        beforeEach(async () => {
-            await webworker(props)
+        beforeEach(() => {
+            webworker(props)
             features = stubServer.getCall(0).args[0]
         })
 

--- a/runtimes/runtimes/webworker.test.ts
+++ b/runtimes/runtimes/webworker.test.ts
@@ -36,16 +36,16 @@ describe('webworker', () => {
         delete (global as any).self
     })
 
-    it('should initialize lsp connection and start listening', () => {
-        webworker(props)
+    it('should initialize lsp connection and start listening', async () => {
+        await webworker(props)
         sinon.assert.calledOnce(stubConnection.listen)
     })
 
     describe('features', () => {
         let features: Features
 
-        beforeEach(() => {
-            webworker(props)
+        beforeEach(async () => {
+            await webworker(props)
             features = stubServer.getCall(0).args[0]
         })
 

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -50,11 +50,12 @@ import {
     updateProfileRequestType,
 } from '../protocol/identity-management'
 import { IdentityManagement } from '../server-interface/identity-management'
+import { getLoggingUtility } from './util/loggingUtil'
 
 declare const self: WindowOrWorkerGlobalScope
 
 // TODO: testing rig for runtimes
-export const webworker = (props: RuntimeProps) => {
+export const webworker = async (props: RuntimeProps) => {
     const lspConnection = createConnection(new BrowserMessageReader(self), new BrowserMessageWriter(self))
 
     const documentsObserver = observe(lspConnection)
@@ -64,9 +65,7 @@ export const webworker = (props: RuntimeProps) => {
     const lspRouter = new LspRouter(lspConnection, props.name, props.version)
 
     // Set up logigng over LSP
-    const logging: Logging = {
-        log: message => lspConnection.console.info(`[${new Date().toISOString()}] ${message}`),
-    }
+    const logging: Logging = await getLoggingUtility(lspConnection)
 
     // Set up telemetry over LSP
     const telemetry: Telemetry = {

--- a/runtimes/server-interface/logging.ts
+++ b/runtimes/server-interface/logging.ts
@@ -1,7 +1,13 @@
+import { LogLevel } from '../runtimes/util/loggingUtil'
+
 /**
  * The logging feature interface
  */
 export type Logging = {
-    // TODO: Implement log levels
+    level: LogLevel
+    error: (message: string) => void
+    warn: (message: string) => void
+    info: (message: string) => void
     log: (message: string) => void
+    debug: (message: string) => void
 }

--- a/runtimes/server-interface/logging.ts
+++ b/runtimes/server-interface/logging.ts
@@ -4,7 +4,6 @@ import { LogLevel } from '../runtimes/util/loggingUtil'
  * The logging feature interface
  */
 export type Logging = {
-    level: LogLevel
     error: (message: string) => void
     warn: (message: string) => void
     info: (message: string) => void


### PR DESCRIPTION
The PR includes the changes to support more logging levels as existing scenario has only method - which is log that outputs to lspConnection.console.info. The changes add support for error, warn, info, log, debug in the order of their severity. Log level can be decided by the client and when a runtime is executed, it requests Log level from client through LSP getConfiguration. 
Test cases for the changes have been added.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
