### PR TITLE
feat: improvements for "openTab" request flow

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -3,6 +3,8 @@ import {
     ChatOptions,
     CodeSelectionType,
     ReferenceTrackerInformation,
+    OPEN_TAB_REQUEST_METHOD,
+    OpenTabResult,
 } from '@aws/language-server-runtimes-types'
 export { InsertToCursorPositionParams } from '@aws/language-server-runtimes-types'
 
@@ -118,6 +120,21 @@ export interface CopyCodeToClipboardMessage {
     params: CopyCodeToClipboardParams
 }
 
+export type UiMessageResultCommand = typeof OPEN_TAB_REQUEST_METHOD
+export type UiMessageResult = OpenTabResult
+export interface UiResultMessage {
+    command: UiMessageResultCommand
+    params: UiMessageResultParams
+}
+export type UiMessageResultParams =
+    | {
+          success: true
+          result: UiMessageResult
+      }
+    | {
+          success: false
+          error: ErrorResult
+      }
 export interface ErrorResult {
     message: string
     type: 'InvalidRequest' | 'InternalError' | 'UnknownError' | string

--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -117,3 +117,8 @@ export interface CopyCodeToClipboardMessage {
     command: typeof COPY_TO_CLIPBOARD
     params: CopyCodeToClipboardParams
 }
+
+export interface ErrorResult {
+    message: string
+    type: 'InvalidRequest' | 'InternalError' | 'UnknownError' | string
+}

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -195,7 +195,12 @@ export interface FollowUpClickParams {
 
 /*
     Defines parameters for opening a tab.
-    Opens existing tab if `tabId` is provided, otherwise creates a new tab and opens it.
+    Opens existing tab if `tabId` is provided, otherwise creates a new tab
+    with options provided in `options` parameter and opens it.
 */
-export interface OpenTabParams extends Partial<TabEventParams> {}
+export interface OpenTabParams extends Partial<TabEventParams> {
+    options?: {
+        needWelcomeMessages?: boolean
+    }
+}
 export interface OpenTabResult extends TabEventParams {}

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -195,12 +195,7 @@ export interface FollowUpClickParams {
 
 /*
     Defines parameters for opening a tab.
-    Opens existing tab if `tabId` is provided, otherwise creates a new tab
-    with options provided in `options` parameter and opens it.
+    Opens existing tab if `tabId` is provided, otherwise creates a new tab and opens it.
 */
-export interface OpenTabParams extends Partial<TabEventParams> {
-    options?: {
-        needWelcomeMessages?: boolean
-    }
-}
+export interface OpenTabParams extends Partial<TabEventParams> {}
 export interface OpenTabResult extends TabEventParams {}


### PR DESCRIPTION


## Problem

- There is no mechanism to return error from `chat-client` to the calling party

## Solution

Extended the protocol to support errors as part of  response over `postMessage`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
