### PR TITLE
feat: extended UI and protocol types for openning settings

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -28,6 +28,7 @@ export const CHAT_OPTIONS = 'chatOptions'
 export const DISCLAIMER_ACKNOWLEDGED = 'disclaimerAcknowledged'
 export const CHAT_PROMPT_OPTION_ACKNOWLEDGED = 'chatPromptOptionAcknowledged'
 export const STOP_CHAT_RESPONSE = 'stopChatResponse'
+export const OPEN_SETTINGS = 'openSettings'
 
 /**
  * A message sent from Chat Client to Extension in response to various actions triggered from Chat UI.
@@ -48,6 +49,7 @@ export type UiMessageCommand =
     | typeof DISCLAIMER_ACKNOWLEDGED
     | typeof CHAT_PROMPT_OPTION_ACKNOWLEDGED
     | typeof STOP_CHAT_RESPONSE
+    | typeof OPEN_SETTINGS
 
 export type UiMessageParams =
     | InsertToCursorPositionParams
@@ -59,6 +61,7 @@ export type UiMessageParams =
     | CopyCodeToClipboardParams
     | ChatPromptOptionAcknowledgedParams
     | StopChatResponseParams
+    | OpenSettingsParams
 
 export interface SendToPromptParams {
     selection: string
@@ -147,6 +150,10 @@ export interface CopyCodeToClipboardParams {
 export interface CopyCodeToClipboardMessage {
     command: typeof COPY_TO_CLIPBOARD
     params: CopyCodeToClipboardParams
+}
+
+export interface OpenSettingsParams {
+    settingKey: string
 }
 
 /**

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,5 +1,6 @@
 import { Position, Range, TextDocumentIdentifier } from './lsp'
 
+// protocol methods
 export const CHAT_REQUEST_METHOD = 'aws/chat/sendChatPrompt'
 export const END_CHAT_REQUEST_METHOD = 'aws/chat/endChat'
 export const QUICK_ACTION_REQUEST_METHOD = 'aws/chat/sendChatQuickAction'
@@ -30,6 +31,9 @@ export const LIST_CONVERSATIONS_REQUEST_METHOD = 'aws/chat/listConversations'
 export const CONVERSATION_CLICK_REQUEST_METHOD = 'aws/chat/conversationClick'
 // export
 export const GET_SERIALIZED_CHAT_REQUEST_METHOD = 'aws/chat/getSerializedChat'
+
+// button ids
+export const OPEN_WORKSPACE_INDEX_SETTINGS_BUTTON_ID = 'open-settings-for-ws-index'
 
 export interface ChatItemAction {
     pillText: string
@@ -116,12 +120,15 @@ export interface FileList {
     details?: Record<string, FileDetails>
 }
 
+export type Status = 'info' | 'success' | 'warning' | 'error'
 export interface Button {
     id: string
     text?: string
     description?: string
     icon?: IconType
     disabled?: boolean
+    keepCardAfterClick?: boolean
+    status?: 'main' | 'primary' | 'clear' | Status
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Problem

We need to prompt use to open settings and enable local workspace indexing, we user tries to use `@workspace` context.

## Solution

Extending protocol to support needed functionality:
- buttons type was extended
- `OPEN_SETTINGS` command and parameters were added to send command from chat client to extension to open settings with specific key

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
