### PR TITLE
feat(runtimes): cache and expose initializeParams as a feature

### DIFF
--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -68,6 +68,7 @@ import { WebBase64Encoding } from './encoding'
 import { LoggingServer } from './lsp/router/loggingServer'
 import { Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
+import { getClientInitializeParamsHandlerFactory } from './util/lspCacheUtil'
 
 declare const self: WindowOrWorkerGlobalScope
 
@@ -174,6 +175,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
         const lsp: Lsp = {
             addInitializer: lspServer.setInitializeHandler,
             onInitialized: lspServer.setInitializedHandler,
+            getClientInitializeParams: getClientInitializeParamsHandlerFactory(lspRouter),
             onCompletion: handler => lspConnection.onCompletion(handler),
             onInlineCompletion: handler => lspConnection.onRequest(inlineCompletionRequestType, handler),
             didChangeConfiguration: lspServer.setDidChangeConfigurationHandler,

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -71,6 +71,7 @@ import { LoggingServer } from './lsp/router/loggingServer'
 import { Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 import { getTelemetryLspServer } from './util/telemetryLspServer'
+import { getClientInitializeParamsHandlerFactory } from './util/lspCacheUtil'
 
 // Honor shared aws config file
 if (checkAWSConfigFile()) {
@@ -300,6 +301,7 @@ export const standalone = (props: RuntimeProps) => {
             const lsp: Lsp = {
                 addInitializer: lspServer.setInitializeHandler,
                 onInitialized: lspServer.setInitializedHandler,
+                getClientInitializeParams: getClientInitializeParamsHandlerFactory(lspRouter),
                 onCompletion: handler => lspConnection.onCompletion(handler),
                 onInlineCompletion: handler => lspConnection.onRequest(inlineCompletionRequestType, handler),
                 didChangeConfiguration: lspServer.setDidChangeConfigurationHandler,

--- a/runtimes/runtimes/util/lspCacheUtil.test.ts
+++ b/runtimes/runtimes/util/lspCacheUtil.test.ts
@@ -1,0 +1,22 @@
+import { StubbedInstance, stubInterface } from 'ts-sinon'
+import assert from 'assert'
+import { LspRouter } from '../lsp/router/lspRouter'
+import { InitializeParams } from '../../protocol'
+import { getClientInitializeParamsHandlerFactory } from './lspCacheUtil'
+
+describe('getClientInitializeParamsFactory', () => {
+    let lspRouterStub: StubbedInstance<LspRouter>
+
+    beforeEach(() => {
+        lspRouterStub = stubInterface<LspRouter>()
+    })
+
+    it('returns the client params of the passed lsp router', () => {
+        const expected: InitializeParams = { processId: 0, rootUri: 'some-root-uri', capabilities: {} }
+        lspRouterStub.clientInitializeParams = expected
+
+        const handler = getClientInitializeParamsHandlerFactory(lspRouterStub)
+
+        assert.deepStrictEqual(handler(), expected)
+    })
+})

--- a/runtimes/runtimes/util/lspCacheUtil.ts
+++ b/runtimes/runtimes/util/lspCacheUtil.ts
@@ -1,0 +1,6 @@
+import { InitializeParams } from '../../protocol'
+import { LspRouter } from '../lsp/router/lspRouter'
+
+export const getClientInitializeParamsHandlerFactory = (lspRouter: LspRouter): (() => InitializeParams | undefined) => {
+    return () => lspRouter.clientInitializeParams
+}

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -103,6 +103,7 @@ export type Lsp = {
      */
     addInitializer: (handler: RequestHandler<InitializeParams, PartialInitializeResult, InitializeError>) => void
     onInitialized: (handler: NotificationHandler<InitializedParams>) => void
+    getClientInitializeParams: () => InitializeParams | undefined
     onInlineCompletion: (
         handler: RequestHandler<
             InlineCompletionParams,


### PR DESCRIPTION
## Problem

It is becoming more frequent that the `initializeParams` sent by the client have to be referenced in different parts of a server _after_ initialization. We need a more scalable way to retrieve these parameters to avoid duplication or having to couple components with the initialization code.

## Solution

The `LspRouter` already caches the client `initializeParams`, so to make these available we can extend the `lsp` feature with a method/property `getClientInitializeParams`, which retrieves the cached client params in the `LspRouter`. Example usage:

```ts
// somewhere in language-servers/servers/aws-lsp-*
const params: InitializeParams = lsp.getClientInitializeParams()
```

Testing: Created a reusable handler for this purpose with unit test. Also packed and installed in a local copy of `language-servers` to verify this feature is now available.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
