### PR TITLE
feat: support file snapshot for diffs

### DIFF
--- a/types/workspace.ts
+++ b/types/workspace.ts
@@ -19,6 +19,7 @@ export interface SelectWorkspaceItemResult {
 
 export interface OpenFileDiffParams {
     originalFileUri: URI
+    originalFileContent?: string
     isDeleted: boolean
     fileContent?: string
 }


### PR DESCRIPTION
## Problem
We need a way to tell clients what the original file contains at the time of generating a diff.

## Solution
Add optional field `originalFileContent` which may be different from the contents of the file at the current point in time.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
