### PR TITLE
feat: add save option to initializeResult to allow LSP server to listen to save file events

### DIFF
--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -83,6 +83,9 @@ describe('LspRouter', () => {
                     textDocumentSync: {
                         openClose: true,
                         change: TextDocumentSyncKind.Incremental,
+                        save: {
+                            includeText: true,
+                        },
                     },
                 },
             }
@@ -102,6 +105,9 @@ describe('LspRouter', () => {
                     textDocumentSync: {
                         openClose: true,
                         change: TextDocumentSyncKind.Incremental,
+                        save: {
+                            includeText: true,
+                        },
                     },
                 },
             }
@@ -143,6 +149,9 @@ describe('LspRouter', () => {
                     textDocumentSync: {
                         openClose: true,
                         change: TextDocumentSyncKind.Incremental,
+                        save: {
+                            includeText: true,
+                        },
                     },
                     completionProvider: { resolveProvider: true },
                     executeCommandProvider: { commands: ['run', 'log', 'test'] },
@@ -183,6 +192,9 @@ describe('LspRouter', () => {
                     textDocumentSync: {
                         openClose: true,
                         change: TextDocumentSyncKind.Incremental,
+                        save: {
+                            includeText: true,
+                        },
                     },
                     completionProvider: { resolveProvider: true },
                 },

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -67,6 +67,9 @@ export class LspRouter {
                 textDocumentSync: {
                     openClose: true,
                     change: TextDocumentSyncKind.Incremental,
+                    save: {
+                        includeText: true,
+                    },
                 },
             },
         }

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -60,6 +60,7 @@ export type PartialServerCapabilities<T = any> = Pick<
     | 'executeCommandProvider'
     | 'semanticTokensProvider'
     | 'signatureHelpProvider'
+    | 'workspace'
 >
 export type PartialInitializeResult<T = any> = {
     /**


### PR DESCRIPTION
We want to be able to listen to **textDocument/didSave** event for allowing LSP server to take an action upon file save. In order for the LSP server to be able to listen on the mentioned event, the initializeResult needs to return one more field `save` under capabilities.textDocumentSync. Property type of save field is described [here](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didSave) 

On a similar front, we also need to listen to **workspace/didCreateFiles**, **workspace/didDeleteFiles** and **workspace/didRenameFiles**. In order for LSP to be able to listen these events, we need to return one more capability from the InitializeResult response - which is workspace.fileOperations.didCreate/didRename/didDelete, which also takes a pattern of the files to look for. For our use case, we are only interested in files of types - JS, TS, Java, Python - that's why it won't be appropriate to put this configuration at a global level, rather it should be defined per capability initialize method, as needed. In order for the individual capabilities to be able to specify this in the initialize response, PartialServerCapabilities has been extended to include `workspace` as part of PR as well. Sample configuration would like below:
`workspace: {
                    fileOperations: {
                        didCreate: { filters: [{ pattern: { glob: "**/*.{ts,tsx}" } }] },
                        didRename: { filters: [{ pattern: { glob: "**/*.{ts,tsx}" } }] },
                        didDelete: { filters: [{ pattern: { glob: "**/*.{ts,tsx}" } }] }
                    }
                }`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
