### PR TITLE
feat(runtimes): add UpdateConfiguration protocol and Server handlers

### DIFF
--- a/runtimes/protocol/configuration.ts
+++ b/runtimes/protocol/configuration.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LSPAny, ProtocolRequestType, ResponseError } from './lsp'
+
+/**
+ * LSP Extension: Configuration Update Support
+ *
+ * This module implements an LSP extension that provides a push-based configuration
+ * update mechanism with synchronous server response. This extends the standard LSP
+ * configuration model to support scenarios requiring immediate confirmation of
+ * configuration changes.
+ *
+ * The extension defines:
+ * - UpdateConfigurationParams interface for specifying section and settings to update
+ * - Protocol request type for configuration updates
+ *
+ * @remarks
+ * This extension should only be used in limited scenarios where immediate server
+ * response is required to maintain stable UX flow. For routine configuration updates,
+ * the standard LSP configuration model using workspace/didChangeConfiguration should
+ * be used instead.
+ *
+ * Example usage:
+ * ```typescript
+ * // Client-side request
+ * const params: UpdateConfigurationParams = {
+ *     section: "aws.amazonq",
+ *     settings: { setting1: "value1" }
+ * };
+ * await client.sendRequest(updateConfigurationRequestType, params);
+ * ```
+ */
+export interface UpdateConfigurationParams {
+    section: string
+    settings: LSPAny
+}
+
+export const updateConfigurationRequestType = new ProtocolRequestType<
+    UpdateConfigurationParams,
+    null,
+    never,
+    ResponseError,
+    void
+>('aws/updateConfiguration')

--- a/runtimes/protocol/index.ts
+++ b/runtimes/protocol/index.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export * from './auth'
 export * from './chat'
 export * from './didChangeDependencyPaths'
@@ -6,3 +11,4 @@ export * from './identity-management'
 export * from './lsp'
 export * from './notification'
 export * from './telemetry'
+export * from './configuration'

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { _EM } from 'vscode-jsonrpc'
 import {
     InitializeParams as _InitializeParamsBase,
@@ -106,6 +111,11 @@ export interface AWSInitializationOptions {
             notifications?: boolean
         }
     }
+    /**
+     * Global region configuration option set by the client application.
+     * Server implementations can use this value to preconfigure SDKs, API clients, etc. at server process startup.
+     */
+    region?: string
 }
 
 /**

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { TextDocuments } from 'vscode-languageserver'
 import {
     DidChangeWorkspaceFoldersNotification,
@@ -185,6 +190,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
                 onDidCreateFiles: params => lspConnection.workspace.onDidCreateFiles(params),
                 onDidDeleteFiles: params => lspConnection.workspace.onDidDeleteFiles(params),
                 onDidRenameFiles: params => lspConnection.workspace.onDidRenameFiles(params),
+                onUpdateConfiguration: lspServer.setUpdateConfigurationHandler,
             },
             window: {
                 showMessage: params => lspConnection.sendNotification(ShowMessageNotification.method, params),

--- a/runtimes/runtimes/lsp/router/lspServer.test.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.test.ts
@@ -4,12 +4,10 @@ import {
     DidChangeConfigurationParams,
     ExecuteCommandParams,
     GetConfigurationFromServerParams,
-    InitializeError,
-    InitializedParams,
     NotificationFollowupParams,
     NotificationParams,
     ResponseError,
-    showNotificationRequestType,
+    UpdateConfigurationParams,
 } from '../../../protocol'
 import { Connection } from 'vscode-languageserver/node'
 import { InitializeParams, PartialInitializeResult } from '../../../server-interface/lsp'
@@ -243,6 +241,22 @@ describe('LspServer', () => {
 
             assert.strictEqual(handled, true)
             assert.deepStrictEqual(result, expectedResult)
+        })
+
+        it('should handle updateConfiguration requests', async () => {
+            const updateConfigurationHandler = sandbox.stub()
+            const params: UpdateConfigurationParams = {
+                section: 'aws.testconfig',
+                settings: {
+                    foo: 'bar',
+                },
+            }
+
+            lspServer.setUpdateConfigurationHandler(updateConfigurationHandler)
+            lspServer.sendUpdateConfigurationRequest(params, mockToken)
+
+            assert(updateConfigurationHandler.calledOnce)
+            assert(updateConfigurationHandler.calledWith(params))
         })
     })
 })

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { TextDocuments } from 'vscode-languageserver'
 import {
     DidChangeWorkspaceFoldersNotification,
@@ -313,6 +318,7 @@ export const standalone = (props: RuntimeProps) => {
                     onDidCreateFiles: params => lspConnection.workspace.onDidCreateFiles(params),
                     onDidDeleteFiles: params => lspConnection.workspace.onDidDeleteFiles(params),
                     onDidRenameFiles: params => lspConnection.workspace.onDidRenameFiles(params),
+                    onUpdateConfiguration: lspServer.setUpdateConfigurationHandler,
                 },
                 window: {
                     showMessage: params => lspConnection.sendNotification(ShowMessageNotification.method, params),

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
     CompletionItem,
     CompletionList,
@@ -47,12 +52,13 @@ import {
     CreateFilesParams,
     RenameFilesParams,
     DidChangeDependencyPathsParams,
+    UpdateConfigurationParams,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
 // This is needed for LSP features as we pass messages down.
 export * from '../protocol/lsp'
-export { GetConfigurationFromServerParams } from '../protocol'
+export { GetConfigurationFromServerParams, UpdateConfigurationParams } from '../protocol'
 
 export type PartialServerCapabilities<T = any> = Pick<
     ServerCapabilities<T>,
@@ -127,6 +133,7 @@ export type Lsp = {
         onDidCreateFiles: (handler: NotificationHandler<CreateFilesParams>) => void
         onDidDeleteFiles: (handler: NotificationHandler<DeleteFilesParams>) => void
         onDidRenameFiles: (handler: NotificationHandler<RenameFilesParams>) => void
+        onUpdateConfiguration: (handler: RequestHandler<UpdateConfigurationParams, void, void>) => void
     }
     window: {
         showMessage: (params: ShowMessageParams) => Promise<void>


### PR DESCRIPTION
## Problem
Some E2E features require support for clients to receive synchronous confirmation of LSP configuration updates, handled by Language Servers. Currently, standard LSP only supports server pull and LSP Notifications models.

## Solution
1. Add new `UpdateConfiguration` LSP RequestType as protocol extension. Implemented support of broadcasting `UpdateConfiguration` request to all registered Servers in LSPRouter: aggregating responses and returning error based on handler responses.
2. Extended LSP feature passed to Server implementation with new `lsp.workspace.onUpdateConfiguration` handler registration point. Every Server implementation may subscribe to this request and implement synchronous configuration handling logic.

### Example of usage in Server implementation

```
import { standalone } from '../runtimes'
import { Server } from '../server-interface'
import { Features } from '../server-interface/server'

export const testServer: Server = (features: Features) => {
    features.lsp.workspace.onUpdateConfiguration(async () => {
        // do something
        // always succeeds
    })

    // dispose callback
    return () => {}
}

export const testServer2: Server = (features: Features) => {
    features.lsp.workspace.onUpdateConfiguration(async () => {
        // always fails
        return Promise.reject(new Error('TestError'))
    })

    // dispose callback
    return () => {}
}

standalone({
    version: '0.1.2',
    servers: [testServer, testServer2],
    name: 'Test Server',
})

```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
