### PR TITLE
feat: add additional messages in support of the final response

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -142,9 +142,33 @@ export interface ChatMessage {
     fileList?: FileList
     contextList?: FileList
 }
-// Response for chat prompt request can be empty,
-// if server chooses to handle the request and push updates asynchronously.
-export interface ChatResult extends ChatMessage {}
+
+/**
+ * Represents the result of a chat interaction.
+ * A ChatResult extends ChatMessage and can optionally include additional messages
+ * that provide context, reasoning, or intermediate steps that led to the final response.
+ *
+ * Response for chat prompt request can be empty, if server chooses to handle the request and push updates asynchronously.
+ */
+export interface ChatResult extends ChatMessage {
+    /**
+     * Optional array of supporting messages that provide additional context for the primary message.
+     * These can include:
+     * - Reasoning steps that led to the final answer
+     * - Tool usage and outputs during processing
+     * - Intermediate calculations or decision points
+     * - Status updates about the processing
+     * - Human interactions that influenced the response
+     *
+     * The primary message (this ChatResult itself) should contain the final, complete response,
+     * while additionalMessages provides transparency into how that response was generated.
+     *
+     * UI implementations should typically display the primary message prominently,
+     * with additionalMessages shown as supporting information when relevant.
+     */
+    additionalMessages?: ChatMessage[]
+}
+
 export interface InlineChatResult extends ChatMessage {
     requestId?: string
 }


### PR DESCRIPTION
## Problem
In order to answer a prompt that requires multiple reasoning steps and tool usages, we need to be able to reply with more than one message.

## Solution
In order to maintain backwards compatibility and indicate the relationship between the messages, an array of `additionalMessages` is added to `ChatResult` to contain the supporting materials.

There's 2 ways to use it:

1. Use the primary message only for the final result, and use `additionalMessages` for all intermediate messages. This would keep the primary message empty until the prompt finally resolves. This means that clients that don't know about this property, will not render anything until completed.

2. Put the most recent message in the primary message, and move the previous messages into `additionalMessages`. Then, as more information comes in, the primary message reflects the most recent information and earlier messages move up in the `additionalMessages` array. This means that unsupporting clients will always show some progress during request processing.

For partial progress updates, the whole primary message and all its `additionalMessages` need to be sent. There could be an optimization to allow individual additionalMessages to be updated without clearing the entire response, but that would be better implemented using `ChatUpdateParams`.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
