### PR TITLE
Add initialization configuration options for file indexing

### DIFF
--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -48,10 +48,10 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
 }
 
 /**
- * Configuration interface for setting up local context file indexing.
- * Controls what files are indexed, size limitations, and indexing behavior.
+ * Configuration options for file indexing in local project context.
+ * Controls what files are indexed.
  */
-export interface ContextConfiguration {
+export interface WorkspaceIndexConfiguration {
     /**
      * Array of file patterns to be be excluded from indexing. Patterns must follow the git ignore convention.
      */
@@ -63,6 +63,13 @@ export interface ContextConfiguration {
      * Files with extensions not in this list will be ignored.
      */
     fileExtensions?: string[]
+}
+
+/**
+ * Represents the global context configuration settings.
+ */
+export interface ContextConfiguration {
+    workspaceIndexConfiguration?: WorkspaceIndexConfiguration
 }
 
 /**
@@ -136,9 +143,9 @@ export interface AWSInitializationOptions {
         }
     }
     /**
-     * Local project context file indexing configuration options
+     * Represents the global context configuration settings.
      */
-    contextConfiguration?: ContextConfiguration
+    contextConfiguration?: WorkspaceIndexConfiguration
     /**
      * Global region configuration option set by the client application.
      * Server implementations can use this value to preconfigure SDKs, API clients, etc. at server process startup.

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -32,8 +32,7 @@ export * from './inlineCompletions'
 // AutoParameterStructuresProtocolRequestType allows ParameterStructures both by-name and by-position
 export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
     extends RequestType<P, R, E>
-    implements ProgressType<PR>, RegistrationType<RO>
-{
+    implements ProgressType<PR>, RegistrationType<RO> {
     /**
      * Clients must not use this property. It is here to ensure correct typing.
      */
@@ -45,6 +44,24 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
     public constructor(method: string) {
         super(method, ParameterStructures.auto)
     }
+}
+
+/**
+ * Configuration interface for setting up local context file indexing.
+ * Controls what files are indexed, size limitations, and indexing behavior.
+ */
+export interface ContextConfiguration {
+    /**
+     * Array of file patterns to be be excluded from indexing. Patterns must follow the git ignore convention.
+     */
+    ignoreFilePatterns?: string[]
+
+    /**
+     * List of file extensions that should be included.
+     * Example: ['.ts', '.js', '.json']
+     * Files with extensions not in this list will be ignored.
+     */
+    fileExtensions?: string[]
 }
 
 /**
@@ -117,6 +134,10 @@ export interface AWSInitializationOptions {
             showSaveFileDialog?: boolean
         }
     }
+    /**
+     * Local project context file indexing configuration options
+     */
+    contextConfiguration?: ContextConfiguration
     /**
      * Global region configuration option set by the client application.
      * Server implementations can use this value to preconfigure SDKs, API clients, etc. at server process startup.

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -32,7 +32,8 @@ export * from './inlineCompletions'
 // AutoParameterStructuresProtocolRequestType allows ParameterStructures both by-name and by-position
 export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
     extends RequestType<P, R, E>
-    implements ProgressType<PR>, RegistrationType<RO> {
+    implements ProgressType<PR>, RegistrationType<RO>
+{
     /**
      * Clients must not use this property. It is here to ensure correct typing.
      */


### PR DESCRIPTION
## Problem
Local project context needs to be configurable within different IDEs with rules for files to exclude from indexing, as well as supported languages.

## Solution
Add a `ContextConfiguration` parameter to the `AWSInitializationOptions` interface to be provided during initialization that will determine how local project context will index the workspace. Additional user defined configuration will be available through the `workspace/configuration` call.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
