### PR TITLE
feat: add autoSubmit param to SendToPromptParams

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -7,6 +7,7 @@ import {
     OpenTabResult,
     GET_SERIALIZED_CHAT_REQUEST_METHOD,
     GetSerializedChatResult,
+    ChatPrompt,
 } from '@aws/language-server-runtimes-types'
 export { InsertToCursorPositionParams } from '@aws/language-server-runtimes-types'
 
@@ -66,6 +67,8 @@ export type UiMessageParams =
 export interface SendToPromptParams {
     selection: string
     triggerType: TriggerType
+    prompt?: ChatPrompt
+    autoSubmit?: boolean
 }
 
 export interface SendToPromptMessage {


### PR DESCRIPTION
## Problem
To support `aws.amazonq.ExplainIssue` in security scan for VSCode we need to have a way to send a generic message to the chat client and automatically submit that message

## Solution
Add an autoSubmit, prompt param to SendToPromptParams. This option will be disabled by default. Only when the IDE explicitily indicates that the user intends for this to automatically send will it auto submit

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
