### PR TITLE
Extend LSP interface

### DIFF
--- a/runtimes/runtimes/lsp/textDocuments/textDocumentConnection.ts
+++ b/runtimes/runtimes/lsp/textDocuments/textDocumentConnection.ts
@@ -29,7 +29,7 @@ type TextDocumentObservable = {
  * with observables for each operation.
  *
  * This is useful for integrating mutliple Servers that each want to handle events one or more times. The {Observable}
- * interface allows for low-level control of subscrive, resubscribe, and notification handling. The callback interface
+ * interface allows for low-level control of subscribe, resubscribe, and notification handling. The callback interface
  * mimics the {TextDocumentConnection}, but does not overwrite each callback with the next.
  *
  * **Note:** {onWillSaveTextDocumentWaitUntil} will NOT support multiple handlers. The last registrered is the one

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -280,6 +280,7 @@ export const standalone = (props: RuntimeProps) => {
                 onDidOpenTextDocument: handler => documentsObserver.callbacks.onDidOpenTextDocument(handler),
                 onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),
                 onDidCloseTextDocument: handler => documentsObserver.callbacks.onDidCloseTextDocument(handler),
+                onDidSaveTextDocument: handler => documentsObserver.callbacks.onDidSaveTextDocument(handler),
                 onExecuteCommand: lspServer.setExecuteCommandHandler,
                 onSemanticTokens: handler => lspConnection.onRequest(SemanticTokensRequest.type, handler),
                 workspace: {

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -288,6 +288,9 @@ export const standalone = (props: RuntimeProps) => {
                     getConfiguration: section => lspConnection.workspace.getConfiguration(section),
                     onDidChangeWorkspaceFolders: handler =>
                         lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler),
+                    onDidCreateFiles: params => lspConnection.workspace.onDidCreateFiles(params),
+                    onDidDeleteFiles: params => lspConnection.workspace.onDidDeleteFiles(params),
+                    onDidRenameFiles: params => lspConnection.workspace.onDidRenameFiles(params),
                 },
                 window: {
                     showMessage: params => lspConnection.sendNotification(ShowMessageNotification.method, params),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -160,6 +160,9 @@ export const webworker = (props: RuntimeProps) => {
                 getConfiguration: section => lspConnection.workspace.getConfiguration(section),
                 onDidChangeWorkspaceFolders: handler =>
                     lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler),
+                onDidCreateFiles: params => lspConnection.workspace.onDidCreateFiles(params),
+                onDidDeleteFiles: params => lspConnection.workspace.onDidDeleteFiles(params),
+                onDidRenameFiles: params => lspConnection.workspace.onDidRenameFiles(params),
             },
             window: {
                 showMessage: params => lspConnection.sendNotification(ShowMessageNotification.method, params),

--- a/runtimes/runtimes/webworker.ts
+++ b/runtimes/runtimes/webworker.ts
@@ -152,6 +152,7 @@ export const webworker = (props: RuntimeProps) => {
             onDidOpenTextDocument: handler => documentsObserver.callbacks.onDidOpenTextDocument(handler),
             onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),
             onDidCloseTextDocument: handler => lspConnection.onDidCloseTextDocument(handler),
+            onDidSaveTextDocument: handler => lspConnection.onDidSaveTextDocument(handler),
             onExecuteCommand: lspServer.setExecuteCommandHandler,
             onSemanticTokens: handler => lspConnection.onRequest(SemanticTokensRequest.type, handler),
             workspace: {

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -42,6 +42,7 @@ import {
     LSPAny,
     ApplyWorkspaceEditParams,
     ApplyWorkspaceEditResult,
+    DidSaveTextDocumentParams,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -107,6 +108,7 @@ export type Lsp = {
     onDidOpenTextDocument: (handler: NotificationHandler<DidOpenTextDocumentParams>) => void
     onDidChangeTextDocument: (handler: NotificationHandler<DidChangeTextDocumentParams>) => void
     onDidCloseTextDocument: (handler: NotificationHandler<DidCloseTextDocumentParams>) => void
+    onDidSaveTextDocument: (handler: NotificationHandler<DidSaveTextDocumentParams>) => void
     publishDiagnostics: (params: PublishDiagnosticsParams) => Promise<void>
     sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => Promise<void>
     onHover: (handler: RequestHandler<HoverParams, Hover | null | undefined, void>) => void

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -43,6 +43,9 @@ import {
     ApplyWorkspaceEditParams,
     ApplyWorkspaceEditResult,
     DidSaveTextDocumentParams,
+    DeleteFilesParams,
+    CreateFilesParams,
+    RenameFilesParams,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -119,6 +122,9 @@ export type Lsp = {
         getConfiguration: (section: string) => Promise<any>
         onDidChangeWorkspaceFolders: (handler: NotificationHandler<DidChangeWorkspaceFoldersParams>) => void
         applyWorkspaceEdit: (params: ApplyWorkspaceEditParams) => Promise<ApplyWorkspaceEditResult>
+        onDidCreateFiles: (handler: NotificationHandler<CreateFilesParams>) => void
+        onDidDeleteFiles: (handler: NotificationHandler<DeleteFilesParams>) => void
+        onDidRenameFiles: (handler: NotificationHandler<RenameFilesParams>) => void
     }
     window: {
         showMessage: (params: ShowMessageParams) => Promise<void>


### PR DESCRIPTION
## Description

Adding support for 4 native LSP methods:

- didSave: `textDocument/didSave`
- didRenameFiles `workspace/didRenameFiles`
- didCreateFiles `workspaceDidCreateFiles`
- didDeleteFiles: `workspaceDidDeleteFiles`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
