### PR TITLE
chore: remove test files from package and include missing .md files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,7 @@ node_modules/
 package-lock.json
 .*
 tsconfig.json
+tsconfig.tsbuildinfo
+*.test.js
+*.test.d.ts
+*.test.js.map

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -2,13 +2,6 @@
     "name": "@aws/language-server-runtimes",
     "version": "0.2.36",
     "description": "Runtimes to host Language Servers for AWS",
-    "files": [
-        "out",
-        "protocol",
-        "runtimes",
-        "server-interface",
-        "testing"
-    ],
     "repository": {
         "type": "git",
         "url": "https://github.com/aws/language-server-runtimes",


### PR DESCRIPTION
## Problem
`*.test.*` files are included in the `@aws/language-server-runtimes` npm package.
## Solution
Deleted package.json `files` and updated .npmignore to exclude test files. Npm will not use .npmignore if `files` are present. Impact:
* Removed 54 unnecessary files
* Reduced package size by 28.4kB
* Reduced unpacked size by 216.8kB

Added missing files: NOTICE, SECRUITY.md and CHANGELOG.md.

Tested by installing the new runtimes tarball package in `aws-lsp-codewhisperer` and running `npm run test`. Also tested manually by comparing outputs using `npm publish --dry-run` in  the runtimes `pub` script.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
