### PR TITLE
Fix generate types compile step

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "scripts": {
         "clean": "ts-node ./script/clean.ts",
         "commitlint": "commitlint --edit",
-        "compile": "npm run generate-types && tsc --build && npm run compile --workspaces --if-present",
+        "precompile": "npm run generate-types --workspaces --if-present",
+        "compile": "tsc --build && npm run compile --workspaces --if-present",
         "check:formatting": "prettier --check .",
         "fix:prettier": "prettier . --write",
         "format-staged": "npx pretty-quick --staged",
@@ -34,8 +35,7 @@
         "test": "npm run test --workspaces --if-present",
         "preversion": "npm run test",
         "version": "npm run compile && git add -A .",
-        "watch": "tsc --build --watch",
-        "generate-types": "ts-node ./script/generate-types.ts"
+        "watch": "tsc --build --watch"
     },
     "devDependencies": {
         "@commitlint/cli": "^19.6.1",

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -21,6 +21,7 @@
     },
     "scripts": {
         "clean": "rm -rf out/",
+        "precompile": "npm run generate-types",
         "compile": "tsc --build",
         "fix:prettier": "prettier . --write",
         "prepare": "husky install",
@@ -30,6 +31,7 @@
         "test:unit": "ts-mocha -b './**/*.test.ts'",
         "test": "npm run test:unit",
         "preversion": "npm run test",
+        "generate-types": "ts-node ./script/generate-types.ts",
         "version": "npm run compile && git add -A ."
     },
     "dependencies": {

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -116,6 +116,7 @@ export interface InitializeParams extends _InitializeParamsBase {
     initializationOptions?: {
         [key: string]: any
         logLevel?: LogLevel
+        telemetryOptOut?: boolean
         aws?: AWSInitializationOptions
     }
 }

--- a/runtimes/runtimes/operational-telemetry/aws-metrics-exporter.test.ts
+++ b/runtimes/runtimes/operational-telemetry/aws-metrics-exporter.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon'
 import { AwsMetricExporter } from './aws-metrics-exporter'
 import { ExportResultCode } from '@opentelemetry/core'
 import { ResourceMetrics } from '@opentelemetry/sdk-metrics'
-import { OperationalTelemetry } from './operational-telemetry'
+import { OperationalTelemetry, TelemetryStatus } from './operational-telemetry'
 import { AwsCognitoApiGatewaySender } from './aws-cognito-gateway-sender'
 import { OperationalEventValidator } from './operational-event-validator'
 
@@ -112,6 +112,7 @@ describe('AwsMetricExporter', () => {
                 'clientInfo.extension.version': '1.0.0',
                 'clientInfo.clientId': 'test-id',
             }),
+            getTelemetryStatus: sinon.stub().returns(TelemetryStatus.Enabled),
         } as any
 
         sender = {

--- a/runtimes/runtimes/operational-telemetry/aws-spans-exporter.test.ts
+++ b/runtimes/runtimes/operational-telemetry/aws-spans-exporter.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon'
 import { AwsSpanExporter } from './aws-spans-exporter'
 import { ExportResultCode } from '@opentelemetry/core'
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base'
-import { OperationalTelemetry } from './operational-telemetry'
+import { OperationalTelemetry, TelemetryStatus } from './operational-telemetry'
 import { AwsCognitoApiGatewaySender } from './aws-cognito-gateway-sender'
 import { OperationalEventValidator } from './operational-event-validator'
 
@@ -58,6 +58,7 @@ describe('AWSSpanExporter', () => {
                 'clientInfo.extension.version': '1.0.0',
                 'clientInfo.clientId': 'test-id',
             }),
+            getTelemetryStatus: sinon.stub().returns(TelemetryStatus.Enabled),
         } as any
 
         sender = {

--- a/runtimes/runtimes/operational-telemetry/operational-telemetry.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry.ts
@@ -6,8 +6,16 @@ export interface OperationalTelemetry {
         scopeName?: string
     ): void
     recordEvent(eventType: string, attributes?: Record<string, any>, scopeName?: string): void
+    updateTelemetryStatus(status: TelemetryStatus): void
+    getTelemetryStatus(): TelemetryStatus
     getCustomAttributes(): Record<string, any>
     updateCustomAttributes(key: string, value: any): void
+}
+
+export enum TelemetryStatus {
+    Disabled,
+    Enabled,
+    Pending,
 }
 
 export class OperationalTelemetryProvider {
@@ -27,6 +35,12 @@ export class OperationalTelemetryProvider {
 }
 
 class NoopOperationalTelemetry implements OperationalTelemetry {
+    getTelemetryStatus(): TelemetryStatus {
+        return TelemetryStatus.Disabled
+    }
+
+    updateTelemetryStatus(ts: TelemetryStatus): void {}
+
     registerGaugeProvider(
         _metricName: string,
         _valueProvider: () => number,
@@ -50,6 +64,14 @@ class ScopedTelemetryService implements OperationalTelemetry {
     constructor(scope: string, telemetryService: OperationalTelemetry) {
         this.telemetryService = telemetryService
         this.defaultScopeName = scope
+    }
+
+    getTelemetryStatus(): TelemetryStatus {
+        return this.telemetryService.getTelemetryStatus()
+    }
+
+    updateTelemetryStatus(ts: TelemetryStatus): void {
+        this.telemetryService.updateTelemetryStatus(ts)
     }
 
     recordEvent(eventName: string, attributes?: Record<string, any>, scopeName?: string): void {

--- a/runtimes/runtimes/standalone.test.ts
+++ b/runtimes/runtimes/standalone.test.ts
@@ -61,7 +61,7 @@ describe('standalone', () => {
                 'Runtime: Initializing runtime without encryption'
             )
             sinon.assert.calledWithExactly(baseChatModule.BaseChat as unknown as sinon.SinonStub, stubConnection)
-            sinon.assert.calledTwice(lspRouterStub.servers.push as sinon.SinonStub)
+            sinon.assert.calledThrice(lspRouterStub.servers.push as sinon.SinonStub)
             sinon.assert.calledOnce(stubConnection.listen)
         })
 
@@ -102,7 +102,7 @@ describe('standalone', () => {
                 encryptionInitialization.key,
                 encryptionInitialization.mode
             )
-            sinon.assert.calledTwice(lspRouterStub.servers.push as sinon.SinonStub)
+            sinon.assert.calledThrice(lspRouterStub.servers.push as sinon.SinonStub)
             sinon.assert.calledOnce(stubConnection.listen)
         })
     })

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -64,6 +64,7 @@ import { Encoding } from './encoding'
 import { LoggingServer } from './lsp/router/loggingServer'
 import { Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
+import { getTelmetryLspServer } from './util/telemetryLspServer'
 
 // Honor shared aws config file
 if (checkAWSConfigFile()) {
@@ -266,6 +267,9 @@ export const standalone = (props: RuntimeProps) => {
         const loggingServer = new LoggingServer(lspConnection, encoding)
         const logging: Logging = loggingServer.getLoggingObject()
         lspRouter.servers.push(loggingServer.getLspServer())
+
+        const telemetryLspServer = getTelmetryLspServer(lspConnection, encoding, logging)
+        lspRouter.servers.push(telemetryLspServer)
 
         // Initialize every Server
         const disposables = props.servers.map(s => {

--- a/runtimes/runtimes/util/telemetryLspServer.ts
+++ b/runtimes/runtimes/util/telemetryLspServer.ts
@@ -1,0 +1,37 @@
+import { Connection, InitializeParams, InitializeResult } from 'vscode-languageserver/node'
+import { Encoding } from '../encoding'
+import { Logging } from '../../server-interface/logging'
+import { LspServer } from '../lsp/router/lspServer'
+import { OperationalTelemetryProvider, TelemetryStatus } from '../operational-telemetry/operational-telemetry'
+
+export function getTelmetryLspServer(lspConnection: Connection, encoding: Encoding, logging: Logging): LspServer {
+    const lspServer = new LspServer(lspConnection, encoding, logging)
+    lspServer.setInitializeHandler(async (params: InitializeParams): Promise<InitializeResult> => {
+        const optOut: boolean = params.initializationOptions?.telemetryOptOut ?? false
+
+        let status = TelemetryStatus.Enabled
+        if (optOut) {
+            status = TelemetryStatus.Disabled
+        }
+
+        OperationalTelemetryProvider.getTelemetryForScope('').updateTelemetryStatus(status)
+
+        return {
+            capabilities: {},
+        }
+    })
+    lspServer.setDidChangeConfigurationHandler(async params => {
+        const optOut = (await lspConnection.workspace.getConfiguration({
+            section: 'aws.q.optOutTelemetry',
+        })) as boolean
+
+        let status = TelemetryStatus.Enabled
+        if (optOut) {
+            status = TelemetryStatus.Disabled
+        }
+
+        OperationalTelemetryProvider.getTelemetryForScope('').updateTelemetryStatus(status)
+    })
+
+    return lspServer
+}

--- a/runtimes/script/generate-types.ts
+++ b/runtimes/script/generate-types.ts
@@ -6,7 +6,7 @@ const execAsync = promisify(exec)
 
 async function generateTypes() {
     try {
-        const schemaDir = path.resolve(__dirname, '../runtimes/runtimes/operational-telemetry/telemetry-schemas')
+        const schemaDir = path.resolve(__dirname, '../runtimes/operational-telemetry/telemetry-schemas')
         const input = path.join(schemaDir, 'telemetry-schema.json')
         const output = path.join(schemaDir, '../types/generated/telemetry.d.ts')
 


### PR DESCRIPTION
## Problem
The compile script needs to be executed in the runtimes package directory, but the `generate-types` script is currently only run in the root-level `package.json` of the monorepo.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
