### PR TITLE
fix: update Dirent interface. 

### DIFF
--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -5,7 +5,7 @@ interface Dirent {
     isFile(): boolean
     isDirectory(): boolean
     name: string
-    path: string
+    parentPath: string
 }
 
 /**

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -4,6 +4,7 @@ import { TextDocument, WorkspaceFolder } from '../protocol'
 interface Dirent {
     isFile(): boolean
     isDirectory(): boolean
+    isSymbolicLink(): boolean
     name: string
     parentPath: string
 }


### PR DESCRIPTION
## Problem
This Dirent interface is difficult to work with for two reasons:
- it uses deprecated and confusing path field ([https://github.com/nodejs/node/issues/51955#issuecomment-1977131319 ](https://github.com/nodejs/node/issues/51955#issuecomment-1977131319)). To summarize, path is the same as parentPath on node 20, but not node 18. this is not clear in the name. 
- does not provide a way to check for links, which are returned by fs.readdir.

## Solution
- update interface to avoid deprecated field, and expose the predicate for checking links. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
