### PR TITLE
chore(chat-client-ui-types): add pair programming card acknowledgement command

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -26,6 +26,7 @@ export const AUTH_FOLLOW_UP_CLICKED = 'authFollowUpClicked'
 export const GENERIC_COMMAND = 'genericCommand'
 export const CHAT_OPTIONS = 'chatOptions'
 export const DISCLAIMER_ACKNOWLEDGED = 'disclaimerAcknowledged'
+export const PAIR_PROGRAMMING_ACKNOWLEDGED = 'pairProgrammingAcknowledged'
 
 /**
  * A message sent from Chat Client to Extension in response to various actions triggered from Chat UI.
@@ -44,6 +45,7 @@ export type UiMessageCommand =
     | typeof CHAT_OPTIONS
     | typeof COPY_TO_CLIPBOARD
     | typeof DISCLAIMER_ACKNOWLEDGED
+    | typeof PAIR_PROGRAMMING_ACKNOWLEDGED
 
 export type UiMessageParams =
     | InsertToCursorPositionParams


### PR DESCRIPTION
## Problem
we need a way to dismiss the pair programming card used in agentic chat

## Solution
when the "X" is pressed on the pair programming card it will send a pairProgrammingAcknowledged event to VSCode

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
