### PR TITLE
fix: make buttons field optional in ChatMessage interface

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -109,7 +109,7 @@ export interface FileList {
 export interface ChatMessage {
     type?: 'answer' | 'prompt' | 'system-prompt' // will default to 'answer'
     body?: string
-    buttons: ChatItemAction[]
+    buttons?: ChatItemAction[]
     icon?: IconType
     messageId?: string
     canBeVoted?: boolean // requires messageId to be filled to show vote thumbs


### PR DESCRIPTION
## Problem
New `buttons` should not be required in ChatMessage interface.

## Solution
Make `buttons` optional.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
