### PR TITLE
chore: adding keepAlive options to AWS SDK client

### DIFF
--- a/runtimes/runtimes/util/standalone/proxyUtil.ts
+++ b/runtimes/runtimes/util/standalone/proxyUtil.ts
@@ -145,6 +145,9 @@ export class ProxyConfigManager {
         const agentOptions = {
             ca: certs,
             rejectUnauthorized: true, // Always validate certificates
+            keepAlive: true,
+            keepAliveMsecs: 30000, // Keep alive for 30 seconds
+            maxSockets: 10, // Maximum number of sockets to allow per host
         }
 
         const proxyUrl = this.getProxyUrl()


### PR DESCRIPTION
## Problem
Adding http keepalive agent in AWS SDK Client to help in reducing the latency of generateCompletions API.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
