### PR TITLE
fix: filter expired certificates in tets

### DIFF
--- a/runtimes/runtimes/util/standalone/experimentalProxyUtil.ts
+++ b/runtimes/runtimes/util/standalone/experimentalProxyUtil.ts
@@ -147,7 +147,7 @@ export class ProxyConfigManager {
         console.debug(`Total certificates read: ${certificates.length}`)
         const validCerts = this.removeExpiredCertificates(certificates)
 
-        console.debug(`Using certificates: ${certificates.length}`)
+        console.debug(`Using certificates: ${validCerts.length}`)
         return validCerts
     }
 


### PR DESCRIPTION
## Problem
The tests are failing because one of the `tls.rootCertificates` expired yesterday. The proxy manager correctly filters out expired certificates, but in tests we compare it against all certificates.

## Solution
Added a function in tests to filter expired certificates.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
