### PR TITLE
fix: agent tools are shared between servers

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -295,6 +295,8 @@ export const standalone = (props: RuntimeProps) => {
 
         const sdkProxyConfigManager = new ProxyConfigManager(telemetry)
 
+        const agent = newAgent()
+
         // Initialize every Server
         const disposables = props.servers.map(s => {
             // Create LSP server representation that holds internal server state
@@ -431,8 +433,6 @@ export const standalone = (props: RuntimeProps) => {
             )
 
             credentialsProvider.onCredentialsDeleted = lspServer.setCredentialsDeleteHandler
-
-            const agent = newAgent()
 
             return s({
                 chat,


### PR DESCRIPTION
## Problem
Agent was scoped per server, meaning it wasn't sharing tools between servers.

## Solution
Instantiate Agents outside the server loop.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
