### PR TITLE
fix: fix the flaky test timeout error

### DIFF
--- a/runtimes/runtimes/util/standalone/proxyUtil.test.ts
+++ b/runtimes/runtimes/util/standalone/proxyUtil.test.ts
@@ -28,7 +28,8 @@ export const generateCert = (validityDays = 365) => {
     }
 }
 
-describe('ProxyConfigManager', () => {
+describe('ProxyConfigManager', function () {
+    this.timeout(0)
     let proxyManager: ProxyConfigManager
     let originalEnv: NodeJS.ProcessEnv
     let readMacosCertificatesStub: sinon.SinonStub


### PR DESCRIPTION
## Problem
The test defined [here](https://github.com/aws/language-server-runtimes/blob/a82a70810592909e1d82c74406124de847f1af0b/runtimes/runtimes/util/standalone/proxyUtil.test.ts#L198) for testing certificate fails sometime with timeout exceed error. The test case uses generateCert function, which uses 'node-forge' library to generate certificates which can be resource intensive at times. On my local as well, I saw the test case running in 1468ms for one of the instance. There are other test cases in the file which are using generateCert function, so there is a possibility of getting the same error for those test cases as well. 

## Solution
Mocha has a default timeout of 2000ms per test case. Mocha provides us the capability to override this timeout value or even disable timeout when we provide 0 value to the timeout function. https://mochajs.org/#test-level 

I have disabled the timeout for the proxyUtil.test.ts and it seems to work perfectly now. Tested by adding resource intensive operations taking more than 2s on my local. 


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
