### PR TITLE
chore: revert of 'bump typescript from 5.7.2 to 5.7.3"'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "sinon": "^19.0.2",
                 "ts-mocha": "^10.0.0",
                 "ts-sinon": "^2.0.2",
-                "typescript": "^5.7.3"
+                "typescript": "^5.6.3"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -3325,10 +3325,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -3584,7 +3585,7 @@
                 "sinon": "^19.0.2",
                 "ts-mocha": "^10.0.0",
                 "ts-sinon": "^2.0.2",
-                "typescript": "^5.7.3"
+                "typescript": "^5.6.3"
             },
             "engines": {
                 "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "sinon": "^19.0.2",
         "ts-mocha": "^10.0.0",
         "ts-sinon": "^2.0.2",
-        "typescript": "^5.7.3"
+        "typescript": "^5.6.3"
     },
     "overrides": {
         "cross-spawn": "^7.0.6"

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -48,7 +48,7 @@
         "sinon": "^19.0.2",
         "ts-mocha": "^10.0.0",
         "ts-sinon": "^2.0.2",
-        "typescript": "^5.7.3"
+        "typescript": "^5.6.3"
     },
     "typesVersions": {
         "*": {


### PR DESCRIPTION
Reverts aws/language-server-runtimes#298