### PR TITLE
Skip publishing Slack notification for Dependabot PRs

### DIFF
--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -5,7 +5,7 @@ on:
 jobs:
     notify:
         name: Slack notification
-        if: github.author != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         runs-on: [ubuntu-latest]
         steps:
             - name: Post message


### PR DESCRIPTION
## Problem
Currently, steps for dependabot PRs are failing

## Solution
Do not push slack notifications for dependabot PRs. (Fix of @volodkevych's PR, `github.actor` / `github.author` is invalid)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
