### PR TITLE
fix: explicit check for initializationOptions and add optional chaining

### DIFF
--- a/runtimes/runtimes/util/serverDataDirPath.ts
+++ b/runtimes/runtimes/util/serverDataDirPath.ts
@@ -3,7 +3,7 @@ import * as os from 'os'
 import { InitializeParams } from '../../protocol'
 
 export function getServerDataDirPath(serverName: string, initializeParams: InitializeParams | undefined): string {
-    const clientSpecifiedLocation = initializeParams?.initializationOptions?.aws.clientDataFolder
+    const clientSpecifiedLocation = initializeParams?.initializationOptions?.aws?.clientDataFolder
     if (clientSpecifiedLocation) {
         return path.join(clientSpecifiedLocation, serverName)
     }
@@ -39,7 +39,7 @@ function getPlatformAppDataFolder(): string {
 
 function getClientNameFromParams(initializeParams: InitializeParams | undefined): string {
     const clientInfo = initializeParams?.clientInfo
-    const awsClientInfo = initializeParams?.initializationOptions?.aws.clientInfo
+    const awsClientInfo = initializeParams?.initializationOptions?.aws?.clientInfo
 
     return [awsClientInfo?.name || clientInfo?.name || '', awsClientInfo?.extension.name || '']
         .filter(Boolean)


### PR DESCRIPTION
## Problem
Check related PRs https://github.com/aws/language-server-runtimes/pull/306 and https://github.com/aws/language-server-runtimes/pull/307
Prevent errors due to aws object being undefined and improve error handling in initialize method

## Solution
- Updating to use optional chaining  
- Adding a check and logging in case `aws` object is not set. 
- 
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
