### PR TITLE
feat: add cancellation token to agent spec

### DIFF
--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -299,7 +299,7 @@ export type Agent = {
      */
     addTool: <T extends InferSchema<S['inputSchema']>, S extends ToolSpec, R>(
         spec: S,
-        handler: (input: T) => Promise<R>
+        handler: (input: T, token?: CancellationToken) => Promise<R>
     ) => void
 
     /**
@@ -312,7 +312,7 @@ export type Agent = {
      * @param input The input to the tool
      * @returns The result of the tool execution
      */
-    runTool: (toolName: string, input: any) => Promise<any>
+    runTool: (toolName: string, input: any, token?: CancellationToken) => Promise<any>
 
     /**
      * Get the list of tools in the local tool repository.

--- a/runtimes/runtimes/agent.ts
+++ b/runtimes/runtimes/agent.ts
@@ -1,12 +1,21 @@
 import Ajv from 'ajv'
-import { Agent, BedrockTools, GetToolsOptions, InferSchema, ObjectSchema, Tools, ToolSpec } from '../server-interface'
+import {
+    Agent,
+    BedrockTools,
+    CancellationToken,
+    GetToolsOptions,
+    InferSchema,
+    ObjectSchema,
+    Tools,
+    ToolSpec,
+} from '../server-interface'
 
 type Tool<T, R> = {
     name: string
     description: string
     inputSchema: ObjectSchema
-    validate: (input: T) => boolean
-    invoke: (input: T) => Promise<R>
+    validate: (input: T, token?: CancellationToken) => boolean
+    invoke: (input: T, token?: CancellationToken) => Promise<R>
 }
 
 export const newAgent = (): Agent => {
@@ -16,7 +25,7 @@ export const newAgent = (): Agent => {
     return {
         addTool: <T extends InferSchema<S['inputSchema']>, S extends ToolSpec>(
             spec: S,
-            handler: (input: T) => Promise<any>
+            handler: (input: T, token?: CancellationToken) => Promise<any>
         ) => {
             const validator = ajv.compile(spec.inputSchema)
             const tool = {
@@ -32,17 +41,17 @@ export const newAgent = (): Agent => {
             tools[spec.name] = tool
         },
 
-        runTool: async (toolName: string, input: any) => {
+        runTool: async (toolName: string, input: any, token?: CancellationToken) => {
             const tool = tools[toolName]
             if (!tool) {
                 throw new Error(`Tool ${toolName} not found`)
             }
 
-            if (!tool.validate(input)) {
+            if (!tool.validate(input, token)) {
                 throw new Error(`Input for tool ${toolName} is invalid`)
             }
 
-            return tool.invoke(input)
+            return tool.invoke(input, token)
         },
 
         getTools: <T extends GetToolsOptions>(options?: T) => {

--- a/runtimes/server-interface/agent.ts
+++ b/runtimes/server-interface/agent.ts
@@ -1,3 +1,5 @@
+import { CancellationToken } from '../protocol'
+
 interface BaseSchema {
     title?: string
     description?: string
@@ -121,7 +123,7 @@ export type Agent = {
      */
     addTool: <T extends InferSchema<S['inputSchema']>, S extends ToolSpec, R>(
         spec: S,
-        handler: (input: T) => Promise<R>
+        handler: (input: T, token?: CancellationToken) => Promise<R>
     ) => void
 
     /**
@@ -134,7 +136,7 @@ export type Agent = {
      * @param input The input to the tool
      * @returns The result of the tool execution
      */
-    runTool: (toolName: string, input: any) => Promise<any>
+    runTool: (toolName: string, input: any, token?: CancellationToken) => Promise<any>
 
     /**
      * Get the list of tools in the local tool repository.


### PR DESCRIPTION
## Problem
we have no way to cancel tools that are actively running. This is probably not relevant for tools like fsWrite/fsRead but really relevant for tools like executeBash/list directories which can take a long time

## Solution
update the api to add in a cancellation token

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
