### PR TITLE
chore: set dependabot to use conventional commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       directory: '/'
       schedule:
           interval: 'weekly'
+      commit-message:
+          prefix: 'chore'


### PR DESCRIPTION
## Problem
PRs created by Dependabot do not follow Conventional Commit spec by default.

## Solution

Configure Dependabot to use Conventional Commit.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
