### PR TITLE
fix: revert the version of jose to 5.9.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1398,155 +1398,6 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.200.0.tgz",
-            "integrity": "sha512-5BiR6i8yHc9+qW7F6LqkuUnIzVNA7lt0qRxIKcKT+gq3eGUPHZ3DY29sfxI3tkvnwMgtnHDMNze5DdxW39HsAw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/otlp-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-transformer": "0.200.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-metrics": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/api-logs": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
-            "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-            "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.200.0.tgz",
-            "integrity": "sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/otlp-transformer": "0.200.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.200.0.tgz",
-            "integrity": "sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.200.0",
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-logs": "0.200.0",
-                "@opentelemetry/sdk-metrics": "2.0.0",
-                "@opentelemetry/sdk-trace-base": "2.0.0",
-                "protobufjs": "^7.3.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
-            "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.3.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-logs": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
-            "integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.200.0",
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/resources": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.4.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
-            "integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/resources": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.9.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
-            "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.3.0 <1.10.0"
-            }
-        },
         "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
             "version": "0.57.2",
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.57.2.tgz",
@@ -4088,15 +3939,6 @@
                 "node": ">= 0.6.0"
             }
         },
-        "node_modules/jose": {
-            "version": "6.0.10",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.10.tgz",
-            "integrity": "sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/panva"
-            }
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5905,7 +5747,7 @@
                 "aws-sdk": "^2.1692.0",
                 "axios": "^1.8.4",
                 "hpagent": "^1.2.0",
-                "jose": "^6.0.10",
+                "jose": "^5.9.6",
                 "mac-ca": "^3.1.1",
                 "rxjs": "^7.8.2",
                 "vscode-languageserver": "^9.0.1",
@@ -5948,6 +5790,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/philsturgeon"
+            }
+        },
+        "runtimes/node_modules/jose": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+            "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
             }
         },
         "types": {

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -48,7 +48,7 @@
         "aws-sdk": "^2.1692.0",
         "axios": "^1.8.4",
         "hpagent": "^1.2.0",
-        "jose": "^6.0.10",
+        "jose": "^5.9.6",
         "mac-ca": "^3.1.1",
         "rxjs": "^7.8.2",
         "vscode-languageserver": "^9.0.1",


### PR DESCRIPTION
## Problem
The language-servers is crashing because jose v6.x is now purely an ESM package and no longer supports CommonJS require(). Since the project is configured to use CommonJS (as defined in the tsconfig.json), this creates a compatibility issue. I saw the below error when i tried to run the server on my local using jose v6.0.10

```
/Users/{user}/Workspaces/language-servers/node_modules/@aws/language-server-runtimes/runtimes/auth/standalone/encryption.js:8
const jose_1 = require("jose");
               ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/{user}/Workspaces/language-servers/node_modules/@aws/language-server-runtimes/node_modules/jose/dist/webapi/index.js from /Users/{user}/Workspaces/language-servers/node_modules/@aws/language-server-runtimes/runtimes/auth/standalone/encryption.js not supported.
Instead change the require of index.js in /Users/{user}/Workspaces/language-servers/node_modules/@aws/language-server-runtimes/runtimes/auth/standalone/encryption.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/{user}/Workspaces/language-servers/node_modules/@aws/language-server-runtimes/runtimes/auth/standalone/encryption.js:8:16)
    at Object.<anonymous> (/Users/{user}/Workspaces/language-servers/node_modules/@aws/language-server-runtimes/runtimes/standalone.js:53:22)
    at Object.<anonymous> (/Users/{user}/Workspaces/language-servers/node_modules/@aws/language-server-runtimes/runtimes/index.js:4:20)
    at Object.<anonymous> (/Users/{user}/Workspaces/language-servers/app/aws-lsp-codewhisperer-runtimes/out/token-standalone.js:3:20) {
  code: 'ERR_REQUIRE_ESM'
}

```
Attaching the screenshot below from https://www.npmjs.com/package/jose, showing only ESM being supported for v6+

<img width="1204" alt="Screenshot 2025-04-16 at 11 15 28" src="https://github.com/user-attachments/assets/7f619365-95c7-4a03-9e02-b57e3a2e056b" />



## Solution
Reverting the version of jose back to 5.9.6

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
