### PR TITLE
fix: change pair programming acknowledged to chat prompt option acknowledged

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -55,6 +55,7 @@ export type UiMessageParams =
     | SendToPromptParams
     | ChatOptions
     | CopyCodeToClipboardParams
+    | ChatPromptOptionAcknowledgedParams
 
 export interface SendToPromptParams {
     selection: string
@@ -92,6 +93,15 @@ export interface GenericCommandParams {
 export interface GenericCommandMessage {
     command: typeof GENERIC_COMMAND
     params: GenericCommandParams
+}
+
+export interface ChatPromptOptionAcknowledgedParams {
+    messageId: string
+}
+
+export interface ChatPromptOptionAcknowledgedMessage {
+    command: typeof CHAT_PROMPT_OPTION_ACKNOWLEDGED
+    params: ChatPromptOptionAcknowledgedParams
 }
 
 export interface ErrorParams {

--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -26,7 +26,7 @@ export const AUTH_FOLLOW_UP_CLICKED = 'authFollowUpClicked'
 export const GENERIC_COMMAND = 'genericCommand'
 export const CHAT_OPTIONS = 'chatOptions'
 export const DISCLAIMER_ACKNOWLEDGED = 'disclaimerAcknowledged'
-export const PAIR_PROGRAMMING_ACKNOWLEDGED = 'pairProgrammingAcknowledged'
+export const CHAT_PROMPT_OPTION_ACKNOWLEDGED = 'chatPromptOptionAcknowledged'
 
 /**
  * A message sent from Chat Client to Extension in response to various actions triggered from Chat UI.
@@ -45,7 +45,7 @@ export type UiMessageCommand =
     | typeof CHAT_OPTIONS
     | typeof COPY_TO_CLIPBOARD
     | typeof DISCLAIMER_ACKNOWLEDGED
-    | typeof PAIR_PROGRAMMING_ACKNOWLEDGED
+    | typeof CHAT_PROMPT_OPTION_ACKNOWLEDGED
 
 export type UiMessageParams =
     | InsertToCursorPositionParams


### PR DESCRIPTION
## Problem
Instead of tying the message send from chat-client -> editors to pair programming, lets make it generic and send a message id and let clients handle this on their side

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
