### PR TITLE
feat(types): add context to ChatParams

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -77,6 +77,11 @@ export interface ChatParams extends PartialResultParams {
     prompt: ChatPrompt
     cursorState?: CursorState[]
     textDocument?: TextDocumentIdentifier
+    /**
+     * Context of the current chat message to be handled by the servers.
+     * Context can be added through QuickActionCommand triggered by `@`.
+     */
+    context?: QuickActionCommand[]
 }
 
 export interface InlineChatParams extends PartialResultParams {


### PR DESCRIPTION
## Problem

In order to implement `@workspace` context in chat, the server needs to understand context sent from Mynah UI. 


Following the example in [vscode toolkits](https://github.com/aws/aws-toolkit-vscode/blob/a96a73e7ae55d7149684141b066f1b8b8413322f/packages/core/src/codewhispererChat/controllers/chat/model.ts#L107).

## Solution

The context is added to `ChatParams`. I am not sure why context can be a string. Just added to be compatible with the Toolkits interface.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
