### PR TITLE
revert: "feat: extend tabdata interface to include support for welcome…

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -24,7 +24,6 @@ export const AUTH_FOLLOW_UP_CLICKED = 'authFollowUpClicked'
 export const GENERIC_COMMAND = 'genericCommand'
 export const CHAT_OPTIONS = 'chatOptions'
 export const DISCLAIMER_ACKNOWLEDGED = 'disclaimerAcknowledged'
-export const WELCOME_COUNTER_UPDATE_MESSAGE = 'welcomeCounterUpdateMessage'
 
 export type UiMessageCommand =
     | typeof SEND_TO_PROMPT
@@ -35,7 +34,6 @@ export type UiMessageCommand =
     | typeof CHAT_OPTIONS
     | typeof COPY_TO_CLIPBOARD
     | typeof DISCLAIMER_ACKNOWLEDGED
-    | typeof WELCOME_COUNTER_UPDATE_MESSAGE
 
 export interface UiMessage {
     command: UiMessageCommand

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -30,8 +30,6 @@ export interface ChatItemAction {
     disabled?: boolean
     description?: string
     type?: string
-    status?: string
-    id?: string
 }
 
 export interface SourceLink {
@@ -109,8 +107,6 @@ export interface FileList {
 export interface ChatMessage {
     type?: 'answer' | 'prompt' | 'system-prompt' // will default to 'answer'
     body?: string
-    buttons: ChatItemAction[]
-    icon?: IconType
     messageId?: string
     canBeVoted?: boolean // requires messageId to be filled to show vote thumbs
     relatedContent?: {
@@ -167,22 +163,8 @@ export interface QuickActions {
 }
 
 export interface TabData {
-    title?: string
-    tabHeader?: TabHeader
-    promptInput?: PromptInput
-    compactMode?: boolean
-    messages: ChatMessage[]
-}
-
-export interface TabHeader {
-    icon?: IconType
-    title?: string
-    description?: string
-}
-
-export interface PromptInput {
     placeholderText?: string
-    label?: string
+    messages: ChatMessage[]
 }
 
 /**


### PR DESCRIPTION
… screen (#411)"

This reverts commit 68354d9e51b17637c91bcf79e320df3fd0975678.

## Problem
As we won't longer need to support a seperate welcome screen anymore, my previous changes need to be reverted

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
