### PR TITLE
ci: don't send slack messages for new prs in draft mode

### DIFF
--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -2,10 +2,11 @@ name: Publish a notification to Slack
 on:
     pull_request:
         branches: [main]
+        types: [opened, reopened, ready_for_review, synchronize]
 jobs:
     notify:
         name: Slack notification
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.draft == false
         runs-on: [ubuntu-latest]
         steps:
             - name: Post message


### PR DESCRIPTION
## Problem
Messages to Slack were being sent through the GitHub CI workflow, even for Draft PRs.

## Solution
Filter to just run on non-draft PRs.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
