### PR TITLE
feat(types): types for device code support

### DIFF
--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -211,7 +211,7 @@ Complete Chat parameter and result interfaces can be found in [chat.ts](src/prot
 The Identity Management feature is designed to centralize the management of authentication and identity-related functionality. The APIs consist of:
 
 - Listing and managing user profiles and SSO sessions
-- Obtaining valid SSO access tokens, handling the PKCE login flow as needed
+- Obtaining valid SSO access tokens, handling the PKCE or Device Code login flows as needed
 - Controlling the lifetime and notifications for active SSO tokens
 - Invalidating cached SSO tokens
 
@@ -227,6 +227,35 @@ The Identity Management feature is designed to centralize the management of auth
 | SSO token changed                    | `aws/identity/ssoTokenChanged`          | `SsoTokenChangedParams`          | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) | n/a                              |
 
 Complete Identity Management parameter and result interfaces can be found in [identity-management.ts](src/protocol/identity-management.ts)
+
+#### Client Capability
+
+Requires the client to implement support for receiving the following requests:
+  - `window/showDocument`
+    ```
+    client.onRequest<ShowDocumentResult, Error>(
+        ShowDocumentRequest.method,
+        async (params: ShowDocumentParams) => { ... }
+    )
+    ```
+  - `window/showMessageRequest`
+    ```
+    client.onRequest<MessageActionItem | null, Error>(
+        ShowMessageRequest.method,
+        async (params: ShowMessageRequestParams) => { ... }
+    )
+    ```
+  - `onProgress`
+    ```
+    client.onProgress(
+        GetSsoTokenProgressType, 
+        GetSsoTokenProgressToken,
+        async (partialResult: GetSsoTokenProgress) => { 
+            // partialResult is likely encrypted
+            ...
+        }
+    )
+    ```
 
 ### Notification
 

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -1,5 +1,6 @@
 import {
     LSPErrorCodes,
+    ProgressType,
     ProtocolNotificationType,
     ProtocolRequestType,
     ResponseError,
@@ -31,6 +32,7 @@ export const AwsErrorCodes = {
     E_SSO_TOKEN_SOURCE_NOT_SUPPORTED: 'E_SSO_TOKEN_SOURCE_NOT_SUPPORTED',
     E_TIMEOUT: 'E_TIMEOUT',
     E_UNKNOWN: 'E_UNKNOWN',
+    E_CANCELLED: 'E_CANCELLED',
 } as const
 
 export interface AwsResponseErrorData {
@@ -151,12 +153,43 @@ export interface IamIdentityCenterSsoTokenSource {
     profileName: string
 }
 
+export type InProgress = 'InProgress'
+export type Complete = 'Complete'
+
+export type GetSsoTokenProgressState = InProgress | Complete
+
+export const GetSsoTokenProgressState = {
+    InProgress: 'InProgress',
+    Complete: 'Complete',
+} as const
+
+export interface GetSsoTokenProgress {
+    message?: string
+    state: GetSsoTokenProgressState
+}
+
+export const GetSsoTokenProgressType = new ProgressType<GetSsoTokenProgress>()
+
+// Use this to identify the sendProgress/onProgress call from the identity server.
+// It indicates that an SSO login is currently in progress.
+export const GetSsoTokenProgressToken = 'aws/identity/getSsoToken/progressToken'
+
+export type DeviceCodeAuthorizationFlowKind = 'DeviceCode'
+export type PkceAuthorizationFlowKind = 'Pkce'
+export type AuthorizationFlowKind = DeviceCodeAuthorizationFlowKind | PkceAuthorizationFlowKind
+export const AuthorizationFlowKind = {
+    DeviceCode: 'DeviceCode',
+    Pkce: 'Pkce',
+} as const
+
 export interface GetSsoTokenOptions {
     loginOnInvalidToken?: boolean
+    authorizationFlow?: AuthorizationFlowKind // Unused if loginOnInvalidToken is false
 }
 
 export const getSsoTokenOptionsDefaults = {
     loginOnInvalidToken: true,
+    authorizationFlow: AuthorizationFlowKind.Pkce,
 } satisfies GetSsoTokenOptions
 
 export interface GetSsoTokenParams {


### PR DESCRIPTION
This PR implements the required types to add device code auth support to the Identity Server. Currently, only PKCE auth flow is supported.

- E_CANCELLED error to indicate the auth flow was cancelled
- `GetSsoTokenProgress` and related types, to indicate to the client whether an authentication is in progress
- `AuthorizationFlowKind` and related types, to indicate what auth flow to use when requesting an SSO token

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
