### PR TITLE
feat: add stopResponse ui event

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -106,6 +106,15 @@ export interface ChatPromptOptionAcknowledgedMessage {
     params: ChatPromptOptionAcknowledgedParams
 }
 
+export interface StopResponseParams {
+    tabId: string
+}
+
+export interface StopResponseMessage {
+    command: typeof STOP_RESPONSE
+    params: StopResponseParams
+}
+
 export interface ErrorParams {
     tabId: string
     triggerType?: TriggerType

--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -27,6 +27,7 @@ export const GENERIC_COMMAND = 'genericCommand'
 export const CHAT_OPTIONS = 'chatOptions'
 export const DISCLAIMER_ACKNOWLEDGED = 'disclaimerAcknowledged'
 export const CHAT_PROMPT_OPTION_ACKNOWLEDGED = 'chatPromptOptionAcknowledged'
+export const STOP_RESPONSE = 'stopResponse'
 
 /**
  * A message sent from Chat Client to Extension in response to various actions triggered from Chat UI.
@@ -46,6 +47,7 @@ export type UiMessageCommand =
     | typeof COPY_TO_CLIPBOARD
     | typeof DISCLAIMER_ACKNOWLEDGED
     | typeof CHAT_PROMPT_OPTION_ACKNOWLEDGED
+    | typeof STOP_RESPONSE
 
 export type UiMessageParams =
     | InsertToCursorPositionParams

--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -27,7 +27,7 @@ export const GENERIC_COMMAND = 'genericCommand'
 export const CHAT_OPTIONS = 'chatOptions'
 export const DISCLAIMER_ACKNOWLEDGED = 'disclaimerAcknowledged'
 export const CHAT_PROMPT_OPTION_ACKNOWLEDGED = 'chatPromptOptionAcknowledged'
-export const STOP_RESPONSE = 'stopResponse'
+export const STOP_CHAT_RESPONSE = 'stopChatResponse'
 
 /**
  * A message sent from Chat Client to Extension in response to various actions triggered from Chat UI.
@@ -47,7 +47,7 @@ export type UiMessageCommand =
     | typeof COPY_TO_CLIPBOARD
     | typeof DISCLAIMER_ACKNOWLEDGED
     | typeof CHAT_PROMPT_OPTION_ACKNOWLEDGED
-    | typeof STOP_RESPONSE
+    | typeof STOP_CHAT_RESPONSE
 
 export type UiMessageParams =
     | InsertToCursorPositionParams
@@ -58,7 +58,7 @@ export type UiMessageParams =
     | ChatOptions
     | CopyCodeToClipboardParams
     | ChatPromptOptionAcknowledgedParams
-    | StopResponseParams
+    | StopChatResponseParams
 
 export interface SendToPromptParams {
     selection: string
@@ -107,13 +107,13 @@ export interface ChatPromptOptionAcknowledgedMessage {
     params: ChatPromptOptionAcknowledgedParams
 }
 
-export interface StopResponseParams {
+export interface StopChatResponseParams {
     tabId: string
 }
 
-export interface StopResponseMessage {
-    command: typeof STOP_RESPONSE
-    params: StopResponseParams
+export interface StopChatResponseMessage {
+    command: typeof STOP_CHAT_RESPONSE
+    params: StopChatResponseParams
 }
 
 export interface ErrorParams {

--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -58,6 +58,7 @@ export type UiMessageParams =
     | ChatOptions
     | CopyCodeToClipboardParams
     | ChatPromptOptionAcknowledgedParams
+    | StopResponseParams
 
 export interface SendToPromptParams {
     selection: string


### PR DESCRIPTION
## Problem
for agentic chat we need a way for the chat client to tell VSCode that we should stop the chat request stream

## Solution
add it

## Other notes
The implementation of how this event would be used is:
- send a notification from chat-client to VSCode
- cancel the token for the active chat request stream
- replicate the equivalent of [this code](https://github.com/aws/aws-toolkit-vscode/blob/feature/agentic-chat/packages/core/src/codewhispererChat/controllers/chat/controller.ts#L415) in flare

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
