### PR TITLE
feat: adding support for readFileSync method in workspace.fs

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -47,7 +47,7 @@ import { RuntimeProps } from './runtime'
 
 import { observe } from './lsp'
 
-import { mkdirSync, existsSync } from 'fs'
+import { mkdirSync, existsSync, readFileSync } from 'fs'
 import { access, readdir, readFile, rm, stat, copyFile, writeFile, appendFile, mkdir } from 'fs/promises'
 import * as os from 'os'
 import * as path from 'path'
@@ -192,6 +192,7 @@ export const standalone = (props: RuntimeProps) => {
                 writeFile: (path, data) => writeFile(path, data),
                 appendFile: (path, data) => appendFile(path, data),
                 mkdir: (path, options?) => mkdir(path, options),
+                readFileSync: path => readFileSync(path),
             },
         }
 

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -192,7 +192,8 @@ export const standalone = (props: RuntimeProps) => {
                 writeFile: (path, data) => writeFile(path, data),
                 appendFile: (path, data) => appendFile(path, data),
                 mkdir: (path, options?) => mkdir(path, options),
-                readFileSync: path => readFileSync(path),
+                readFileSync: (path, options?) =>
+                    readFileSync(path, { encoding: (options?.encoding || 'utf-8') as BufferEncoding }),
             },
         }
 

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -48,7 +48,6 @@ import {
 import { IdentityManagement } from '../server-interface/identity-management'
 import { Encoding, WebBase64Encoding } from './encoding'
 import { LoggingServer } from './lsp/router/loggingServer'
-import { Buffer } from 'node:buffer'
 
 declare const self: WindowOrWorkerGlobalScope
 

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -86,7 +86,7 @@ export const webworker = (props: RuntimeProps) => {
             writeFile: (_path, _data) => Promise.resolve(),
             appendFile: (_path, _data) => Promise.resolve(),
             mkdir: (_path, _options?) => Promise.resolve(''),
-            readFileSync: _path => Buffer.alloc(0),
+            readFileSync: (_path, _options?) => '',
         },
     }
 

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -48,6 +48,7 @@ import {
 import { IdentityManagement } from '../server-interface/identity-management'
 import { Encoding, WebBase64Encoding } from './encoding'
 import { LoggingServer } from './lsp/router/loggingServer'
+import { Buffer } from 'node:buffer'
 
 declare const self: WindowOrWorkerGlobalScope
 
@@ -86,6 +87,7 @@ export const webworker = (props: RuntimeProps) => {
             writeFile: (_path, _data) => Promise.resolve(),
             appendFile: (_path, _data) => Promise.resolve(),
             mkdir: (_path, _options?) => Promise.resolve(''),
+            readFileSync: _path => Buffer.alloc(0),
         },
     }
 

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -49,6 +49,12 @@ export type Workspace = {
         writeFile: (path: string, data: string) => Promise<void>
         appendFile: (path: string, data: string) => Promise<void>
         mkdir: (path: string, options?: { recursive?: boolean }) => Promise<string | undefined>
+        /**
+         * Reads the entire contents of a file.
+         * @param {string} path - The path to the file.
+         * @param {string} [options.encoding] - The encoding to use when reading the file, defaults to 'utf-8'.
+         * @returns A string referring to the contents of the file.
+         */
         readFileSync: (path: string, options?: { encoding?: string }) => string
     }
 }

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -49,6 +49,6 @@ export type Workspace = {
         writeFile: (path: string, data: string) => Promise<void>
         appendFile: (path: string, data: string) => Promise<void>
         mkdir: (path: string, options?: { recursive?: boolean }) => Promise<string | undefined>
-        readFileSync: (path: string) => Buffer
+        readFileSync: (path: string, options?: { encoding?: string }) => string
     }
 }

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -49,5 +49,6 @@ export type Workspace = {
         writeFile: (path: string, data: string) => Promise<void>
         appendFile: (path: string, data: string) => Promise<void>
         mkdir: (path: string, options?: { recursive?: boolean }) => Promise<string | undefined>
+        readFileSync: (path: string) => Buffer
     }
 }


### PR DESCRIPTION
Adding support for readFileSync method in workspace.fs feature of runtimes.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
