### PR TITLE
fix(runtimes): maintain nodejs built-in certificates for SDK proxy configuration

### DIFF
--- a/runtimes/runtimes/util/standalone/proxyUtil.ts
+++ b/runtimes/runtimes/util/standalone/proxyUtil.ts
@@ -4,6 +4,7 @@
  */
 
 import { readFileSync } from 'node:fs'
+import * as tls from 'node:tls'
 import { Agent as HttpsAgent } from 'node:https'
 import { X509Certificate } from 'node:crypto'
 import { ConfigurationOptions } from 'aws-sdk'
@@ -106,7 +107,8 @@ export class ProxyConfigManager {
      * @returns {string[]} Array of certificate strings in PEM format
      */
     getCertificates(): string[] {
-        const certificates: string[] = []
+        // Preserve NodeJS default certificates
+        const certificates = [...tls.rootCertificates]
 
         try {
             const certs = this.readSystemCertificates()


### PR DESCRIPTION
## Problem
When reading certificates from OS fails, SDK client proxy agent is configured with no SSL certificates at all, which cause requests to fail.

## Solution
Keep NodeJS's built-in certificates in HTTP agent configuration, as they are good to work with AWS SDK by default.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
