### PR TITLE
fix: file click outside of workspace crashes whole process

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -105,6 +105,7 @@ export interface EncryptedChatParams extends PartialResultParams {
 
 export interface FileDetails {
     description?: string
+    fullPath?: string
     lineRanges?: Array<{ first: number; second: number }>
     changes?: {
         added?: number
@@ -367,6 +368,7 @@ export interface FileClickParams {
     filePath: string
     action?: FileAction
     messageId?: string
+    fullPath?: string
 }
 
 // context


### PR DESCRIPTION
## Problem

`onFileClick` for file outside of workspace crashes the whole process.

## Solution

Extend protocol to allow pass the full path for context items and not resolve them every time on server again.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
