### PR TITLE
feat(runtimes): extend awsClientCapabilities generically to signal server-specific capabilities

### DIFF
--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -107,6 +107,7 @@ export interface AWSInitializationOptions {
      * The client signals AWS capabilities it supports.
      */
     awsClientCapabilities?: {
+        [key: string]: any
         window?: {
             notifications?: boolean
         }


### PR DESCRIPTION
## Problem

For language server `aws-lsp-codewhisperer` in particular, we need a way for clients to be able to signal that they support Q developer profiles at initialization.

## Solution

Extend the `awsClientCapabilities` entry of `AWSInitializationOptions` with `[key: string]: any`. This enables clients to signal support for server-specific capabilities in a generic way.

Testing: build and installed the change into a local copy of the language servers repository to verify that the server can now parse for any client capabilities.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
