### PR TITLE
feat: add opt-out mechanism to operational telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2339,7 +2339,6 @@
             "version": "22.13.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
             "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.20.0"
@@ -2769,7 +2768,6 @@
             "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
@@ -2867,6 +2865,86 @@
             "engines": {
                 "node": ">=16"
             }
+        },
+        "node_modules/copyfiles": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+            "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.0.5",
+                "minimatch": "^3.0.3",
+                "mkdirp": "^1.0.4",
+                "noms": "0.0.0",
+                "through2": "^2.0.1",
+                "untildify": "^4.0.0",
+                "yargs": "^16.1.0"
+            },
+            "bin": {
+                "copyfiles": "copyfiles",
+                "copyup": "copyfiles"
+            }
+        },
+        "node_modules/copyfiles/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/copyfiles/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/copyfiles/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/copyfiles/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
         },
         "node_modules/cosmiconfig": {
             "version": "9.0.0",
@@ -4304,6 +4382,16 @@
                 "path-to-regexp": "^8.1.0"
             }
         },
+        "node_modules/noms": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+            "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "readable-stream": "~1.0.31"
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4591,6 +4679,12 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
+        },
         "node_modules/protobufjs": {
             "version": "7.4.0",
             "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
@@ -4654,6 +4748,18 @@
             "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "1.0.34",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
             }
         },
         "node_modules/readdirp": {
@@ -5003,6 +5109,12 @@
                 "node": ">= 10.x"
             }
         },
+        "node_modules/string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+            "dev": true
+        },
         "node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -5117,6 +5229,52 @@
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
+        "node_modules/through2/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
+        },
+        "node_modules/through2/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/through2/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "node_modules/through2/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
         },
         "node_modules/tinyexec": {
             "version": "0.3.1",
@@ -5421,6 +5579,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/untildify": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/url": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -5442,6 +5609,12 @@
                 "is-typed-array": "^1.1.3",
                 "which-typed-array": "^1.1.2"
             }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
         },
         "node_modules/uuid": {
             "version": "9.0.1",
@@ -5585,6 +5758,15 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5600,7 +5782,6 @@
             "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cliui": "^7.0.2",
                 "escalade": "^3.1.1",
@@ -5620,7 +5801,6 @@
             "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -5705,6 +5885,7 @@
                 "@types/mocha": "^10.0.9",
                 "@types/node": "^22.13.1",
                 "assert": "^2.0.0",
+                "copyfiles": "^2.4.1",
                 "husky": "^9.1.7",
                 "json-schema-to-typescript": "^15.0.4",
                 "prettier": "3.4.2",

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -21,7 +21,7 @@
     },
     "scripts": {
         "clean": "rm -rf out/",
-        "compile": "tsc --build",
+        "compile": "tsc --build && npm run copy-files",
         "fix:prettier": "prettier . --write",
         "prepare": "husky install",
         "prepub:copyFiles": "shx cp ../.npmignore CHANGELOG.md ../LICENSE ../NOTICE README.md ../SECURITY.md package.json out/",
@@ -30,7 +30,8 @@
         "test:unit": "ts-mocha -b './**/*.test.ts'",
         "test": "npm run test:unit",
         "preversion": "npm run test",
-        "version": "npm run compile && git add -A ."
+        "version": "npm run compile && git add -A .",
+        "copy-files": "copyfiles runtimes/operational-telemetry/telemetry-schemas/*.json out"
     },
     "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -60,6 +61,7 @@
         "@types/mocha": "^10.0.9",
         "@types/node": "^22.13.1",
         "assert": "^2.0.0",
+        "copyfiles": "^2.4.1",
         "husky": "^9.1.7",
         "json-schema-to-typescript": "^15.0.4",
         "prettier": "3.4.2",

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -116,6 +116,7 @@ export interface InitializeParams extends _InitializeParamsBase {
     initializationOptions?: {
         [key: string]: any
         logLevel?: LogLevel
+        telemetryOptOut?: boolean
         aws?: AWSInitializationOptions
     }
 }

--- a/runtimes/runtimes/operational-telemetry/README.md
+++ b/runtimes/runtimes/operational-telemetry/README.md
@@ -9,12 +9,20 @@ Json telemetry schemas can be extended in the future to send other type of opera
 
 The collected data is then securely sent in batches via http to an AWS API Gateway endpoint using Cognito authentication. Collected data is sent on a best effort basis, and any telemetry related error should not impact customer experience using standalone runtime.
 
+
+## Telemetry Opt-Out
+
+The OperationalTelemetryService implements a telemetry opt-out mechanism that respects user privacy preferences and allows changes during the session without restarting the IDE. When telemetry is opted out, all data collection and exports are disabled through OpenTelemetry SDK shutdown. The opt-out state can be toggled at any time using the toggleOptOut method.
+
+For the standalone runtime, the OperationalTelemetryService instance is initialized during the initialize handshake. It checks for telemetry preferences in the initialization options, defaulting to opted-out (true) if no preference is specified. It then instantiates the OperationalTelemetryService with these preferences along with service information and client details. A didChangeConfigurationHandler is added to listen for updates to the 'aws.optOutTelemetry' workspace setting, allowing users to dynamically toggle telemetry collection through their IDE settings. When a configuration change occurs, the handler updates the telemetry opt-out state accordingly through the OperationalTelemetryProvider.
+
+
 ## Usage Instructions
 
 1. Initialize the OperationalTelemetryService and set it in the OperationalTelemetryProvider:
 
 ```typescript
-const telemetryService = OperationalTelemetryService.getInstance('language-server-runtimes', '1.0.0', remoteConsole, 'poolId', 'us-east-1', 'amazon.com');
+const telemetryService = OperationalTelemetryService.getInstance({serviceName: 'language-server-runtimes', serviceVersion: '1.0.0', lspConsole: lspConnection.console, poolId: 'poolId', region: 'us-east-1', endpoint: 'example.com', telemetryOptOut: false});
 OperationalTelemetryProvider.setTelemetryInstance(telemetryService)
 ```
 

--- a/runtimes/runtimes/operational-telemetry/aws-metrics-exporter.test.ts
+++ b/runtimes/runtimes/operational-telemetry/aws-metrics-exporter.test.ts
@@ -3,13 +3,11 @@ import sinon from 'sinon'
 import { AwsMetricExporter } from './aws-metrics-exporter'
 import { ExportResultCode } from '@opentelemetry/core'
 import { ResourceMetrics } from '@opentelemetry/sdk-metrics'
-import { OperationalTelemetry, TelemetryStatus } from './operational-telemetry'
 import { AwsCognitoApiGatewaySender } from './aws-cognito-gateway-sender'
 import { OperationalEventValidator } from './operational-event-validator'
 
 describe('AwsMetricExporter', () => {
     let exporter: AwsMetricExporter
-    let telemetryService: sinon.SinonStubbedInstance<OperationalTelemetry>
     let sender: sinon.SinonStubbedInstance<AwsCognitoApiGatewaySender>
     let resultCallback: sinon.SinonSpy
     const mockResourceMetrics: ResourceMetrics = {
@@ -18,6 +16,11 @@ describe('AwsMetricExporter', () => {
                 sessionId: 'test-session',
                 'service.name': 'test-service',
                 'service.version': '1.0.0',
+                'clientInfo.name': 'test-client',
+                'clientInfo.version': '1.2.3',
+                'clientInfo.extension.name': 'test-extension',
+                'clientInfo.extension.version': '1.0.0',
+                'clientInfo.clientId': 'test-id',
             },
         },
         scopeMetrics: [
@@ -80,6 +83,7 @@ describe('AwsMetricExporter', () => {
         },
         clientInfo: {
             name: 'test-client',
+            version: '1.2.3',
             extension: {
                 name: 'test-extension',
                 version: '1.0.0',
@@ -105,21 +109,11 @@ describe('AwsMetricExporter', () => {
     }
 
     beforeEach(() => {
-        telemetryService = {
-            getCustomAttributes: sinon.stub().returns({
-                'clientInfo.name': 'test-client',
-                'clientInfo.extension.name': 'test-extension',
-                'clientInfo.extension.version': '1.0.0',
-                'clientInfo.clientId': 'test-id',
-            }),
-            getTelemetryStatus: sinon.stub().returns(TelemetryStatus.Enabled),
-        } as any
-
         sender = {
             sendOperationalTelemetryData: sinon.stub().resolves(),
         } as any
 
-        exporter = new AwsMetricExporter(telemetryService as any, sender as any, new OperationalEventValidator())
+        exporter = new AwsMetricExporter(sender as any, new OperationalEventValidator())
         resultCallback = sinon.spy()
     })
 

--- a/runtimes/runtimes/operational-telemetry/aws-metrics-exporter.test.ts
+++ b/runtimes/runtimes/operational-telemetry/aws-metrics-exporter.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon'
 import { AwsMetricExporter } from './aws-metrics-exporter'
 import { ExportResultCode } from '@opentelemetry/core'
 import { ResourceMetrics } from '@opentelemetry/sdk-metrics'
-import { OperationalTelemetry } from './operational-telemetry'
+import { OperationalTelemetry, TelemetryStatus } from './operational-telemetry'
 import { AwsCognitoApiGatewaySender } from './aws-cognito-gateway-sender'
 import { OperationalEventValidator } from './operational-event-validator'
 
@@ -112,6 +112,7 @@ describe('AwsMetricExporter', () => {
                 'clientInfo.extension.version': '1.0.0',
                 'clientInfo.clientId': 'test-id',
             }),
+            getTelemetryStatus: sinon.stub().returns(TelemetryStatus.Enabled),
         } as any
 
         sender = {

--- a/runtimes/runtimes/operational-telemetry/aws-spans-exporter.test.ts
+++ b/runtimes/runtimes/operational-telemetry/aws-spans-exporter.test.ts
@@ -3,13 +3,11 @@ import sinon from 'sinon'
 import { AwsSpanExporter } from './aws-spans-exporter'
 import { ExportResultCode } from '@opentelemetry/core'
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base'
-import { OperationalTelemetry, TelemetryStatus } from './operational-telemetry'
 import { AwsCognitoApiGatewaySender } from './aws-cognito-gateway-sender'
 import { OperationalEventValidator } from './operational-event-validator'
 
 describe('AWSSpanExporter', () => {
     let exporter: AwsSpanExporter
-    let telemetryService: sinon.SinonStubbedInstance<OperationalTelemetry>
     let sender: sinon.SinonStubbedInstance<AwsCognitoApiGatewaySender>
     let resultCallback: sinon.SinonSpy
 
@@ -20,6 +18,11 @@ describe('AWSSpanExporter', () => {
                     sessionId: 'test-session',
                     'service.name': 'test-service',
                     'service.version': '1.0.0',
+                    'clientInfo.name': 'test-client',
+                    'clientInfo.version': '1.2.3',
+                    'clientInfo.extension.name': 'test-extension',
+                    'clientInfo.extension.version': '1.0.0',
+                    'clientInfo.clientId': 'test-id',
                 },
             },
             instrumentationLibrary: {
@@ -51,21 +54,11 @@ describe('AWSSpanExporter', () => {
     ]
 
     beforeEach(() => {
-        telemetryService = {
-            getCustomAttributes: sinon.stub().returns({
-                'clientInfo.name': 'test-client',
-                'clientInfo.extension.name': 'test-extension',
-                'clientInfo.extension.version': '1.0.0',
-                'clientInfo.clientId': 'test-id',
-            }),
-            getTelemetryStatus: sinon.stub().returns(TelemetryStatus.Enabled),
-        } as any
-
         sender = {
             sendOperationalTelemetryData: sinon.stub().resolves(),
         } as any
 
-        exporter = new AwsSpanExporter(telemetryService as any, sender as any, new OperationalEventValidator())
+        exporter = new AwsSpanExporter(sender as any, new OperationalEventValidator())
         resultCallback = sinon.spy()
     })
 
@@ -136,6 +129,7 @@ describe('AWSSpanExporter', () => {
                 },
                 clientInfo: {
                     name: 'test-client',
+                    version: '1.2.3',
                     extension: {
                         name: 'test-extension',
                         version: '1.0.0',

--- a/runtimes/runtimes/operational-telemetry/aws-spans-exporter.test.ts
+++ b/runtimes/runtimes/operational-telemetry/aws-spans-exporter.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon'
 import { AwsSpanExporter } from './aws-spans-exporter'
 import { ExportResultCode } from '@opentelemetry/core'
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base'
-import { OperationalTelemetry } from './operational-telemetry'
+import { OperationalTelemetry, TelemetryStatus } from './operational-telemetry'
 import { AwsCognitoApiGatewaySender } from './aws-cognito-gateway-sender'
 import { OperationalEventValidator } from './operational-event-validator'
 
@@ -58,6 +58,7 @@ describe('AWSSpanExporter', () => {
                 'clientInfo.extension.version': '1.0.0',
                 'clientInfo.clientId': 'test-id',
             }),
+            getTelemetryStatus: sinon.stub().returns(TelemetryStatus.Enabled),
         } as any
 
         sender = {

--- a/runtimes/runtimes/operational-telemetry/operational-telemetry-service.test.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry-service.test.ts
@@ -80,6 +80,35 @@ describe('OperationalTelemetryService', () => {
 
             sinon.assert.calledOnce(NodeSDK.prototype.start as sinon.SinonStub)
         })
+
+        it('should correctly handle multiple toggles between opt-in and opt-out', () => {
+            // Initial: telemetry enabled
+            const config = { ...defaultConfig, telemetryOptOut: false }
+            const optel = OperationalTelemetryService.getInstance(config)
+
+            sinon.assert.notCalled(NodeSDK.prototype.shutdown as sinon.SinonStub)
+            sinon.assert.calledOnce(NodeSDK.prototype.start as sinon.SinonStub)
+
+            // First toggle: opt-in -> opt-out
+            optel.toggleOptOut(true)
+            sinon.assert.calledOnce(NodeSDK.prototype.shutdown as sinon.SinonStub)
+            sinon.assert.calledOnce(NodeSDK.prototype.start as sinon.SinonStub)
+
+            // Second toggle: opt-out -> opt-in
+            optel.toggleOptOut(false)
+            sinon.assert.calledTwice(NodeSDK.prototype.start as sinon.SinonStub)
+            sinon.assert.calledOnce(NodeSDK.prototype.shutdown as sinon.SinonStub)
+
+            // Third toggle: opt-in -> opt-out
+            optel.toggleOptOut(true)
+            sinon.assert.calledTwice(NodeSDK.prototype.start as sinon.SinonStub)
+            sinon.assert.calledTwice(NodeSDK.prototype.shutdown as sinon.SinonStub)
+
+            // Fourth toggle: opt-out -> opt-in
+            optel.toggleOptOut(false)
+            sinon.assert.calledThrice(NodeSDK.prototype.start as sinon.SinonStub)
+            sinon.assert.calledTwice(NodeSDK.prototype.shutdown as sinon.SinonStub)
+        })
     })
 
     describe('getInstance', () => {

--- a/runtimes/runtimes/operational-telemetry/operational-telemetry-service.test.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry-service.test.ts
@@ -1,0 +1,93 @@
+import sinon from 'sinon'
+import { OperationalTelemetryService } from './operational-telemetry-service'
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import assert from 'assert'
+
+describe('OperationalTelemetryService', () => {
+    const defaultConfig = {
+        serviceName: 'test-service',
+        serviceVersion: '1.0.0',
+        lspConsole: {
+            debug: () => {},
+            error: () => {},
+            info: () => {},
+            log: () => {},
+            warn: () => {},
+        } as any,
+        poolId: 'test-pool',
+        region: 'us-west-2',
+        endpoint: 'https://test.endpoint',
+        telemetryOptOut: true,
+    }
+
+    beforeEach(() => {
+        // @ts-ignore
+        OperationalTelemetryService.sdk?.shutdown()
+        // @ts-ignore
+        OperationalTelemetryService.instance = undefined
+
+        sinon.stub(NodeSDK.prototype, 'start').callsFake(() => {})
+        sinon.stub(NodeSDK.prototype, 'shutdown').callsFake(() => new Promise<void>(() => {}))
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('constructor', () => {
+        it('should not start SDK when telemetryOptOut is true', () => {
+            const config = { ...defaultConfig, telemetryOptOut: true }
+            OperationalTelemetryService.getInstance(config)
+
+            sinon.assert.notCalled(NodeSDK.prototype.start as sinon.SinonStub)
+        })
+
+        it('should start SDK when telemetryOptOut is false', () => {
+            const config = { ...defaultConfig, telemetryOptOut: false }
+            OperationalTelemetryService.getInstance(config)
+
+            sinon.assert.calledOnce(NodeSDK.prototype.start as sinon.SinonStub)
+        })
+    })
+
+    describe('toggleOptOut', () => {
+        it('should do nothing when new value matches current telemetryOptOut state', () => {
+            const config = { ...defaultConfig, telemetryOptOut: false }
+            const optel = OperationalTelemetryService.getInstance(config)
+            ;(NodeSDK.prototype.start as sinon.SinonStub).resetHistory()
+            ;(NodeSDK.prototype.shutdown as sinon.SinonStub).resetHistory()
+
+            optel.toggleOptOut(false)
+
+            sinon.assert.notCalled(NodeSDK.prototype.start as sinon.SinonStub)
+            sinon.assert.notCalled(NodeSDK.prototype.shutdown as sinon.SinonStub)
+        })
+
+        it('should shutdown SDK when switching from opt-in to opt-out', () => {
+            const config = { ...defaultConfig, telemetryOptOut: false }
+            const optel = OperationalTelemetryService.getInstance(config)
+
+            optel.toggleOptOut(true)
+
+            sinon.assert.calledOnce(NodeSDK.prototype.shutdown as sinon.SinonStub)
+        })
+
+        it('should start SDK when switching from opt-out to opt-in', () => {
+            const config = { ...defaultConfig, telemetryOptOut: true }
+            const optel = OperationalTelemetryService.getInstance(config)
+
+            optel.toggleOptOut(false)
+
+            sinon.assert.calledOnce(NodeSDK.prototype.start as sinon.SinonStub)
+        })
+    })
+
+    describe('getInstance', () => {
+        it('should return the same instance when getInstance is called multiple times', () => {
+            const instance1 = OperationalTelemetryService.getInstance(defaultConfig)
+            const instance2 = OperationalTelemetryService.getInstance(defaultConfig)
+
+            assert.strictEqual(instance1, instance2)
+        })
+    })
+})

--- a/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
@@ -13,7 +13,7 @@ import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { OperationalEventValidator } from './operational-event-validator'
 import { ExtendedClientInfo } from '../../server-interface'
 
-type OperationalTelmetryConfig = {
+type OperationalTelemetryConfig = {
     serviceName: string
     serviceVersion?: string
     extendedClientInfo?: ExtendedClientInfo
@@ -38,14 +38,14 @@ export class OperationalTelemetryService implements OperationalTelemetry {
     private awsConfig: AwsConfig
     private telemetryOptOut: boolean
 
-    static getInstance(config: OperationalTelmetryConfig): OperationalTelemetryService {
+    static getInstance(config: OperationalTelemetryConfig): OperationalTelemetryService {
         if (!OperationalTelemetryService.instance) {
             OperationalTelemetryService.instance = new OperationalTelemetryService(config)
         }
         return OperationalTelemetryService.instance
     }
 
-    private constructor(config: OperationalTelmetryConfig) {
+    private constructor(config: OperationalTelemetryConfig) {
         diag.setLogger(
             {
                 debug: message => config.lspConsole.debug(message),

--- a/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
@@ -42,7 +42,6 @@ export class OperationalTelemetryService implements OperationalTelemetry {
         if (!OperationalTelemetryService.instance) {
             OperationalTelemetryService.instance = new OperationalTelemetryService(config)
         }
-        diag.error('Operational telemetry already initialized')
         return OperationalTelemetryService.instance
     }
 
@@ -82,7 +81,7 @@ export class OperationalTelemetryService implements OperationalTelemetry {
         }
     }
 
-    toggleTelemetry(telemetryOptOut: boolean): void {
+    toggleOptOut(telemetryOptOut: boolean): void {
         if (this.telemetryOptOut === telemetryOptOut) {
             return
         }
@@ -90,13 +89,13 @@ export class OperationalTelemetryService implements OperationalTelemetry {
         this.telemetryOptOut = telemetryOptOut
 
         if (this.telemetryOptOut) {
-            this.startupSdk()
-        } else {
             this.shutdownSdk()
+        } else {
+            this.startupSdk()
         }
     }
 
-    startupSdk() {
+    private startupSdk() {
         const eventValidator = new OperationalEventValidator()
         const awsSender = new AwsCognitoApiGatewaySender(
             this.awsConfig.endpoint,
@@ -137,7 +136,7 @@ export class OperationalTelemetryService implements OperationalTelemetry {
         })
     }
 
-    shutdownSdk() {
+    private shutdownSdk() {
         this.sdk?.shutdown()
     }
 

--- a/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
@@ -1,7 +1,7 @@
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
 import { AwsMetricExporter } from './aws-metrics-exporter'
-import { OperationalTelemetry, TelemetryStatus } from './operational-telemetry'
-import opentelemetry, { diag, Attributes, DiagLogLevel, trace } from '@opentelemetry/api'
+import { OperationalTelemetry } from './operational-telemetry'
+import { diag, Attributes, DiagLogLevel, trace, metrics } from '@opentelemetry/api'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { Resource } from '@opentelemetry/resources'
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions'
@@ -11,26 +11,32 @@ import { AwsCognitoApiGatewaySender } from './aws-cognito-gateway-sender'
 import { AwsSpanExporter } from './aws-spans-exporter'
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { OperationalEventValidator } from './operational-event-validator'
+import { ExtendedClientInfo } from '../../server-interface'
 
 type OperationalTelmetryConfig = {
     serviceName: string
-    serviceVersion: string
+    serviceVersion?: string
+    extendedClientInfo?: ExtendedClientInfo
     lspConsole: RemoteConsole
     poolId: string
     region: string
     endpoint: string
+    telemetryOptOut: boolean
+}
+
+type AwsConfig = {
+    endpoint: string
+    region: string
+    poolId: string
 }
 
 export class OperationalTelemetryService implements OperationalTelemetry {
-    private customAttributes: Record<string, any> = {}
     private static instance: OperationalTelemetryService
     private readonly RUNTIMES_SCOPE_NAME = 'language-server-runtimes'
-    private telemetryStatus = TelemetryStatus.Pending
     private sdk: NodeSDK | null = null
-    // private initializeConfig: OperationalTelmetryConfig
-    private spanProcessor: BatchSpanProcessor
-    private metricReader: PeriodicExportingMetricReader
-    private baseResource: Resource
+    private readonly baseResource: Resource
+    private awsConfig: AwsConfig
+    private telemetryOptOut: boolean
 
     static getInstance(config: OperationalTelmetryConfig): OperationalTelemetryService {
         if (!OperationalTelemetryService.instance) {
@@ -52,65 +58,75 @@ export class OperationalTelemetryService implements OperationalTelemetry {
             DiagLogLevel.ALL
         )
 
+        this.baseResource = new Resource({
+            [ATTR_SERVICE_NAME]: config.serviceName,
+            [ATTR_SERVICE_VERSION]: config.serviceVersion,
+            'clientInfo.name': config.extendedClientInfo?.name,
+            'clientInfo.version': config.extendedClientInfo?.version,
+            'clientInfo.clientId': config.extendedClientInfo?.clientId,
+            'clientInfo.extension.name': config.extendedClientInfo?.extension.name,
+            'clientInfo.extension.version': config.extendedClientInfo?.extension.version,
+            sessionId: randomUUID(),
+        })
+
+        this.awsConfig = {
+            endpoint: config.endpoint,
+            region: config.region,
+            poolId: config.poolId,
+        }
+
+        this.telemetryOptOut = config.telemetryOptOut
+
+        if (!this.telemetryOptOut) {
+            this.startupSdk()
+        }
+    }
+
+    toggleTelemetry(telemetryOptOut: boolean): void {
+        if (this.telemetryOptOut === telemetryOptOut) {
+            return
+        }
+
+        this.telemetryOptOut = telemetryOptOut
+
+        if (this.telemetryOptOut) {
+            this.startupSdk()
+        } else {
+            this.shutdownSdk()
+        }
+    }
+
+    startupSdk() {
         const eventValidator = new OperationalEventValidator()
-        const awsSender = new AwsCognitoApiGatewaySender(config.endpoint, config.region, config.poolId)
-        const metricExporter = new AwsMetricExporter(this, awsSender, eventValidator)
-        const spansExporter = new AwsSpanExporter(this, awsSender, eventValidator)
+        const awsSender = new AwsCognitoApiGatewaySender(
+            this.awsConfig.endpoint,
+            this.awsConfig.region,
+            this.awsConfig.poolId
+        )
+        const metricExporter = new AwsMetricExporter(awsSender, eventValidator)
+        const spansExporter = new AwsSpanExporter(awsSender, eventValidator)
 
         const fiveMinutes = 300000
         const fiveSeconds = 5000
 
         // Collects metrics every `exportIntervalMillis` and sends it to exporter.
         // Registered callbacks are evaluated once during the collection process.
-        this.metricReader = new PeriodicExportingMetricReader({
+        const metricReader = new PeriodicExportingMetricReader({
             exporter: metricExporter,
             exportIntervalMillis: fiveMinutes,
         })
 
         // Sends collected spans every `scheduledDelayMillis` if batch is non-empty.
         // Triggers export immediately when collected spans reach `maxExportBatchSize` limit.
-        this.spanProcessor = new BatchSpanProcessor(spansExporter, {
+        const spanProcessor = new BatchSpanProcessor(spansExporter, {
             maxExportBatchSize: 20,
             scheduledDelayMillis: fiveSeconds,
         })
 
-        this.baseResource = new Resource({
-            [ATTR_SERVICE_NAME]: config.serviceName,
-            [ATTR_SERVICE_VERSION]: config.serviceVersion,
-            sessionId: randomUUID(),
-        })
-
-        this.startupSdk()
-    }
-
-    getTelemetryStatus(): TelemetryStatus {
-        return this.telemetryStatus
-    }
-
-    updateTelemetryStatus(newStatus: TelemetryStatus): void {
-        if (this.telemetryStatus === newStatus) {
-            return
-        }
-
-        const previousStatus = this.telemetryStatus
-        this.telemetryStatus = newStatus
-
-        if (newStatus === TelemetryStatus.Enabled) {
-            if (previousStatus === TelemetryStatus.Disabled) {
-                this.startupSdk()
-            }
-        }
-
-        if (newStatus === TelemetryStatus.Disabled) {
-            this.shutdownSdk()
-        }
-    }
-
-    startupSdk() {
         this.sdk = new NodeSDK({
             resource: this.baseResource,
-            metricReader: this.metricReader,
-            spanProcessor: this.spanProcessor,
+            metricReader: metricReader,
+            spanProcessor: spanProcessor,
         })
 
         this.sdk.start()
@@ -123,7 +139,6 @@ export class OperationalTelemetryService implements OperationalTelemetry {
 
     shutdownSdk() {
         this.sdk?.shutdown()
-        // this.sdk=null
     }
 
     recordEvent(eventType: string, attributes?: Record<string, any>, scopeName?: string): void {
@@ -144,18 +159,10 @@ export class OperationalTelemetryService implements OperationalTelemetry {
         attributes?: Record<string, any>,
         scopeName?: string
     ): void {
-        const meter = opentelemetry.metrics.getMeter(scopeName ? scopeName : this.RUNTIMES_SCOPE_NAME)
+        const meter = metrics.getMeter(scopeName ? scopeName : this.RUNTIMES_SCOPE_NAME)
         const gauge = meter.createObservableGauge(metricName)
         gauge.addCallback(result => {
             result.observe(valueProvider(), attributes as Attributes)
         })
-    }
-
-    getCustomAttributes(): Record<string, any> {
-        return this.customAttributes
-    }
-
-    updateCustomAttributes(key: string, value: any): void {
-        this.customAttributes[key] = value
     }
 }

--- a/runtimes/runtimes/operational-telemetry/operational-telemetry.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry.ts
@@ -6,11 +6,11 @@ export interface OperationalTelemetry {
         scopeName?: string
     ): void
     recordEvent(eventType: string, attributes?: Record<string, any>, scopeName?: string): void
-    toggleTelemetry(telemetryOptOut: boolean): void
+    toggleOptOut(telemetryOptOut: boolean): void
 }
 
 class NoopOperationalTelemetry implements OperationalTelemetry {
-    toggleTelemetry(telemetryOptOut: boolean): void {}
+    toggleOptOut(telemetryOptOut: boolean): void {}
 
     registerGaugeProvider(
         _metricName: string,
@@ -31,8 +31,8 @@ class ScopedTelemetryService implements OperationalTelemetry {
         this.defaultScopeName = scope
     }
 
-    toggleTelemetry(telemetryOptOut: boolean): void {
-        this.telemetryService.toggleTelemetry(telemetryOptOut)
+    toggleOptOut(telemetryOptOut: boolean): void {
+        this.telemetryService.toggleOptOut(telemetryOptOut)
     }
 
     recordEvent(eventName: string, attributes?: Record<string, any>, scopeName?: string): void {

--- a/runtimes/runtimes/operational-telemetry/operational-telemetry.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry.ts
@@ -6,8 +6,16 @@ export interface OperationalTelemetry {
         scopeName?: string
     ): void
     recordEvent(eventType: string, attributes?: Record<string, any>, scopeName?: string): void
+    updateTelemetryStatus(status: TelemetryStatus): void
+    getTelemetryStatus(): TelemetryStatus
     getCustomAttributes(): Record<string, any>
     updateCustomAttributes(key: string, value: any): void
+}
+
+export enum TelemetryStatus {
+    Disabled,
+    Enabled,
+    Pending,
 }
 
 export class OperationalTelemetryProvider {
@@ -27,6 +35,12 @@ export class OperationalTelemetryProvider {
 }
 
 class NoopOperationalTelemetry implements OperationalTelemetry {
+    getTelemetryStatus(): TelemetryStatus {
+        return TelemetryStatus.Disabled
+    }
+
+    updateTelemetryStatus(ts: TelemetryStatus): void {}
+
     registerGaugeProvider(
         _metricName: string,
         _valueProvider: () => number,
@@ -50,6 +64,14 @@ class ScopedTelemetryService implements OperationalTelemetry {
     constructor(scope: string, telemetryService: OperationalTelemetry) {
         this.telemetryService = telemetryService
         this.defaultScopeName = scope
+    }
+
+    getTelemetryStatus(): TelemetryStatus {
+        return this.telemetryService.getTelemetryStatus()
+    }
+
+    updateTelemetryStatus(ts: TelemetryStatus): void {
+        this.telemetryService.updateTelemetryStatus(ts)
     }
 
     recordEvent(eventName: string, attributes?: Record<string, any>, scopeName?: string): void {

--- a/runtimes/runtimes/standalone.test.ts
+++ b/runtimes/runtimes/standalone.test.ts
@@ -61,7 +61,7 @@ describe('standalone', () => {
                 'Runtime: Initializing runtime without encryption'
             )
             sinon.assert.calledWithExactly(baseChatModule.BaseChat as unknown as sinon.SinonStub, stubConnection)
-            sinon.assert.calledTwice(lspRouterStub.servers.push as sinon.SinonStub)
+            sinon.assert.calledThrice(lspRouterStub.servers.push as sinon.SinonStub)
             sinon.assert.calledOnce(stubConnection.listen)
         })
 
@@ -102,7 +102,7 @@ describe('standalone', () => {
                 encryptionInitialization.key,
                 encryptionInitialization.mode
             )
-            sinon.assert.calledTwice(lspRouterStub.servers.push as sinon.SinonStub)
+            sinon.assert.calledThrice(lspRouterStub.servers.push as sinon.SinonStub)
             sinon.assert.calledOnce(stubConnection.listen)
         })
     })

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -64,7 +64,7 @@ import { Encoding } from './encoding'
 import { LoggingServer } from './lsp/router/loggingServer'
 import { Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
-import { getTelmetryLspServer } from './util/telemetryLspServer'
+import { getTelemetryLspServer } from './util/telemetryLspServer'
 
 // Honor shared aws config file
 if (checkAWSConfigFile()) {
@@ -268,7 +268,7 @@ export const standalone = (props: RuntimeProps) => {
         const logging: Logging = loggingServer.getLoggingObject()
         lspRouter.servers.push(loggingServer.getLspServer())
 
-        const telemetryLspServer = getTelmetryLspServer(lspConnection, encoding, logging, props)
+        const telemetryLspServer = getTelemetryLspServer(lspConnection, encoding, logging, props)
         lspRouter.servers.push(telemetryLspServer)
 
         // Initialize every Server

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -268,8 +268,8 @@ export const standalone = (props: RuntimeProps) => {
         const logging: Logging = loggingServer.getLoggingObject()
         lspRouter.servers.push(loggingServer.getLspServer())
 
-        // const telemetryLspServer = getTelmetryLspServer(lspConnection, encoding, logging, props)
-        // lspRouter.servers.push(telemetryLspServer)
+        const telemetryLspServer = getTelmetryLspServer(lspConnection, encoding, logging, props)
+        lspRouter.servers.push(telemetryLspServer)
 
         // Initialize every Server
         const disposables = props.servers.map(s => {

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -64,6 +64,7 @@ import { Encoding } from './encoding'
 import { LoggingServer } from './lsp/router/loggingServer'
 import { Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
+import { getTelmetryLspServer } from './util/telemetryLspServer'
 
 // Honor shared aws config file
 if (checkAWSConfigFile()) {
@@ -266,6 +267,9 @@ export const standalone = (props: RuntimeProps) => {
         const loggingServer = new LoggingServer(lspConnection, encoding)
         const logging: Logging = loggingServer.getLoggingObject()
         lspRouter.servers.push(loggingServer.getLspServer())
+
+        const telemetryLspServer = getTelmetryLspServer(lspConnection, encoding, logging)
+        lspRouter.servers.push(telemetryLspServer)
 
         // Initialize every Server
         const disposables = props.servers.map(s => {

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -268,8 +268,8 @@ export const standalone = (props: RuntimeProps) => {
         const logging: Logging = loggingServer.getLoggingObject()
         lspRouter.servers.push(loggingServer.getLspServer())
 
-        const telemetryLspServer = getTelmetryLspServer(lspConnection, encoding, logging)
-        lspRouter.servers.push(telemetryLspServer)
+        // const telemetryLspServer = getTelmetryLspServer(lspConnection, encoding, logging, props)
+        // lspRouter.servers.push(telemetryLspServer)
 
         // Initialize every Server
         const disposables = props.servers.map(s => {

--- a/runtimes/runtimes/util/telemetryLspServer.ts
+++ b/runtimes/runtimes/util/telemetryLspServer.ts
@@ -18,18 +18,18 @@ export function getTelmetryLspServer(
     lspServer.setInitializeHandler(async (params: InitializeParams): Promise<InitializeResult> => {
         const optOut = params.initializationOptions?.telemetryOptOut ?? true // telemetry disabled if option not provided
 
-        const optel = OperationalTelemetryService.getInstance({
-            serviceName: props.name,
-            serviceVersion: props.version,
-            extendedClientInfo: params.initializationOptions?.aws?.clientInfo,
-            lspConsole: lspConnection.console,
-            poolId: '',
-            region: '',
-            endpoint: '',
-            telemetryOptOut: optOut,
-        })
+        // const optel = OperationalTelemetryService.getInstance({
+        //     serviceName: props.name,
+        //     serviceVersion: props.version,
+        //     extendedClientInfo: params.initializationOptions?.aws?.clientInfo,
+        //     lspConsole: lspConnection.console,
+        //     poolId: '',
+        //     region: '',
+        //     endpoint: '',
+        //     telemetryOptOut: optOut,
+        // })
 
-        OperationalTelemetryProvider.setTelemetryInstance(optel)
+        // OperationalTelemetryProvider.setTelemetryInstance(optel)
 
         return {
             capabilities: {},
@@ -42,7 +42,7 @@ export function getTelmetryLspServer(
         })
 
         if (typeof optOut === 'boolean') {
-            OperationalTelemetryProvider.getTelemetryForScope('').toggleTelemetry(optOut)
+            OperationalTelemetryProvider.getTelemetryForScope('').toggleOptOut(optOut)
         }
     })
 

--- a/runtimes/runtimes/util/telemetryLspServer.ts
+++ b/runtimes/runtimes/util/telemetryLspServer.ts
@@ -7,7 +7,7 @@ import { RuntimeProps } from '../runtime'
 import { OperationalTelemetryService } from '../operational-telemetry/operational-telemetry-service'
 import { InitializeParams, InitializeResult } from '../../protocol'
 
-export function getTelmetryLspServer(
+export function getTelemetryLspServer(
     lspConnection: Connection,
     encoding: Encoding,
     logging: Logging,

--- a/runtimes/runtimes/util/telemetryLspServer.ts
+++ b/runtimes/runtimes/util/telemetryLspServer.ts
@@ -1,0 +1,37 @@
+import { Connection, InitializeParams, InitializeResult } from 'vscode-languageserver/node'
+import { Encoding } from '../encoding'
+import { Logging } from '../../server-interface/logging'
+import { LspServer } from '../lsp/router/lspServer'
+import { OperationalTelemetryProvider, TelemetryStatus } from '../operational-telemetry/operational-telemetry'
+
+export function getTelmetryLspServer(lspConnection: Connection, encoding: Encoding, logging: Logging): LspServer {
+    const lspServer = new LspServer(lspConnection, encoding, logging)
+    lspServer.setInitializeHandler(async (params: InitializeParams): Promise<InitializeResult> => {
+        const optOut: boolean = params.initializationOptions?.telemetryOptOut ?? false
+
+        let status = TelemetryStatus.Enabled
+        if (optOut) {
+            status = TelemetryStatus.Disabled
+        }
+
+        OperationalTelemetryProvider.getTelemetryForScope('').updateTelemetryStatus(status)
+
+        return {
+            capabilities: {},
+        }
+    })
+    lspServer.setDidChangeConfigurationHandler(async params => {
+        const optOut = (await lspConnection.workspace.getConfiguration({
+            section: 'aws.q.optOutTelemetry',
+        })) as boolean
+
+        let status = TelemetryStatus.Enabled
+        if (optOut) {
+            status = TelemetryStatus.Disabled
+        }
+
+        OperationalTelemetryProvider.getTelemetryForScope('').updateTelemetryStatus(status)
+    })
+
+    return lspServer
+}

--- a/runtimes/runtimes/util/telemetryLspServer.ts
+++ b/runtimes/runtimes/util/telemetryLspServer.ts
@@ -1,36 +1,49 @@
-import { Connection, InitializeParams, InitializeResult } from 'vscode-languageserver/node'
+import { Connection } from 'vscode-languageserver/node'
 import { Encoding } from '../encoding'
 import { Logging } from '../../server-interface/logging'
 import { LspServer } from '../lsp/router/lspServer'
-import { OperationalTelemetryProvider, TelemetryStatus } from '../operational-telemetry/operational-telemetry'
+import { OperationalTelemetryProvider } from '../operational-telemetry/operational-telemetry'
+import { RuntimeProps } from '../runtime'
+import { OperationalTelemetryService } from '../operational-telemetry/operational-telemetry-service'
+import { InitializeParams, InitializeResult } from '../../protocol'
 
-export function getTelmetryLspServer(lspConnection: Connection, encoding: Encoding, logging: Logging): LspServer {
+export function getTelmetryLspServer(
+    lspConnection: Connection,
+    encoding: Encoding,
+    logging: Logging,
+    props: RuntimeProps
+): LspServer {
     const lspServer = new LspServer(lspConnection, encoding, logging)
+
     lspServer.setInitializeHandler(async (params: InitializeParams): Promise<InitializeResult> => {
-        const optOut: boolean = params.initializationOptions?.telemetryOptOut ?? false
+        const optOut = params.initializationOptions?.telemetryOptOut ?? true // telemetry disabled if option not provided
 
-        let status = TelemetryStatus.Enabled
-        if (optOut) {
-            status = TelemetryStatus.Disabled
-        }
+        const optel = OperationalTelemetryService.getInstance({
+            serviceName: props.name,
+            serviceVersion: props.version,
+            extendedClientInfo: params.initializationOptions?.aws?.clientInfo,
+            lspConsole: lspConnection.console,
+            poolId: '',
+            region: '',
+            endpoint: '',
+            telemetryOptOut: optOut,
+        })
 
-        OperationalTelemetryProvider.getTelemetryForScope('').updateTelemetryStatus(status)
+        OperationalTelemetryProvider.setTelemetryInstance(optel)
 
         return {
             capabilities: {},
         }
     })
+
     lspServer.setDidChangeConfigurationHandler(async params => {
-        const optOut = (await lspConnection.workspace.getConfiguration({
-            section: 'aws.q.optOutTelemetry',
-        })) as boolean
+        const optOut = await lspConnection.workspace.getConfiguration({
+            section: 'aws.optOutTelemetry',
+        })
 
-        let status = TelemetryStatus.Enabled
-        if (optOut) {
-            status = TelemetryStatus.Disabled
+        if (typeof optOut === 'boolean') {
+            OperationalTelemetryProvider.getTelemetryForScope('').toggleTelemetry(optOut)
         }
-
-        OperationalTelemetryProvider.getTelemetryForScope('').updateTelemetryStatus(status)
     })
 
     return lspServer


### PR DESCRIPTION
## Problem
We need to respect customer decision and provide a way for them to opt-out of the operational telemetry.

## Solution
- Extended the telemetry interface with a method to update telemetry opt out status, which determines if metrics are collected or not.
- Added another LSP server to the router that updates telemetry opt-out status upon initialization and when workspace configuration variables change.
- The OpenTelemetry SDK is shut down when a user turns off telemetry and started again when a user enables telemetry.
- Enabling or disabling telemetry does not require an IDE/extension restart.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
