### PR TITLE
chore: notify servers of bearer token signout so that servers can update/reset local state

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -422,6 +422,8 @@ export const standalone = (props: RuntimeProps) => {
             })
         })
 
+        auth.setLspRouter(lspRouter)
+
         // Free up any resources or threads used by Servers
         lspConnection.onExit(() => {
             disposables.forEach(d => d())


### PR DESCRIPTION
## Problem
We need to notify servers in case of bearer token sign out so that they can update or reset the local state, which means resetting the developer profile. It's needed when profile has changed, but server has not received updated profile yet and calls are made to the wrong region (race condition)

## Solution
Introduced a change so that Auth utility has access to the router class in order to be able to send messages/notifications to the servers. Without doing so, we only have reference to the lspConnection only, but not the servers.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
