### PR TITLE
fix: adding try/catch to initialize lsp server, added telemetry log events 

### DIFF
--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -430,8 +430,7 @@ describe('LspRouter', () => {
 
         it('should send notification if notifications are supported and server name is defined', async () => {
             const notificationSpy = sandbox.spy()
-            const lspConn = <Connection>{}
-            lspConn.sendNotification = notificationSpy
+            const lspConn = stubLspConnection({ sendNotification: notificationSpy })
 
             const server = newServer({ lspConnection: lspConn, initializeHandler: initHandler })
             await server.initialize(initParam as InitializeParams, {} as CancellationToken)
@@ -443,8 +442,7 @@ describe('LspRouter', () => {
 
         it('should not send notification if server name is not defined', async () => {
             const notificationSpy = sandbox.spy()
-            const lspConn = <Connection>{}
-            lspConn.sendNotification = notificationSpy
+            const lspConn = stubLspConnection({ sendNotification: notificationSpy })
 
             const server = newServer({
                 lspConnection: lspConn,
@@ -461,8 +459,7 @@ describe('LspRouter', () => {
 
         it('should not send notification if not supported by client', async () => {
             const notificationSpy = sandbox.spy()
-            const lspConn = <Connection>{}
-            lspConn.sendNotification = notificationSpy
+            const lspConn = stubLspConnection({ sendNotification: notificationSpy })
 
             const server = newServer({ lspConnection: lspConn, initializeHandler: initHandler })
             await server.initialize({} as InitializeParams, {} as CancellationToken)
@@ -473,7 +470,7 @@ describe('LspRouter', () => {
         })
 
         it('should send followup to source server by matching server name in id', async () => {
-            const lspConn = <Connection>{}
+            const lspConn = stubLspConnection()
 
             const server = newServer({ lspConnection: lspConn, initializeHandler: initHandler })
             await server.initialize(initParam as InitializeParams, {} as CancellationToken)
@@ -494,7 +491,7 @@ describe('LspRouter', () => {
         })
     })
 
-    function stubLspConnection() {
+    function stubLspConnection(overrides = {}): Connection {
         return <Connection>{
             console: {
                 info: (message: any) => {},
@@ -508,6 +505,7 @@ describe('LspRouter', () => {
             onRequest: (handler: any) => {},
             onNotification: (handler: any) => {},
             onDidChangeConfiguration: (handler: any) => {},
+            ...overrides,
         }
     }
 

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -499,6 +499,9 @@ describe('LspRouter', () => {
             console: {
                 info: (message: any) => {},
             },
+            telemetry: {
+                logEvent: (message: any) => {},
+            },
             onInitialize: (handler: any) => {},
             onInitialized: (handler: any) => {},
             onExecuteCommand: (handler: any) => {},

--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -89,14 +89,17 @@ export class LspServer {
         token: CancellationToken
     ): Promise<PartialInitializeResult | ResponseError<InitializeError> | undefined> => {
         if (!params.initializationOptions?.aws) {
-            this.lspConnection.telemetry.logEvent({
-                name: 'Initialization error',
-                result: 'Failed',
-                data: JSON.stringify(params.initializationOptions),
-                errorData: {
-                    reason: 'Unknown initialization error with initialization options Error',
-                },
-            })
+            if (this.lspConnection?.telemetry) {
+                this.lspConnection.telemetry.logEvent({
+                    name: 'Initialization error',
+                    result: 'Failed',
+                    data: JSON.stringify(params.initializationOptions),
+                    errorData: {
+                        reason: 'Unknown initialization error with initialization options Error',
+                    },
+                })
+            }
+
             this.logger.log(
                 `Unknown initialization error\nwith initialization options: ${JSON.stringify(params.initializationOptions)}`
             )

--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -89,16 +89,17 @@ export class LspServer {
         token: CancellationToken
     ): Promise<PartialInitializeResult | ResponseError<InitializeError> | undefined> => {
         if (!params.initializationOptions?.aws) {
-            if (this.lspConnection?.telemetry) {
-                this.lspConnection.telemetry.logEvent({
-                    name: 'Initialization error',
-                    result: 'Failed',
-                    data: JSON.stringify(params.initializationOptions),
-                    errorData: {
-                        reason: 'Unknown initialization error with initialization options Error',
-                    },
-                })
-            }
+            this.lspConnection.telemetry.logEvent({
+                name: 'runtimeInitialization_validation',
+                result: 'Failed',
+                data: {
+                    hasAwsConfig: Boolean(params.initializationOptions?.aws),
+                    hasLogLevel: params.initializationOptions?.logLevel,
+                },
+                errorData: {
+                    reason: 'aws field is not defined in InitializeResult',
+                },
+            })
 
             this.logger.log(
                 `Unknown initialization error\nwith initialization options: ${JSON.stringify(params.initializationOptions)}`
@@ -121,8 +122,8 @@ export class LspServer {
 
             return initializeResult
         } catch (e) {
-            this.logger.log(`Unknown initialization error\n${e}`)
-            return new ResponseError(ErrorCodes.UnknownErrorCode, `Unknown initialization error\n${e}`)
+            this.logger.log(`Runtime Initialization Error\n${e}`)
+            return new ResponseError(ErrorCodes.ServerNotInitialized, `Runtime Initialization Error\n${e}`)
         }
     }
 


### PR DESCRIPTION


## Problem
Relevant PRs for the background : https://github.com/aws/language-server-runtimes/pull/307, https://github.com/aws/language-server-runtimes/pull/310 and https://github.com/aws/language-server-runtimes/pull/306


As part of the comment/ followup - we want to add observability related improvements including telemetry and try/catch blocks. 
 
## Solution

As a followup to fixing the optional field 'aws' in the initialization options, this PR adds : 
1. Try/ catch block to the initialization of the router
2. Added a telemetry log event for observability 
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
