### PR TITLE
feat(types): add imports to InlineCompletionItemWithReferences type

### DIFF
--- a/types/inlineCompletionWithReferences.ts
+++ b/types/inlineCompletionWithReferences.ts
@@ -1,7 +1,7 @@
 import { InlineCompletionItem } from 'vscode-languageserver-types'
 
 /**
- * Extend InlineCompletionItem to include optional references.
+ * Extend InlineCompletionItem to include optional references and imports.
  */
 export type InlineCompletionItemWithReferences = InlineCompletionItem & {
     /**
@@ -17,6 +17,10 @@ export type InlineCompletionItemWithReferences = InlineCompletionItem & {
             startCharacter?: number
             endCharacter?: number
         }
+    }[]
+
+    mostRelevantMissingImports?: {
+        statement?: string
     }[]
 }
 /**


### PR DESCRIPTION
## Problem
We need to support import adder feature for inline completions through language server
## Solution
add import to `InlineCompletionItemWithReferences` interface

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
