### PR TITLE
fix: moving the telemetry logging for initialization options to the l…

### DIFF
--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -46,6 +46,7 @@ describe('LspRouter', () => {
         const onInitializeSpy = sandbox.spy(lspConnection, 'onInitialize')
         const onExecuteommandSpy = sandbox.spy(lspConnection, 'onExecuteCommand')
         lspConnection.telemetry.logEvent = sandbox.stub()
+        lspConnection.console.log = sandbox.stub()
 
         lspRouter = new LspRouter(lspConnection, 'AWS LSP Standalone', '1.0.0')
 
@@ -83,6 +84,25 @@ describe('LspRouter', () => {
             await initializeHandler(params, {} as CancellationToken)
             // @ts-ignore
             sinon.assert.calledOnce(lspConnection.telemetry.logEvent)
+            // @ts-ignore
+            sinon.assert.calledOnce(lspConnection.console.log)
+        })
+
+        it('should log telemetry event only once when aws config is missing in InitializeParams when multiple servers are present', async () => {
+            const params: InitializeParams = {
+                processId: null,
+                rootUri: null,
+                capabilities: {},
+                initializationOptions: {},
+            }
+            lspRouter.servers.push(newServer({}))
+            lspRouter.servers.push(newServer({}))
+
+            await initializeHandler(params, {} as CancellationToken)
+            // @ts-ignore
+            sinon.assert.calledOnce(lspConnection.telemetry.logEvent)
+            // @ts-ignore
+            sinon.assert.calledOnce(lspConnection.console.log)
         })
 
         it('should return the default response when no handlers are registered', async () => {

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -45,6 +45,7 @@ describe('LspRouter', () => {
     beforeEach(() => {
         const onInitializeSpy = sandbox.spy(lspConnection, 'onInitialize')
         const onExecuteommandSpy = sandbox.spy(lspConnection, 'onExecuteCommand')
+        lspConnection.telemetry.logEvent = sandbox.stub()
 
         lspRouter = new LspRouter(lspConnection, 'AWS LSP Standalone', '1.0.0')
 
@@ -69,6 +70,19 @@ describe('LspRouter', () => {
             const initParam = {} as InitializeParams
             initializeHandler(initParam, {} as CancellationToken)
             assert(lspRouter.clientInitializeParams === initParam)
+        })
+
+        it('should log telemetry event when aws config is missing in InitializeParams', async () => {
+            const params: InitializeParams = {
+                processId: null,
+                rootUri: null,
+                capabilities: {},
+                initializationOptions: {},
+            }
+
+            await initializeHandler(params, {} as CancellationToken)
+            // @ts-ignore
+            sinon.assert.calledOnce(lspConnection.telemetry.logEvent)
         })
 
         it('should return the default response when no handlers are registered', async () => {

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -43,6 +43,21 @@ export class LspRouter {
     ): Promise<InitializeResult | ResponseError<InitializeError>> => {
         this.clientInitializeParams = params
 
+        if (!params.initializationOptions?.aws) {
+            this.lspConnection.telemetry.logEvent({
+                name: 'runtimeInitialization_validation',
+                result: 'Failed',
+                data: {
+                    hasAwsConfig: Boolean(params.initializationOptions?.aws),
+                    logLevel: params.initializationOptions?.logLevel,
+                    initializationOptionsStr: JSON.stringify(params.initializationOptions),
+                },
+                errorData: {
+                    reason: 'aws field is not defined in InitializeResult',
+                },
+            })
+        }
+
         let responsesList = await Promise.all(this.servers.map(s => s.initialize(params, token)))
         responsesList = responsesList.filter(r => r != undefined)
         const responseError = responsesList.find(el => el instanceof ResponseError)

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -18,7 +18,7 @@ import {
 import { Connection } from 'vscode-languageserver/node'
 import { LspServer } from './lspServer'
 import { findDuplicates, mergeObjects } from './util'
-import { PartialInitializeResult } from '../../../server-interface'
+import { Logging, PartialInitializeResult } from '../../../server-interface'
 
 export class LspRouter {
     public clientInitializeParams?: InitializeParams
@@ -56,6 +56,10 @@ export class LspRouter {
                     reason: 'aws field is not defined in InitializeResult',
                 },
             })
+
+            this.lspConnection.console.log(
+                `Unknown initialization error\nwith initialization options: ${JSON.stringify(params.initializationOptions)}`
+            )
         }
 
         let responsesList = await Promise.all(this.servers.map(s => s.initialize(params, token)))

--- a/runtimes/runtimes/lsp/router/lspServer.test.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.test.ts
@@ -91,35 +91,6 @@ describe('LspServer', () => {
             )
         })
 
-        it('should log error when aws config is missing', async () => {
-            const params: InitializeParams = {
-                processId: null,
-                rootUri: null,
-                capabilities: {},
-                initializationOptions: {},
-            }
-
-            const expectedResult: PartialInitializeResult = {
-                capabilities: {},
-                serverInfo: {
-                    name: 'testServer',
-                },
-            }
-            lspServer.setInitializeHandler(() => expectedResult)
-            const result = await lspServer.initialize(params, mockToken)
-
-            sinon.assert.calledOnce(
-                // @ts-ignore
-                mockConnection.telemetry.logEvent
-            )
-            sinon.assert.calledWithMatch(
-                // @ts-ignore
-                mockLogger.log,
-                'Unknown initialization error\nwith initialization options: {}'
-            )
-            assert.strictEqual(result, expectedResult)
-        })
-
         it('should handle initialization errors', async () => {
             const params: InitializeParams = {
                 processId: null,

--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -88,24 +88,6 @@ export class LspServer {
         params: InitializeParams,
         token: CancellationToken
     ): Promise<PartialInitializeResult | ResponseError<InitializeError> | undefined> => {
-        if (!params.initializationOptions?.aws) {
-            this.lspConnection.telemetry.logEvent({
-                name: 'runtimeInitialization_validation',
-                result: 'Failed',
-                data: {
-                    hasAwsConfig: Boolean(params.initializationOptions?.aws),
-                    logLevel: params.initializationOptions?.logLevel,
-                    initializationOptionsStr: JSON.stringify(params.initializationOptions),
-                },
-                errorData: {
-                    reason: 'aws field is not defined in InitializeResult',
-                },
-            })
-
-            this.logger.log(
-                `Unknown initialization error\nwith initialization options: ${JSON.stringify(params.initializationOptions)}`
-            )
-        }
         this.clientSupportsNotifications =
             params.initializationOptions?.aws?.awsClientCapabilities?.window?.notifications
 


### PR DESCRIPTION
…spRouter

## Problem
Relevant PRs for context : https://github.com/aws/language-server-runtimes/pull/332
https://github.com/aws/language-server-runtimes/pull/310
* Logs/Telemetry is getting invoked for each server, hence it is duplicate and spamming the logs. 

## Solution
* Moving the aws check logic into the router so it does not get invoked each time for each server 
* Removing the logging, can add back if required since it is logging the same thing as the telemetry. 


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
