### PR TITLE
Created CODEOWNERS file, indicating flare as owner of the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aws/flare


### PR DESCRIPTION
## Problem
There was no `.github/CODEOWNERS` file yet, but having this file is nice for confirming that the @aws/flare team owns this repository and should review PRs.

## Solution
Added the file.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
