### PR TITLE
feat: support remove tool in Agent

### DIFF
--- a/runtimes/runtimes/agent.test.ts
+++ b/runtimes/runtimes/agent.test.ts
@@ -115,4 +115,22 @@ describe('Agent Tools', () => {
             SOME_TOOL_SPEC_WITH_EXTENSIONS.inputSchema.someExtension
         )
     })
+
+    it('should allow removing a tool', () => {
+        AGENT.addTool(SOME_TOOL_SPEC, SOME_TOOL_HANDLER)
+        assert.equal(AGENT.getTools().length, 1)
+        AGENT.removeTool(SOME_TOOL_SPEC.name)
+        assert.equal(AGENT.getTools().length, 0)
+    })
+
+    it('removeTool should be safe for unknown tools', () => {
+        AGENT.removeTool('doesNotExist')
+        assert.equal(AGENT.getTools().length, 0)
+    })
+
+    it('should throw when running a removed tool', async () => {
+        AGENT.addTool(SOME_TOOL_SPEC, SOME_TOOL_HANDLER)
+        AGENT.removeTool(SOME_TOOL_SPEC.name)
+        await assert.rejects(() => AGENT.runTool(SOME_TOOL_SPEC.name, { test: 'test' }), /not found/)
+    })
 })

--- a/runtimes/runtimes/agent.ts
+++ b/runtimes/runtimes/agent.ts
@@ -80,5 +80,9 @@ export const newAgent = (): Agent => {
                 }
             }) as T extends { format: 'bedrock' } ? never : Tools
         },
+
+        removeTool: (name: string) => {
+            delete tools[name]
+        },
     }
 }

--- a/runtimes/server-interface/agent.ts
+++ b/runtimes/server-interface/agent.ts
@@ -144,4 +144,10 @@ export type Agent = {
      * @returns The tool repository in the requested output format
      */
     getTools: <T extends GetToolsOptions>(options?: T) => T extends { format: 'bedrock' } ? BedrockTools : Tools
+
+    /**
+     * Remove a tool from the local tool repository.
+     * @param toolName The name of the tool to remove
+     */
+    removeTool: (toolName: string) => void
 }


### PR DESCRIPTION
## Problem
To support MCP server removal or updates, the Agent needs the ability to dynamically remove tools.
## Solution
Add a removeTool interface in the Agent to enable tool removal.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
