### PR TITLE
Update protocol for regions use cases

### DIFF
--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -32,6 +32,9 @@ import {
     EncryptedChatParams,
     EncryptedQuickActionParams,
     QuickActionResult,
+    OPEN_TAB_REQUEST_METHOD,
+    OpenTabParams,
+    OpenTabResult,
 } from './lsp'
 
 export const chatRequestType = new AutoParameterStructuresProtocolRequestType<
@@ -74,4 +77,7 @@ export const sourceLinkClickNotificationType = new ProtocolNotificationType<Sour
 )
 export const followUpClickNotificationType = new ProtocolNotificationType<FollowUpClickParams, void>(
     FOLLOW_UP_CLICK_NOTIFICATION_METHOD
+)
+export const openTabRequestType = new ProtocolRequestType<OpenTabParams, OpenTabResult, never, void, void>(
+    OPEN_TAB_REQUEST_METHOD
 )

--- a/runtimes/runtimes/auth/auth.test.ts
+++ b/runtimes/runtimes/auth/auth.test.ts
@@ -357,6 +357,24 @@ describe('Auth', () => {
 
             assert.deepEqual(credentialsProvider.getConnectionType(), 'identityCenter')
         })
+
+        it('getConnectionType return none', async () => {
+            const CONNECTION_METADATA = {
+                sso: {},
+            }
+
+            const updateRequest: UpdateCredentialsParams = {
+                data: bearerCredentials,
+                metadata: CONNECTION_METADATA,
+                encrypted: false,
+            }
+            const auth = new Auth(serverConnection)
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
+
+            await clientConnection.sendRequest(credentialsProtocolMethodNames.bearerCredentialsUpdate, updateRequest)
+
+            assert.deepEqual(credentialsProvider.getConnectionType(), 'none')
+        })
     })
 
     describe('Encrypted credentials', () => {

--- a/runtimes/runtimes/auth/auth.test.ts
+++ b/runtimes/runtimes/auth/auth.test.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'node:crypto'
 import * as jose from 'jose'
 import { Duplex } from 'stream'
 import { Connection, createConnection } from 'vscode-languageserver/node'
-import { Auth } from './auth'
+import { Auth, BUILDER_ID_START_URL } from './auth'
 import { ParameterStructures, UpdateCredentialsParams } from '../../protocol'
 import { IamCredentials, BearerCredentials, CredentialsType, CredentialsProvider } from '../../server-interface'
 
@@ -64,6 +64,9 @@ const serverLspConnectionMock = <Connection>{
         },
         error: (str: string) => {
             console.log(str)
+        },
+        warn: (str: string) => {
+            console.warn(str)
         },
     },
 }
@@ -150,7 +153,29 @@ describe('Auth', () => {
         assert.deepEqual(credentialsProvider.getCredentials('bearer'), bearerCredentials)
     })
 
-    it('Updates connection metadata on receiving Set Bearer credentials request', async () => {
+    it('Updates connection metadata on receiving Set Bearer credentials request with metadata', async () => {
+        const CONNECTION_METADATA = {
+            sso: {
+                startUrl: 'testStartUrl',
+            },
+        }
+
+        const updateRequest: UpdateCredentialsParams = {
+            data: bearerCredentials,
+            metadata: CONNECTION_METADATA,
+            encrypted: false,
+        }
+        const auth = new Auth(serverConnection)
+        const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
+
+        assert(!credentialsProvider.getConnectionMetadata())
+
+        await clientConnection.sendRequest(credentialsProtocolMethodNames.bearerCredentialsUpdate, updateRequest)
+
+        assert.deepEqual(credentialsProvider.getConnectionMetadata(), CONNECTION_METADATA)
+    })
+
+    it('Requests connection metadata on receiving Set Bearer credentials request without metadata', async () => {
         const CONNECTION_METADATA = {
             sso: {
                 startUrl: 'testStartUrl',
@@ -291,6 +316,46 @@ describe('Auth', () => {
                 () => credentialsProvider.getCredentials('unsupported_type' as CredentialsType),
                 /Unsupported credentials type/
             )
+        })
+
+        it('getConnectionType return builderId', async () => {
+            const CONNECTION_METADATA = {
+                sso: {
+                    startUrl: BUILDER_ID_START_URL,
+                },
+            }
+
+            const updateRequest: UpdateCredentialsParams = {
+                data: bearerCredentials,
+                metadata: CONNECTION_METADATA,
+                encrypted: false,
+            }
+            const auth = new Auth(serverConnection)
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
+
+            await clientConnection.sendRequest(credentialsProtocolMethodNames.bearerCredentialsUpdate, updateRequest)
+
+            assert.deepEqual(credentialsProvider.getConnectionType(), 'builderId')
+        })
+
+        it('getConnectionType return identityCenter', async () => {
+            const CONNECTION_METADATA = {
+                sso: {
+                    startUrl: 'https://idc.awsapps.com/start',
+                },
+            }
+
+            const updateRequest: UpdateCredentialsParams = {
+                data: bearerCredentials,
+                metadata: CONNECTION_METADATA,
+                encrypted: false,
+            }
+            const auth = new Auth(serverConnection)
+            const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()
+
+            await clientConnection.sendRequest(credentialsProtocolMethodNames.bearerCredentialsUpdate, updateRequest)
+
+            assert.deepEqual(credentialsProvider.getConnectionType(), 'identityCenter')
         })
     })
 

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -33,6 +33,7 @@ import {
     ShowMessageNotification,
     ShowMessageRequest,
     ShowDocumentRequest,
+    openTabRequestType,
 } from '../protocol'
 import { createConnection } from 'vscode-languageserver/browser'
 import {
@@ -132,6 +133,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
         onInfoLinkClick: handler => lspConnection.onNotification(infoLinkClickNotificationType.method, handler),
         onSourceLinkClick: handler => lspConnection.onNotification(sourceLinkClickNotificationType.method, handler),
         onFollowUpClicked: handler => lspConnection.onNotification(followUpClickNotificationType.method, handler),
+        openTab: params => lspConnection.sendRequest(openTabRequestType.method, params),
     }
 
     const identityManagement: IdentityManagement = {

--- a/runtimes/runtimes/chat/baseChat.ts
+++ b/runtimes/runtimes/chat/baseChat.ts
@@ -29,6 +29,9 @@ import {
     followUpClickNotificationType,
     endChatRequestType,
     quickActionRequestType,
+    OpenTabParams,
+    OpenTabResult,
+    openTabRequestType,
 } from '../../protocol'
 import { Chat } from '../../server-interface'
 
@@ -85,5 +88,9 @@ export class BaseChat implements Chat {
 
     public onFollowUpClicked(handler: NotificationHandler<FollowUpClickParams>) {
         this.connection.onNotification(followUpClickNotificationType.method, handler)
+    }
+
+    public openTab(params: OpenTabParams): Promise<OpenTabResult> {
+        return this.connection.sendRequest(openTabRequestType.method, params)
     }
 }

--- a/runtimes/server-interface/auth.ts
+++ b/runtimes/server-interface/auth.ts
@@ -5,9 +5,11 @@ export { IamCredentials, BearerCredentials, ConnectionMetadata }
 
 export type CredentialsType = 'iam' | 'bearer'
 export type Credentials = IamCredentials | BearerCredentials
+export type SsoConnectionType = 'builderId' | 'identityCenter' | 'none'
 
 export interface CredentialsProvider {
     hasCredentials: (type: CredentialsType) => boolean
     getCredentials: (type: CredentialsType) => Credentials | undefined
     getConnectionMetadata: () => ConnectionMetadata | undefined
+    getConnectionType: () => SsoConnectionType
 }

--- a/runtimes/server-interface/chat.ts
+++ b/runtimes/server-interface/chat.ts
@@ -16,6 +16,8 @@ import {
     TabChangeParams,
     TabAddParams,
     TabRemoveParams,
+    OpenTabParams,
+    OpenTabResult,
 } from '../protocol'
 
 /**
@@ -26,6 +28,7 @@ export type Chat = {
     onChatPrompt: (handler: RequestHandler<ChatParams, ChatResult | undefined | null, ChatResult>) => void
     onEndChat: (handler: RequestHandler<EndChatParams, EndChatResult, void>) => void
     onQuickAction: (handler: RequestHandler<QuickActionParams, QuickActionResult, void>) => void
+    openTab: (params: OpenTabParams) => Promise<OpenTabResult>
     // Notifications
     onSendFeedback: (handler: NotificationHandler<FeedbackParams>) => void
     onReady: (handler: NotificationHandler<void>) => void

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -19,6 +19,7 @@ export interface ConnectionMetadata {
 export interface UpdateCredentialsParams {
     // Plaintext Credentials (for browser based environments) or encrypted JWT token
     data: IamCredentials | BearerCredentials | string
+    metadata?: ConnectionMetadata
     // If the payload is encrypted
     // Defaults to false if undefined or null
     encrypted?: boolean

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -14,6 +14,7 @@ export const LINK_CLICK_NOTIFICATION_METHOD = 'aws/chat/linkClick'
 export const INFO_LINK_CLICK_NOTIFICATION_METHOD = 'aws/chat/infoLinkClick'
 export const SOURCE_LINK_CLICK_NOTIFICATION_METHOD = 'aws/chat/sourceLinkClick'
 export const FOLLOW_UP_CLICK_NOTIFICATION_METHOD = 'aws/chat/followUpClick'
+export const OPEN_TAB_REQUEST_METHOD = 'aws/chat/openTab'
 
 export interface ChatItemAction {
     pillText: string
@@ -191,3 +192,10 @@ export interface FollowUpClickParams {
     messageId: string
     followUp: ChatItemAction
 }
+
+/*
+    Defines parameters for opening a tab.
+    Opens existing tab if `tabId` is provided, otherwise creates a new tab and opens it.
+*/
+export interface OpenTabParams extends Partial<TabEventParams> {}
+export interface OpenTabResult extends TabEventParams {}


### PR DESCRIPTION
## Problem

There is no way to request chat UI to open a new tab from server. This will be needed to restore chat state after profile switch.

Given connection type becomes required now for region detection, we should move it to `aws/credentails/token/update` request - it simplifies the flow and less error-prone.

## Solution

- extended chat protocol with `'aws/chat/openTab'`
- extended `UpdateCredentialsParams` in `'aws/credentials/token/update'` with `startUrl`
- moved the logic to define connection type to runtimes

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
