### PR TITLE
fix: generate types in runtimes repo before compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "scripts": {
         "clean": "ts-node ./script/clean.ts",
         "commitlint": "commitlint --edit",
-        "compile": "npm run generate-types && tsc --build && npm run compile --workspaces --if-present",
+        "precompile": "npm run generate-types --workspaces --if-present",
+        "compile": "tsc --build && npm run compile --workspaces --if-present",
         "check:formatting": "prettier --check .",
         "fix:prettier": "prettier . --write",
         "format-staged": "npx pretty-quick --staged",
@@ -34,8 +35,7 @@
         "test": "npm run test --workspaces --if-present",
         "preversion": "npm run test",
         "version": "npm run compile && git add -A .",
-        "watch": "tsc --build --watch",
-        "generate-types": "ts-node ./script/generate-types.ts"
+        "watch": "tsc --build --watch"
     },
     "devDependencies": {
         "@commitlint/cli": "^19.6.1",

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -21,6 +21,7 @@
     },
     "scripts": {
         "clean": "rm -rf out/",
+        "precompile": "npm run generate-types",
         "compile": "tsc --build",
         "fix:prettier": "prettier . --write",
         "prepare": "husky install",
@@ -30,7 +31,8 @@
         "test:unit": "ts-mocha -b './**/*.test.ts'",
         "test": "npm run test:unit",
         "preversion": "npm run test",
-        "version": "npm run compile && git add -A ."
+        "version": "npm run compile && git add -A .",
+        "generate-types": "ts-node ./script/generate-types.ts"
     },
     "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/runtimes/script/generate-types.ts
+++ b/runtimes/script/generate-types.ts
@@ -6,7 +6,7 @@ const execAsync = promisify(exec)
 
 async function generateTypes() {
     try {
-        const schemaDir = path.resolve(__dirname, '../runtimes/runtimes/operational-telemetry/telemetry-schemas')
+        const schemaDir = path.resolve(__dirname, '../runtimes/operational-telemetry/telemetry-schemas')
         const input = path.join(schemaDir, 'telemetry-schema.json')
         const output = path.join(schemaDir, '../types/generated/telemetry.d.ts')
 


### PR DESCRIPTION
## Problem
The compile script needs to be executed in the runtimes package directory, but the generate-types script is currently only run in the root-level package.json of the monorepo.
## Solution
Added precompile step to both runtimes and root-level package.json.

This means that the root-level compile step will run the generate-types step twice.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
