### PR TITLE
fix: avoid path import on web.

### DIFF
--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -91,7 +91,7 @@ import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 import { getClientInitializeParamsHandlerFactory } from './util/lspCacheUtil'
 import { newAgent } from './agent'
 import { ShowSaveFileDialogRequestType } from '../protocol/window'
-import { join } from 'path'
+import { joinUnixPaths } from './util/pathUtil'
 
 declare const self: WindowOrWorkerGlobalScope
 
@@ -131,7 +131,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
             exists: _path => Promise.resolve(false),
             getFileSize: _path => Promise.resolve({ size: 0 }),
             getServerDataDirPath: serverName =>
-                join(
+                joinUnixPaths(
                     lspRouter.clientInitializeParams?.initializationOptions?.aws?.clientDataFolder ?? defaultHomeDir,
                     serverName
                 ),

--- a/runtimes/runtimes/util/pathUtil.test.ts
+++ b/runtimes/runtimes/util/pathUtil.test.ts
@@ -1,0 +1,57 @@
+import * as assert from 'assert'
+import { joinUnixPaths } from './pathUtil'
+
+describe('joinUnixPaths', function () {
+    it('handles basic joining', function () {
+        assert.strictEqual(joinUnixPaths('foo', 'bar'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('foo'), 'foo')
+        assert.strictEqual(joinUnixPaths(), '')
+        assert.strictEqual(joinUnixPaths(''), '')
+    })
+
+    it('ignores leading and trailing slashes', function () {
+        assert.strictEqual(joinUnixPaths('/foo', 'bar'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('foo/', 'bar'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('foo', '/bar'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('foo', 'bar/'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('/foo/', '/bar/'), 'foo/bar')
+    })
+
+    it('handles multiple consecutive slashes', function () {
+        assert.strictEqual(joinUnixPaths('foo//', '//bar'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('///foo///', '///bar///'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('foo///bar'), 'foo/bar')
+    })
+
+    it('handles dot segments correctly', function () {
+        assert.strictEqual(joinUnixPaths('foo', '.', 'bar'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('foo/./bar'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('./foo/bar'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('foo/bar/.'), 'foo/bar')
+    })
+
+    it('handles double-dot segments correctly', function () {
+        assert.strictEqual(joinUnixPaths('foo', '..', 'bar'), 'bar')
+        assert.strictEqual(joinUnixPaths('foo/bar/..'), 'foo')
+        assert.strictEqual(joinUnixPaths('foo/../bar'), 'bar')
+        assert.strictEqual(joinUnixPaths('foo/bar/../baz'), 'foo/baz')
+        assert.strictEqual(joinUnixPaths('foo/bar/../../baz'), 'baz')
+    })
+
+    it('handles complex path combinations', function () {
+        assert.strictEqual(joinUnixPaths('/foo/bar', '../baz/./qux/'), 'foo/baz/qux')
+        assert.strictEqual(joinUnixPaths('foo/./bar', '../baz//qux/..'), 'foo/baz')
+        assert.strictEqual(joinUnixPaths('/foo/bar/', './baz/../qux'), 'foo/bar/qux')
+        assert.strictEqual(joinUnixPaths('foo', 'bar', 'baz', '..', 'qux'), 'foo/bar/qux')
+    })
+
+    it('handles empty segments', function () {
+        assert.strictEqual(joinUnixPaths('foo', '', 'bar'), 'foo/bar')
+        assert.strictEqual(joinUnixPaths('', 'foo', '', 'bar', ''), 'foo/bar')
+    })
+
+    it('handles paths with multiple consecutive dots', function () {
+        assert.strictEqual(joinUnixPaths('foo', '...', 'bar'), 'foo/.../bar')
+        assert.strictEqual(joinUnixPaths('foo/...bar'), 'foo/...bar')
+    })
+})

--- a/runtimes/runtimes/util/pathUtil.ts
+++ b/runtimes/runtimes/util/pathUtil.ts
@@ -1,3 +1,8 @@
+/**
+ * Simplified version of path.join that can be safely used on web
+ * @param segments
+ * @returns
+ */
 export function joinUnixPaths(...segments: string[]): string {
     // Filter out empty segments and normalize each segment
     const normalizedSegments = segments.filter(Boolean).map(segment => segment.replace(/^\/+|\/+$/g, ''))

--- a/runtimes/runtimes/util/pathUtil.ts
+++ b/runtimes/runtimes/util/pathUtil.ts
@@ -1,0 +1,23 @@
+export function joinUnixPaths(...segments: string[]): string {
+    // Filter out empty segments and normalize each segment
+    const normalizedSegments = segments.filter(Boolean).map(segment => segment.replace(/^\/+|\/+$/g, ''))
+
+    // Join segments with a single slash and then split to handle internal slashes
+    const parts = normalizedSegments
+        .join('/')
+        .replace(/\/+/g, '/') // Replace multiple consecutive slashes with a single slash
+        .split('/')
+
+    const result = []
+
+    for (const part of parts) {
+        if (part === '..') {
+            result.pop()
+        } else if (part !== '.' && part !== '') {
+            // Skip empty parts and current directory markers
+            result.push(part)
+        }
+    }
+
+    return result.join('/')
+}


### PR DESCRIPTION
## Problem
path is imported to join paths on web. This was assumed to be safe since `path` is polyfilled with `path-browserify` in the webpack config. However, this polyfill requires consumers to add this dependency, which can be undesirable. 

## Solution
- write our own simplified join for unix paths that can be used in the browser case. 
- remove path import. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
