### PR TITLE
feat: inject home directory into runtimes. 

### DIFF
--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -119,7 +119,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
             getServerDataDirPath: serverName =>
                 lspRouter.clientInitializeParams?.initializationOptions?.aws?.clientDataFolder ?? `/${serverName}`,
             getTempDirPath: () => '/tmp',
-            getUserHomeDir: () => '',
+            getUserHomeDir: () => '/home/user',
             readFile: (_path, _options?) => Promise.resolve(''),
             readdir: _path => Promise.resolve([]),
             isFile: _path => Promise.resolve(false),

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -117,7 +117,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
             exists: _path => Promise.resolve(false),
             getFileSize: _path => Promise.resolve({ size: 0 }),
             getServerDataDirPath: serverName =>
-                lspRouter.clientInitializeParams!.initializationOptions?.aws?.clientDataFolder ?? `/${serverName}`,
+                lspRouter.clientInitializeParams?.initializationOptions?.aws?.clientDataFolder ?? `/${serverName}`,
             getTempDirPath: () => '/tmp',
             getUserHomeDir: () => '',
             readFile: (_path, _options?) => Promise.resolve(''),

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -116,8 +116,10 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
             copyFile: (_src, _dest, _options?) => Promise.resolve(),
             exists: _path => Promise.resolve(false),
             getFileSize: _path => Promise.resolve({ size: 0 }),
-            getServerDataDirPath: _serverName => '',
+            getServerDataDirPath: serverName =>
+                lspRouter.clientInitializeParams!.initializationOptions?.aws?.clientDataFolder ?? `/${serverName}`,
             getTempDirPath: () => '/tmp',
+            getUserHomeDir: () => '',
             readFile: (_path, _options?) => Promise.resolve(''),
             readdir: _path => Promise.resolve([]),
             isFile: _path => Promise.resolve(false),

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -79,6 +79,7 @@ import { Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 import { getClientInitializeParamsHandlerFactory } from './util/lspCacheUtil'
 import { newAgent } from './agent'
+import { join } from 'path'
 
 declare const self: WindowOrWorkerGlobalScope
 
@@ -107,6 +108,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
     }
 
     // Set up the workspace to use the LSP Text Documents component
+    const defaultHomeDir = '/home/user'
     const workspace: Workspace = {
         getTextDocument: async uri => documents.get(uri),
         getAllTextDocuments: async () => documents.all(),
@@ -117,9 +119,12 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
             exists: _path => Promise.resolve(false),
             getFileSize: _path => Promise.resolve({ size: 0 }),
             getServerDataDirPath: serverName =>
-                lspRouter.clientInitializeParams?.initializationOptions?.aws?.clientDataFolder ?? `/${serverName}`,
+                join(
+                    lspRouter.clientInitializeParams?.initializationOptions?.aws?.clientDataFolder ?? defaultHomeDir,
+                    serverName
+                ),
             getTempDirPath: () => '/tmp',
-            getUserHomeDir: () => '/home/user',
+            getUserHomeDir: () => defaultHomeDir,
             readFile: (_path, _options?) => Promise.resolve(''),
             readdir: _path => Promise.resolve([]),
             isFile: _path => Promise.resolve(false),

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -213,6 +213,7 @@ export const standalone = (props: RuntimeProps) => {
                         os.type() === 'Darwin' ? '/tmp' : os.tmpdir(),
                         'aws-language-servers'
                     ),
+                getUserHomeDir: () => os.homedir(),
                 readdir: path => readdir(path, { withFileTypes: true }),
                 readFile: (path, options?) =>
                     readFile(path, { encoding: (options?.encoding || 'utf-8') as BufferEncoding }),

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -32,6 +32,7 @@ export type Workspace = {
         getFileSize: (path: string) => Promise<{ size: number }>
         getServerDataDirPath: (serverName: string) => string
         getTempDirPath: () => string
+        getUserHomeDir: () => string
         /**
          * Reads the contents of a directory.
          * @param {string} path - The path to the directory.


### PR DESCRIPTION
## Problem
The home directory is currently fetched via https://github.com/aws/language-servers/blob/ecd755576df2d2e3ca4591cf44b605d7b72b0bc3/core/aws-lsp-core/src/util/path.ts#L96 for components that require it, but this is not available on web. 

Rather than adding web-safe checks around this, we should inject this into the runtime via the `Workspace` interface. 

Injecting this behavior will also make it easier to test certain scenarios as we can directly manipulate the home directory without mocking. 

## Solution
- Add `workspace.fs.getUserHomeDir` that resolves to `os.homedir()` on standalone processes. 
- Default to an empty string in web browsers where there is no concept of home directories. 
- For fetching server directory on web, attempt to use `initializationOptions.clientDataFolder` and fallback to server name. Previously this resolved to empty string always. Empty string is now reserved for the home directory. 

## Note
This PR is done with the assumption that home directories will not be used directly unless explicitly required by a feature. For storage purposes, the server storage should the default. [Example](https://github.com/aws/language-servers/blob/594729d9272109aba7386d08ad1b2f68b493ac63/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts#L47): could be changed to avoid browser check and simply use server storage. 

## Follow-up:
On version bump, replace references to `os.homedir()` with `workspace.fs.getUserHomeDir`. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
