### PR TITLE
fix(runtimes): add doUpdateConfiguration to TestFeatures

### DIFF
--- a/runtimes/testing/TestFeatures.ts
+++ b/runtimes/testing/TestFeatures.ts
@@ -25,6 +25,7 @@ import {
     SemanticTokensParams,
     TextDocument,
     SignatureHelpParams,
+    UpdateConfigurationParams,
 } from '../protocol'
 import { IdentityManagement } from '../server-interface/identity-management'
 import { Service } from 'aws-sdk'
@@ -165,6 +166,10 @@ export class TestFeatures {
 
     async doExecuteCommand(params: ExecuteCommandParams, token: CancellationToken) {
         return this.lsp.onExecuteCommand.args[0]?.[0](params, token)
+    }
+
+    async doUpdateConfiguration(params: UpdateConfigurationParams, token: CancellationToken) {
+        return this.lsp.workspace.onUpdateConfiguration.args[0]?.[0](params, token)
     }
 
     async simulateTyping(uri: string, text: string) {


### PR DESCRIPTION
## Problem
doUpdateConfiguration helper is needed for adding tests for new UpdateConfiguration API in language servers (e.g. https://github.com/aws/language-servers/pull/822)

## Solution
Added new helper to TestFeatures

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
