### PR TITLE
feat: add license check workflow

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -3,7 +3,6 @@ name: License Check
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:
   license-check:
@@ -24,29 +23,8 @@ jobs:
     - name: Run license check
       run: |
         #!/bin/bash
-
         set -euo pipefail
 
-        EXCLUDED_PACKAGES=("@amzn/eevee-service" "@aws/lsp-codewhisperer" "@aws/lsp-core" "@c9/eevee-scanner" "@amzn/dexp-runtime-server-build-configuration")
         EXCLUDED_LICENSES="MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD,Python-2.0,BlueOak-1.0.0"
 
-        process_packages() {
-          local output="$1"
-          IFS=$'\n'
-
-          for line in $output; do
-            if [[ "$line" =~ ^├─\ (.+)@ ]]; then
-              package_name="${BASH_REMATCH[1]}"
-
-              if [[ ! "${EXCLUDED_PACKAGES[*]}" =~ "${package_name}" ]]; then
-                echo "License for package '$package_name' is either not pre-approved or package is not in the excluded package list."
-                exit 1
-              fi
-            fi
-          done
-
-          IFS=$' \t\n'
-        }
-
-        LICENSE_CHECK_RESULT=$(license-checker --production --exclude $EXCLUDED_LICENSES)
-        process_packages "$LICENSE_CHECK_RESULT"
+        license-checker --production --exclude "$EXCLUDED_LICENSES" --excludePackages "*"


### PR DESCRIPTION
## Problem
* Adding a license check github workflow to run on every PR. 

## Solution

* Introducing a github workflow that will check if packages belong to a list of pre approved licenses. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
