### PR TITLE
feat(runtimes): log detail server info during initialization

### DIFF
--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -484,6 +484,9 @@ describe('LspRouter', () => {
 
     function stubLspConnection() {
         return <Connection>{
+            console: {
+                info: (message: any) => {},
+            },
             onInitialize: (handler: any) => {},
             onInitialized: (handler: any) => {},
             onExecuteCommand: (handler: any) => {},

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -71,10 +71,15 @@ export class LspRouter {
             },
         }
         resultList.unshift(defaultResponse)
-
-        return resultList.reduceRight((acc, curr) => {
+        const result = resultList.reduceRight((acc, curr) => {
             return mergeObjects(acc, curr)
         })
+        this.lspConnection.console.info(
+            `Runtime: Initializing server ${JSON.stringify(result.serverInfo?.name)} version ${JSON.stringify(result.serverInfo?.version)} with capabilities:
+${JSON.stringify({ ...result.capabilities, ...result.awsServerCapabilities })}`
+        )
+
+        return result
     }
 
     executeCommand = async (


### PR DESCRIPTION
## Problem
Runtime details helps easily monitor and debug the LSP server startup, ensures customers are using the right version.

## Solution
Added logging for server name, server version and capabilities during initialize request.
<img width="1126" alt="Screenshot 2024-12-31 at 10 35 48" src="https://github.com/user-attachments/assets/7cbad435-0d29-438b-babf-7121f7e44792" />


## License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
