### PR TITLE
feat: add env variables getter in runtime

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -241,7 +241,8 @@ export const standalone = (props: RuntimeProps) => {
                 version: props.version,
             },
             platform: os.platform(),
-            getEnvironmentConfiguration(key: string) {
+            // gets the configurations from the environment variables
+            getConfiguration(key: string) {
                 return process.env[key]
             },
         }

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -123,7 +123,7 @@ export const webworker = (props: RuntimeProps) => {
             version: props.version,
         },
         platform: 'browser',
-        getEnvironmentConfiguration(key: string) {
+        getConfiguration(key: string) {
             return undefined
         },
     }

--- a/runtimes/server-interface/runtime.ts
+++ b/runtimes/server-interface/runtime.ts
@@ -21,9 +21,9 @@ export interface Runtime {
     platform: Platform
 
     /**
-     * Get the value of an environment variable.
-     * @param key The name of the environment variable.
-     * @returns The value of the environment variable or undefined if the environment variable is not set.
+     * Get a runtime configuration value.
+     * @param key The configuration key to retrieve.
+     * @returns The configuration value or undefined if the key is not set.
      */
-    getEnvironmentConfiguration(key: string): string | undefined
+    getConfiguration(key: string): string | undefined
 }


### PR DESCRIPTION
## Problem
We want to be able to inject environment variables via runtime
## Solution
Added a environment variables getter in `Runtime`, for the webworker returns undefined as `process`object  is not defined for webworker. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
