### PR TITLE
fix: add requestId to InlineChat response

### DIFF
--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -41,6 +41,7 @@ import {
     FileClickParams,
     INLINE_CHAT_REQUEST_METHOD,
     InlineChatParams,
+    InlineChatResult,
 } from './lsp'
 
 export const chatRequestType = new AutoParameterStructuresProtocolRequestType<
@@ -52,8 +53,8 @@ export const chatRequestType = new AutoParameterStructuresProtocolRequestType<
 >(CHAT_REQUEST_METHOD)
 export const inlineChatRequestType = new AutoParameterStructuresProtocolRequestType<
     InlineChatParams | EncryptedChatParams,
-    ChatResult | string,
-    ChatResult | string,
+    InlineChatResult | string,
+    InlineChatResult | string,
     void,
     void
 >(INLINE_CHAT_REQUEST_METHOD)

--- a/runtimes/runtimes/chat/baseChat.ts
+++ b/runtimes/runtimes/chat/baseChat.ts
@@ -38,6 +38,7 @@ import {
     fileClickNotificationType,
     inlineChatRequestType,
     InlineChatParams,
+    InlineChatResult,
 } from '../../protocol'
 import { Chat } from '../../server-interface'
 
@@ -48,7 +49,9 @@ export class BaseChat implements Chat {
         this.connection.onRequest(chatRequestType.method, handler)
     }
 
-    public onInlineChatPrompt(handler: RequestHandler<InlineChatParams, ChatResult | null | undefined, ChatResult>) {
+    public onInlineChatPrompt(
+        handler: RequestHandler<InlineChatParams, InlineChatResult | null | undefined, InlineChatResult>
+    ) {
         this.connection.onRequest(inlineChatRequestType.method, handler)
     }
 

--- a/runtimes/runtimes/chat/encryptedChat.ts
+++ b/runtimes/runtimes/chat/encryptedChat.ts
@@ -15,6 +15,7 @@ import {
     LSPErrorCodes,
     InlineChatParams,
     inlineChatRequestType,
+    InlineChatResult,
 } from '../../protocol'
 import { CredentialsEncoding, encryptObjectWithKey, isMessageJWEEncrypted } from '../auth/standalone/encryption'
 import { BaseChat } from './baseChat'
@@ -51,8 +52,8 @@ export class EncryptedChat extends BaseChat {
         this.registerEncryptedRequestHandler<
             EncryptedChatParams,
             InlineChatParams,
-            ChatResult | null | undefined,
-            ChatResult
+            InlineChatResult | null | undefined,
+            InlineChatResult
         >(inlineChatRequestType, handler)
     }
 

--- a/runtimes/server-interface/chat.ts
+++ b/runtimes/server-interface/chat.ts
@@ -21,6 +21,7 @@ import {
     ChatUpdateParams,
     FileClickParams,
     InlineChatParams,
+    InlineChatResult,
 } from '../protocol'
 
 /**
@@ -29,7 +30,9 @@ import {
 export type Chat = {
     // Requests
     onChatPrompt: (handler: RequestHandler<ChatParams, ChatResult | undefined | null, ChatResult>) => void
-    onInlineChatPrompt: (handler: RequestHandler<InlineChatParams, ChatResult | undefined | null, ChatResult>) => void
+    onInlineChatPrompt: (
+        handler: RequestHandler<InlineChatParams, InlineChatResult | undefined | null, InlineChatResult>
+    ) => void
     onEndChat: (handler: RequestHandler<EndChatParams, EndChatResult, void>) => void
     onQuickAction: (handler: RequestHandler<QuickActionParams, QuickActionResult, void>) => void
     openTab: (params: OpenTabParams) => Promise<OpenTabResult>

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -115,6 +115,9 @@ export interface ChatMessage {
 // Response for chat prompt request can be empty,
 // if server chooses to handle the request and push updates asynchronously.
 export interface ChatResult extends ChatMessage {}
+export interface InlineChatResult extends ChatMessage {
+    requestId?: string
+}
 
 export type EndChatParams = { tabId: string }
 export type EndChatResult = boolean


### PR DESCRIPTION
The PR adds requestId to the response of inline chat, as it's needed by client for emitting telemetry. Similar to how these parameters are passed from InlineCompletion response.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
