### PR TITLE
fix(types): npm publish (with out folder)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,16 @@
                 "@aws/language-server-runtimes-types": "^0.0.7"
             }
         },
+        "chat-client-ui-types/node_modules/@aws/language-server-runtimes-types": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.7.tgz",
+            "integrity": "sha512-P83YkgWITcUGHaZvYFI0N487nWErgRpejALKNm/xs8jEcHooDfjigOpliN8TgzfF9BGvGeQnnAzIG16UBXc9ig==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "vscode-languageserver-textdocument": "^1.0.12",
+                "vscode-languageserver-types": "^3.17.5"
+            }
+        },
         "node_modules/@aws/chat-client-ui-types": {
             "resolved": "chat-client-ui-types",
             "link": true
@@ -3592,9 +3602,19 @@
                 "node": ">=18.0.0"
             }
         },
+        "runtimes/node_modules/@aws/language-server-runtimes-types": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.7.tgz",
+            "integrity": "sha512-P83YkgWITcUGHaZvYFI0N487nWErgRpejALKNm/xs8jEcHooDfjigOpliN8TgzfF9BGvGeQnnAzIG16UBXc9ig==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "vscode-languageserver-textdocument": "^1.0.12",
+                "vscode-languageserver-types": "^3.17.5"
+            }
+        },
         "types": {
             "name": "@aws/language-server-runtimes-types",
-            "version": "0.0.7",
+            "version": "0.0.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",

--- a/types/.npmignore
+++ b/types/.npmignore
@@ -1,0 +1,5 @@
+src/
+node_modules/
+package-lock.json
+.*
+tsconfig.*

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/language-server-runtimes-types",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "Type definitions in Language Servers and Runtimes for AWS",
     "main": "out/index.js",
     "scripts": {
@@ -8,7 +8,7 @@
         "compile": "tsc --build",
         "prepub:copyFiles": "shx cp ../.npmignore CHANGELOG.md ../LICENSE ../NOTICE README.md ../SECURITY.md package.json out/",
         "prepub": "npm run clean && npm run compile && npm run prepub:copyFiles",
-        "pub": "cd out && npm publish"
+        "pub": "npm publish"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Problem
The [published package on npm for `types`](https://www.npmjs.com/package/@aws/language-server-runtimes-types?activeTab=code) doesn't contain the `./out` folder however the `main` in `package.json` file refers to that.
This causes bundlers to fail since they're not able to find the `out/index.ts` file.

## Solution
- Added individual `.npmignore` file to `types` folder to avoid `out` folder to be skipped because of parent folder `.gitignore` conflict
  - Skipping all the files except package.json and the `out` folder
- Updated `pub` _(publish)_ script to use the root folder of `types` instead of `out` folder. The published package will contain the `out` folder.
- Updated version to `0.0.8`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
