### PR TITLE
feat: extend tabdata interface to include support for welcome screen

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -24,6 +24,7 @@ export const AUTH_FOLLOW_UP_CLICKED = 'authFollowUpClicked'
 export const GENERIC_COMMAND = 'genericCommand'
 export const CHAT_OPTIONS = 'chatOptions'
 export const DISCLAIMER_ACKNOWLEDGED = 'disclaimerAcknowledged'
+export const WELCOME_COUNTER_UPDATE_MESSAGE = 'welcomeCounterUpdateMessage'
 
 export type UiMessageCommand =
     | typeof SEND_TO_PROMPT
@@ -34,6 +35,7 @@ export type UiMessageCommand =
     | typeof CHAT_OPTIONS
     | typeof COPY_TO_CLIPBOARD
     | typeof DISCLAIMER_ACKNOWLEDGED
+    | typeof WELCOME_COUNTER_UPDATE_MESSAGE
 
 export interface UiMessage {
     command: UiMessageCommand

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -158,18 +158,21 @@ export interface QuickActions {
 }
 
 export interface TabData {
-    title: string
-    placeholderText?: string
-    placeHolderLabel?: string
+    tabHeader?: TabHeader
+    promptInput?: PromptInput
     compactMode?: boolean
     messages: ChatMessage[]
-    tabHeaderDetails?: TabHeaderDetails
 }
 
-export interface TabHeaderDetails {
+export interface TabHeader {
     icon?: IconType
     title?: string
     description?: string
+}
+
+export interface PromptInput {
+    placeHolderText?: string
+    label?: string
 }
 
 /**

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -159,6 +159,7 @@ export interface QuickActions {
 }
 
 export interface TabData {
+    title?: string
     tabHeader?: TabHeader
     promptInput?: PromptInput
     compactMode?: boolean

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -28,6 +28,7 @@ export interface ChatItemAction {
     description?: string
     type?: string
     status?: string
+    id?: string
 }
 
 export interface SourceLink {
@@ -171,7 +172,7 @@ export interface TabHeader {
 }
 
 export interface PromptInput {
-    placeHolderText?: string
+    placeholderText?: string
     label?: string
 }
 

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -27,6 +27,7 @@ export interface ChatItemAction {
     disabled?: boolean
     description?: string
     type?: string
+    status?: string
 }
 
 export interface SourceLink {
@@ -100,6 +101,8 @@ export interface FileList {
 export interface ChatMessage {
     type?: 'answer' | 'prompt' | 'system-prompt' // will default to 'answer'
     body?: string
+    buttons: ChatItemAction[]
+    icon?: IconType
     messageId?: string
     canBeVoted?: boolean // requires messageId to be filled to show vote thumbs
     relatedContent?: {
@@ -155,7 +158,10 @@ export interface QuickActions {
 }
 
 export interface TabData {
+    title: string
     placeholderText?: string
+    placeHolderLabel?: string
+    centerContent?: boolean
     messages: ChatMessage[]
 }
 

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -161,8 +161,15 @@ export interface TabData {
     title: string
     placeholderText?: string
     placeHolderLabel?: string
-    centerContent?: boolean
+    compactMode?: boolean
     messages: ChatMessage[]
+    tabHeaderDetails?: TabHeaderDetails
+}
+
+export interface TabHeaderDetails {
+    icon?: IconType
+    title?: string
+    description?: string
 }
 
 /**


### PR DESCRIPTION
## Problem
We don't have a way to integrate the current welcome screen in Q through flare

## Solution
Extending to protocol so we can integrate the welcome screen UI in flare

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
