### PR TITLE
feat: add chat message content to support context transparency

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -83,10 +83,16 @@ export interface EncryptedChatParams extends PartialResultParams {
     message: string
 }
 
+export interface FileDetails {
+    description?: string
+    lineRanges?: Array<{ first: number; second: number }>
+}
+
 export interface FileList {
     rootFolderTitle?: string
     filePaths?: string[]
     deletedFiles?: string[]
+    details?: Record<string, FileDetails>
 }
 
 export interface ChatMessage {
@@ -104,6 +110,7 @@ export interface ChatMessage {
     }
     codeReference?: ReferenceTrackerInformation[]
     fileList?: FileList
+    contextList?: FileList
 }
 // Response for chat prompt request can be empty,
 // if server chooses to handle the request and push updates asynchronously.


### PR DESCRIPTION
## Problem

We want to implement context transparency feature which allows for a header to be accepted. This header can be used to provide context of the files used to the user. For this purpose we add a new ChatItemContent type which accepts few fields. 

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
