### PR TITLE
Fix global context configuration param type

### DIFF
--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -145,7 +145,7 @@ export interface AWSInitializationOptions {
     /**
      * Represents the global context configuration settings.
      */
-    contextConfiguration?: WorkspaceIndexConfiguration
+    contextConfiguration?: ContextConfiguration
     /**
      * Global region configuration option set by the client application.
      * Server implementations can use this value to preconfigure SDKs, API clients, etc. at server process startup.

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -48,10 +48,10 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
 }
 
 /**
- * Configuration interface for setting up local context file indexing.
- * Controls what files are indexed, size limitations, and indexing behavior.
+ * Configuration options for file indexing in local project context.
+ * Controls what files are indexed.
  */
-export interface ContextConfiguration {
+export interface WorkspaceIndexConfiguration {
     /**
      * Array of file patterns to be be excluded from indexing. Patterns must follow the git ignore convention.
      */
@@ -63,6 +63,13 @@ export interface ContextConfiguration {
      * Files with extensions not in this list will be ignored.
      */
     fileExtensions?: string[]
+}
+
+/**
+ * Represents the global context configuration settings.
+ */
+export interface ContextConfiguration {
+    workspaceIndexConfiguration?: WorkspaceIndexConfiguration
 }
 
 /**
@@ -136,9 +143,9 @@ export interface AWSInitializationOptions {
         }
     }
     /**
-     * Local project context file indexing configuration options
+     * Represents the global context configuration settings.
      */
-    contextConfiguration?: ContextConfiguration
+    contextConfiguration?: WorkspaceIndexConfiguration
     /**
      * Global region configuration option set by the client application.
      * Server implementations can use this value to preconfigure SDKs, API clients, etc. at server process startup.

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -32,8 +32,7 @@ export * from './inlineCompletions'
 // AutoParameterStructuresProtocolRequestType allows ParameterStructures both by-name and by-position
 export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
     extends RequestType<P, R, E>
-    implements ProgressType<PR>, RegistrationType<RO>
-{
+    implements ProgressType<PR>, RegistrationType<RO> {
     /**
      * Clients must not use this property. It is here to ensure correct typing.
      */
@@ -45,6 +44,24 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
     public constructor(method: string) {
         super(method, ParameterStructures.auto)
     }
+}
+
+/**
+ * Configuration interface for setting up local context file indexing.
+ * Controls what files are indexed, size limitations, and indexing behavior.
+ */
+export interface ContextConfiguration {
+    /**
+     * Array of file patterns to be be excluded from indexing. Patterns must follow the git ignore convention.
+     */
+    ignoreFilePatterns?: string[]
+
+    /**
+     * List of file extensions that should be included.
+     * Example: ['.ts', '.js', '.json']
+     * Files with extensions not in this list will be ignored.
+     */
+    fileExtensions?: string[]
 }
 
 /**
@@ -117,6 +134,10 @@ export interface AWSInitializationOptions {
             showSaveFileDialog?: boolean
         }
     }
+    /**
+     * Local project context file indexing configuration options
+     */
+    contextConfiguration?: ContextConfiguration
     /**
      * Global region configuration option set by the client application.
      * Server implementations can use this value to preconfigure SDKs, API clients, etc. at server process startup.

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -32,7 +32,8 @@ export * from './inlineCompletions'
 // AutoParameterStructuresProtocolRequestType allows ParameterStructures both by-name and by-position
 export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
     extends RequestType<P, R, E>
-    implements ProgressType<PR>, RegistrationType<RO> {
+    implements ProgressType<PR>, RegistrationType<RO>
+{
     /**
      * Clients must not use this property. It is here to ensure correct typing.
      */


### PR DESCRIPTION
## Problem
The global context configuration param is incorrect.

## Solution
Update the global context configuration param to be `ContextConfiguration`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
