### PR TITLE
fix: handling of aws object of initializationOptions and initialize error handling

### DIFF
--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -88,7 +88,7 @@ export class LspServer {
         token: CancellationToken
     ): Promise<PartialInitializeResult | ResponseError<InitializeError> | undefined> => {
         this.clientSupportsNotifications =
-            params.initializationOptions?.aws.awsClientCapabilities?.window?.notifications
+                params.initializationOptions?.aws?.awsClientCapabilities?.window?.notifications
 
         if (!this.initializeHandler) {
             return

--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -87,22 +87,29 @@ export class LspServer {
         params: InitializeParams,
         token: CancellationToken
     ): Promise<PartialInitializeResult | ResponseError<InitializeError> | undefined> => {
-        this.clientSupportsNotifications =
+        try {
+            this.clientSupportsNotifications =
                 params.initializationOptions?.aws?.awsClientCapabilities?.window?.notifications
 
-        if (!this.initializeHandler) {
+            if (!this.initializeHandler) {
+                return
+            }
+
+            const initializeResult = await asPromise(this.initializeHandler(params, token))
+            if (!(initializeResult instanceof ResponseError)) {
+                this.initializeResult = initializeResult
+                if (initializeResult?.serverInfo) {
+                    this.notificationRouter = new RouterByServerName(initializeResult.serverInfo.name, this.encoding)
+                }
+            }
+
+            return initializeResult
+        } catch (error) {
+            this.lspConnection.console.log(
+                `Error in initialize handler: "${error}",\nwith initialization options: ${JSON.stringify(params.initializationOptions)}`
+            )
             return
         }
-
-        const initializeResult = await asPromise(this.initializeHandler(params, token))
-        if (!(initializeResult instanceof ResponseError)) {
-            this.initializeResult = initializeResult
-            if (initializeResult?.serverInfo) {
-                this.notificationRouter = new RouterByServerName(initializeResult.serverInfo.name, this.encoding)
-            }
-        }
-
-        return initializeResult
     }
 
     public tryExecuteCommand = async (

--- a/runtimes/runtimes/util/serverDataDirPath.ts
+++ b/runtimes/runtimes/util/serverDataDirPath.ts
@@ -3,7 +3,7 @@ import * as os from 'os'
 import { InitializeParams } from '../../protocol'
 
 export function getServerDataDirPath(serverName: string, initializeParams: InitializeParams | undefined): string {
-    const clientSpecifiedLocation = initializeParams?.initializationOptions?.aws.clientDataFolder
+    const clientSpecifiedLocation = initializeParams?.initializationOptions?.aws?.clientDataFolder
     if (clientSpecifiedLocation) {
         return path.join(clientSpecifiedLocation, serverName)
     }
@@ -39,7 +39,7 @@ function getPlatformAppDataFolder(): string {
 
 function getClientNameFromParams(initializeParams: InitializeParams | undefined): string {
     const clientInfo = initializeParams?.clientInfo
-    const awsClientInfo = initializeParams?.initializationOptions?.aws.clientInfo
+    const awsClientInfo = initializeParams?.initializationOptions?.aws?.clientInfo
 
     return [awsClientInfo?.name || clientInfo?.name || '', awsClientInfo?.extension.name || '']
         .filter(Boolean)


### PR DESCRIPTION
## Problem
Prevent errors due to aws object being undefined and improve error handling in initialize method
 
## Solution
Access aws object safely via with optional chaining and wrap the initialize method in a try/catch block logging error info
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
