### PR TITLE
Skip publish notification to slack for dependabot

### DIFF
--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -5,6 +5,7 @@ on:
 jobs:
     notify:
         name: Slack notification
+        if: github.actor != 'dependabot[bot]'
         runs-on: [ubuntu-latest]
         steps:
             - name: Post message


### PR DESCRIPTION
## Problem

Currently, steps for dependabot PRs are failing

## Solution

Do not push slack notifications for dependabot PRs:
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
