### PR TITLE
fix(log): remove logging class names

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -374,7 +374,7 @@ export const standalone = (props: RuntimeProps) => {
                             ...current_config,
                             requestHandler: requestHandler,
                         })
-                        logging.log(`Configured AWS SDK V3 Proxy for ${Ctor.name}`)
+                        logging.log(`Configured AWS SDK V3 Proxy for client.`)
                         return instance
                     } catch (err) {
                         telemetry.emitMetric({
@@ -386,9 +386,7 @@ export const standalone = (props: RuntimeProps) => {
                         })
 
                         // Fallback
-                        logging.log(
-                            `Failed to configure AWS SDK V3 Proxy for client ${Ctor.name}. Starting without proxy.`
-                        )
+                        logging.log(`Failed to configure AWS SDK V3 Proxy for client. Starting without proxy.`)
                         return new Ctor({ ...current_config })
                     }
                 },
@@ -408,7 +406,7 @@ export const standalone = (props: RuntimeProps) => {
                             logging.log(`Using ${isExperimentalProxy ? 'experimental' : 'standard'} proxy util`)
 
                             instance.config.update(configOptions)
-                            logging.log(`Configured AWS SDK V2 Proxy for ${Ctor.name}`)
+                            logging.log(`Configured AWS SDK V2 Proxy for client.`)
                             return instance
                         } catch (err) {
                             telemetry.emitMetric({
@@ -420,9 +418,7 @@ export const standalone = (props: RuntimeProps) => {
                             })
 
                             // Fallback
-                            logging.log(
-                                `Failed to configure AWS SDK V2 Proxy for client ${Ctor.name}. Starting without proxy.`
-                            )
+                            logging.log(`Failed to configure AWS SDK V2 Proxy for client. Starting without proxy.`)
                             return instance
                         }
                     },


### PR DESCRIPTION
## Problem
Since truncated logging from bundling minimization modifies and makes class/function names unrecognizable, we remove class name logging from runtimes, instead and we log directly hardoded class names from language-servers (see https://github.com/aws/language-servers/pull/909)

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
