### PR TITLE
feat: add workspaceIdentifier to AWSInitializationOptions

### DIFF
--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -70,6 +70,10 @@ export interface WorkspaceIndexConfiguration {
  */
 export interface ContextConfiguration {
     workspaceIndexConfiguration?: WorkspaceIndexConfiguration
+    /**
+     * Identifier for the IDE workspace.
+     */
+    workspaceIdentifier?: string
 }
 
 /**

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -71,7 +71,8 @@ export interface WorkspaceIndexConfiguration {
 export interface ContextConfiguration {
     workspaceIndexConfiguration?: WorkspaceIndexConfiguration
     /**
-     * Identifier for the IDE workspace.
+     * A unique identifier for the IDE workspace that remains consistent across IDE window reopenings.
+     * The value should be stable and unique for each workspace, regardless of IDE restarts or system reboots.
      */
     workspaceIdentifier?: string
 }


### PR DESCRIPTION
## Problem

We need an identifier to uniquely and consistently identify an IDE workspace.

## Solution

Extension would pass such an identifier to AWSInitializationOptions

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
