### PR TITLE
fix(types): fixed publish package contents

### DIFF
--- a/types/.npmignore
+++ b/types/.npmignore
@@ -2,4 +2,5 @@ src/
 node_modules/
 package-lock.json
 .*
+/*.ts
 tsconfig.*

--- a/types/package.json
+++ b/types/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "clean": "rm -rf out/",
         "compile": "tsc --build",
-        "prepub:copyFiles": "shx cp ../.npmignore CHANGELOG.md ../LICENSE ../NOTICE README.md ../SECURITY.md package.json out/",
+        "prepub:copyFiles": "shx cp ../LICENSE ../NOTICE ../SECURITY.md .",
         "prepub": "npm run clean && npm run compile && npm run prepub:copyFiles",
         "pub": "npm publish"
     },


### PR DESCRIPTION
## Problem
Even though the previous release fixed the `main` path targeting to the correct `./out` folder, it contains `.ts` files (not the `.d.ts`) which shouldn't be in the package. Also, some files like NOTICE, SECURITY etc. are missing.

## Solution
Updated the `.npmignore` and fixed the copy files on `prepub`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
