### PR TITLE
feat: extending ui contract with dynamic feature config types

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -152,3 +152,19 @@ export interface ErrorResult {
     message: string
     type: 'InvalidRequest' | 'InternalError' | 'UnknownError' | string
 }
+
+/*
+ * A message injected into the client to dynamically add new features, namely the UI.
+ */
+export interface FeatureValue {
+    boolValue?: boolean
+    doubleValue?: number
+    longValue?: number
+    stringValue?: string
+}
+
+export interface FeatureContext {
+    name?: string
+    variation: string
+    value: FeatureValue
+}


### PR DESCRIPTION
## Problem
Currently we need a way to inject features such as contextCommands into our chat client. This PR is needed to copy over the types that the vscode team are also using

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
