### PR TITLE
feat: add hasTextDocument abstraction

### DIFF
--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -119,6 +119,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
     const defaultHomeDir = '/home/user'
     const workspace: Workspace = {
         getTextDocument: async uri => documents.get(uri),
+        hasTextDocument: async uri => documents.get(uri) !== undefined,
         getAllTextDocuments: async () => documents.all(),
         getWorkspaceFolder: _uri =>
             lspRouter.clientInitializeParams!.workspaceFolders && lspRouter.clientInitializeParams!.workspaceFolders[0],

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -175,6 +175,7 @@ export const standalone = (props: RuntimeProps) => {
         // Set up the workspace sync to use the LSP Text Document Sync capability
         const workspace: Workspace = {
             getTextDocument: async uri => documents.get(uri),
+            hasTextDocument: async uri => documents.get(uri) !== undefined,
             getAllTextDocuments: async () => documents.all(),
             // Get all workspace folders and return the workspace folder that contains the uri
             getWorkspaceFolder: uri => {

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -17,6 +17,7 @@ interface Dirent {
  */
 export type Workspace = {
     getTextDocument: (uri: string) => Promise<TextDocument | undefined>
+    hasTextDocument: (uri: string) => Promise<boolean>
     getAllTextDocuments: () => Promise<TextDocument[]>
     getWorkspaceFolder: (uri: string) => WorkspaceFolder | null | undefined
     fs: {


### PR DESCRIPTION
## Problem
When trying to determine if a workspace contains a given file, one must reimplement this simple function every time.

## Solution
- Add it to the workspace API. 
- Defining it in one place reduces the chance of errors, and allows other functionality to be built on top of it. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
