### PR TITLE
chore(release): bump chat-client-ui-types version to 0.0.9

### DIFF
--- a/chat-client-ui-types/CHANGELOG.md
+++ b/chat-client-ui-types/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.9] - 2024-12-11
+
+### Added
+- `DISCLAIMER_ACKNOWLEDGED` contract for acknowledging the legal disclaimer
 
 ## [0.0.8] - 2024-10-22
 

--- a/chat-client-ui-types/package.json
+++ b/chat-client-ui-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/chat-client-ui-types",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "Type definitions for Chat UIs in Language Servers and Runtimes for AWS",
     "main": "./out/index.js",
     "scripts": {


### PR DESCRIPTION
## Problem
Version should be bumped for new release of `@aws/chat-client-ui-types`, with the extension of UI contracts.

## Solution
Bumped version to `0.0.9`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
