### PR TITLE
fix: add jose to the ignore list for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
           interval: 'weekly'
       commit-message:
           prefix: 'chore'
+      ignore:
+          - dependency-name: 'jose'


### PR DESCRIPTION
## Problem
Related PR https://github.com/aws/language-server-runtimes/pull/441 to disable the update suggestions for jose package as 6+ version of jose do not support CJS.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
