### PR TITLE
fix: support JSON Schema extension keywords and properly infer required fields

### DIFF
--- a/runtimes/runtimes/agent.test.ts
+++ b/runtimes/runtimes/agent.test.ts
@@ -17,6 +17,21 @@ describe('Agent Tools', () => {
             required: ['test'],
         },
     } as const
+
+    const SOME_TOOL_SPEC_WITH_EXTENSIONS = {
+        name: 'test',
+        description: 'test',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                test: {
+                    type: 'string',
+                },
+            },
+            required: ['test'],
+            someExtension: true,
+        },
+    } as const
     const SOME_TOOL_HANDLER = async (_: { test: string }) => true
 
     beforeEach(() => {
@@ -90,5 +105,14 @@ describe('Agent Tools', () => {
         assert.equal(tools[0].name, SOME_TOOL_SPEC.name)
         assert.equal(tools[0].description, SOME_TOOL_SPEC.description)
         assert.equal(tools[0].inputSchema, SOME_TOOL_SPEC.inputSchema)
+    })
+
+    it('should support JSON Schema extension keywords', () => {
+        AGENT.addTool(SOME_TOOL_SPEC_WITH_EXTENSIONS, SOME_TOOL_HANDLER)
+        const tools = AGENT.getTools({ format: 'bedrock' })
+        assert.equal(
+            tools[0].toolSpecification.inputSchema.json['someExtension'],
+            SOME_TOOL_SPEC_WITH_EXTENSIONS.inputSchema.someExtension
+        )
     })
 })

--- a/runtimes/runtimes/agent.ts
+++ b/runtimes/runtimes/agent.ts
@@ -11,7 +11,7 @@ type Tool<T, R> = {
 
 export const newAgent = (): Agent => {
     const tools: Record<string, Tool<any, any>> = {}
-    const ajv = new Ajv()
+    const ajv = new Ajv({ strictSchema: false })
 
     return {
         addTool: <T extends InferSchema<S['inputSchema']>, S extends ToolSpec>(


### PR DESCRIPTION
## Problem

The Bedrock JSON Schema allows any extension keyword to be defined, so we have to support a string indexer field.

When providing mixed required and non-required properties in JSON objects, they were not inferred properly.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
