### PR TITLE
feat: get telemetry aws config from env variables

### DIFF
--- a/runtimes/runtimes/operational-telemetry/README.md
+++ b/runtimes/runtimes/operational-telemetry/README.md
@@ -52,7 +52,12 @@ The service requires the following configuration:
 - AWS Region
 - AWS API Gateway Endpoint
 
-These values are currently set in the `AwsCognitoApiGatewaySender` constructor in `operational-telemetry-service.ts`.
+This can be configured using the following environment variables:
+- `TELEMETRY_GATEWAY_ENDPOINT` - The endpoint URL for the telemetry gateway
+- `TELEMETRY_COGNITO_REGION` - AWS region for Cognito authentication
+- `TELEMETRY_COGNITO_POOL_ID` - Cognito Pool ID for authentication
+
+Default values for these configurations can be found in `language-server-runtimes/runtimes/runtimes/util/telemetryLspServer.ts`.
 
 ## Data Flow
 

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -268,7 +268,7 @@ export const standalone = (props: RuntimeProps) => {
         const logging: Logging = loggingServer.getLoggingObject()
         lspRouter.servers.push(loggingServer.getLspServer())
 
-        const telemetryLspServer = getTelemetryLspServer(lspConnection, encoding, logging, props)
+        const telemetryLspServer = getTelemetryLspServer(lspConnection, encoding, logging, props, runtime)
         lspRouter.servers.push(telemetryLspServer)
 
         const sdkProxyConfigManager = new ProxyConfigManager()

--- a/runtimes/runtimes/util/telemetryLspServer.ts
+++ b/runtimes/runtimes/util/telemetryLspServer.ts
@@ -36,7 +36,7 @@ export function getTelemetryLspServer(
         //     poolId: poolId,
         //     region: region,
         //     endpoint: endpoint,
-        //     telemetryOptOut: false,
+        //     telemetryOptOut: optOut,
         // })
 
         // OperationalTelemetryProvider.setTelemetryInstance(optel)

--- a/runtimes/runtimes/util/telemetryLspServer.ts
+++ b/runtimes/runtimes/util/telemetryLspServer.ts
@@ -6,27 +6,37 @@ import { OperationalTelemetryProvider } from '../operational-telemetry/operation
 import { RuntimeProps } from '../runtime'
 import { OperationalTelemetryService } from '../operational-telemetry/operational-telemetry-service'
 import { InitializeParams, InitializeResult } from '../../protocol'
+import { Runtime } from '../../server-interface'
+
+const DEFAULT_TELEMETRY_GATEWAY_ENDPOINT = ''
+const DEFAULT_TELEMETRY_COGNITO_REGION = ''
+const DEFAULT_TELEMETRY_COGNITO_POOL_ID = ''
 
 export function getTelemetryLspServer(
     lspConnection: Connection,
     encoding: Encoding,
     logging: Logging,
-    props: RuntimeProps
+    props: RuntimeProps,
+    runtime: Runtime
 ): LspServer {
     const lspServer = new LspServer(lspConnection, encoding, logging)
 
     lspServer.setInitializeHandler(async (params: InitializeParams): Promise<InitializeResult> => {
         const optOut = params.initializationOptions?.telemetryOptOut ?? true // telemetry disabled if option not provided
 
+        const endpoint = runtime.getConfiguration('TELEMETRY_GATEWAY_ENDPOINT') ?? DEFAULT_TELEMETRY_GATEWAY_ENDPOINT
+        const region = runtime.getConfiguration('TELEMETRY_COGNITO_REGION') ?? DEFAULT_TELEMETRY_COGNITO_REGION
+        const poolId = runtime.getConfiguration('TELEMETRY_COGNITO_POOL_ID') ?? DEFAULT_TELEMETRY_COGNITO_POOL_ID
+
         // const optel = OperationalTelemetryService.getInstance({
         //     serviceName: props.name,
         //     serviceVersion: props.version,
         //     extendedClientInfo: params.initializationOptions?.aws?.clientInfo,
         //     lspConsole: lspConnection.console,
-        //     poolId: '',
-        //     region: '',
-        //     endpoint: '',
-        //     telemetryOptOut: optOut,
+        //     poolId: poolId,
+        //     region: region,
+        //     endpoint: endpoint,
+        //     telemetryOptOut: false,
         // })
 
         // OperationalTelemetryProvider.setTelemetryInstance(optel)


### PR DESCRIPTION
## Problem
We need a mechanism to inject different telemetry configuration for testing.

## Solution
Added getting telemetry config from environmental variables.
Tested manually by setting different environment variables in the language-servers launch configuration with linked runtimes changes.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
