### PR TITLE
feat(types): add mode to fs writeFile

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -218,7 +218,7 @@ export const standalone = (props: RuntimeProps) => {
                     readFile(path, { encoding: (options?.encoding || 'utf-8') as BufferEncoding }),
                 rm: (dir, options?) => rm(dir, options),
                 isFile: path => stat(path).then(({ isFile }) => isFile()),
-                writeFile: (path, data) => writeFile(path, data),
+                writeFile: (path, data, options?) => writeFile(path, data, options),
                 appendFile: (path, data) => appendFile(path, data),
                 mkdir: (path, options?) => mkdir(path, options),
                 readFileSync: (path, options?) =>

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -47,7 +47,7 @@ export type Workspace = {
         readFile: (path: string, options?: { encoding?: string }) => Promise<string>
         isFile: (path: string) => Promise<boolean>
         rm: (dir: string, options?: { recursive?: boolean; force?: boolean }) => Promise<void>
-        writeFile: (path: string, data: string) => Promise<void>
+        writeFile: (path: string, data: string, options?: { mode?: number | string }) => Promise<void>
         appendFile: (path: string, data: string) => Promise<void>
         mkdir: (path: string, options?: { recursive?: boolean }) => Promise<string | undefined>
         /**


### PR DESCRIPTION
## Problem
We need to pass in mode to fs.writeFile from a recent app sec finding
## Solution
add optional mode as param for writeFile
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
