### PR TITLE
docs: add explanation on differences with servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Language Server Runtimes for AWS Monorepo
 
+## Relation with Language Servers
+
+This monorepo hosts the runtime library for creating a fully working language server. The runtime is responsible to provide the interface of the server and expose the features of the protocol defined through them. All official AWS Language Servers created using this implementation is stored in the [Language Servers repo](https://github.com/aws/language-servers/tree/main).
+
+Want to create a new protocol or feature that would be available to all language servers? See what we already provide in [runtimes package](runtimes).
+
+Want to create a new language capability? Head over to the [Language Servers repo](https://github.com/aws/language-servers/tree/main) and start building!
+
 ## Structure
 
 Monorepo


### PR DESCRIPTION
## Problem
There is no explanation on the relation between [servers](https://github.com/aws/language-servers) and runtimes, which causes confusion for developers new to the repo.

## Solution
Add a brief explanation in the README

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
