### PR TITLE
feat: support using rootUri for workspaceFolders and handle workspaceChangeEvent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3898,6 +3898,11 @@
             "version": "3.17.5",
             "license": "MIT"
         },
+        "node_modules/vscode-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+            "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "dev": true,
@@ -4086,6 +4091,7 @@
                 "rxjs": "^7.8.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-protocol": "^3.17.5",
+                "vscode-uri": "^3.1.0",
                 "win-ca": "^3.5.1"
             },
             "devDependencies": {

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -47,7 +47,8 @@
         "rxjs": "^7.8.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-protocol": "^3.17.5",
-        "win-ca": "^3.5.1"
+        "win-ca": "^3.5.1",
+        "vscode-uri": "^3.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^10.0.9",

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -124,8 +124,8 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
     const workspace: Workspace = {
         getTextDocument: async uri => documents.get(uri),
         getAllTextDocuments: async () => documents.all(),
-        getWorkspaceFolder: _uri =>
-            lspRouter.clientInitializeParams!.workspaceFolders && lspRouter.clientInitializeParams!.workspaceFolders[0],
+        getWorkspaceFolder: _uri => lspRouter.getAllWorkspaceFolders() && lspRouter.getAllWorkspaceFolders()[0],
+        getAllWorkspaceFolders: () => lspRouter.getAllWorkspaceFolders(),
         fs: {
             copyFile: (_src, _dest, _options?) => Promise.resolve(),
             exists: _path => Promise.resolve(false),

--- a/runtimes/runtimes/lsp/router/initializeUtils.test.ts
+++ b/runtimes/runtimes/lsp/router/initializeUtils.test.ts
@@ -34,7 +34,7 @@ describe('initializeUtils', () => {
                 { name: 'folder2', uri: 'file:///path/to/folder2' },
             ]
             const params = createParams({ workspaceFolders })
-            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+            const result = getWorkspaceFoldersFromInit(consoleStub, params)
 
             assert.deepStrictEqual(result, workspaceFolders)
         })
@@ -48,12 +48,12 @@ describe('initializeUtils', () => {
             invalidWorkspaceFolderCases.forEach(([name, input]) => {
                 it(`should return root uri for ${name}`, () => {
                     const params = createParams(input)
-                    const result = getWorkspaceFoldersFromInit(params, consoleStub)
+                    const result = getWorkspaceFoldersFromInit(consoleStub, params)
                     assert.deepStrictEqual(result, [sampleWorkspaceFolder])
                 })
             })
             const params = createParams({ rootUri: sampleWorkspaceUri })
-            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+            const result = getWorkspaceFoldersFromInit(consoleStub, params)
 
             assert.deepStrictEqual(result, [sampleWorkspaceFolder])
         })
@@ -61,7 +61,7 @@ describe('initializeUtils', () => {
         it('should create workspace folder from rootPath when neither workspaceFolders nor rootUri is provided', () => {
             const rootPath = '/path/to/folder'
             const params = createParams({ rootPath: rootPath })
-            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+            const result = getWorkspaceFoldersFromInit(consoleStub, params)
 
             assert.deepStrictEqual(result, [sampleWorkspaceFolder])
         })
@@ -69,7 +69,7 @@ describe('initializeUtils', () => {
         it('should use uri as folder name when URI basename is empty', () => {
             const rootUri = 'file:///'
             const params = createParams({ rootUri })
-            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+            const result = getWorkspaceFoldersFromInit(consoleStub, params)
 
             assert.deepStrictEqual(result, [{ name: rootUri, uri: rootUri }])
         })
@@ -79,7 +79,7 @@ describe('initializeUtils', () => {
             const pathUri = URI.parse(rootPath).toString()
             const params = createParams({ rootPath })
 
-            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+            const result = getWorkspaceFoldersFromInit(consoleStub, params)
 
             const expectedName = path.basename(URI.parse(pathUri).fsPath)
             assert.deepStrictEqual(result, [{ name: expectedName, uri: pathUri }])
@@ -91,7 +91,7 @@ describe('initializeUtils', () => {
             const folderName = path.basename(decodedPath)
 
             const params = createParams({ rootUri })
-            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+            const result = getWorkspaceFoldersFromInit(consoleStub, params)
 
             assert.deepStrictEqual(result, [{ name: folderName, uri: rootUri }])
             assert.equal('special project', result[0].name)
@@ -107,7 +107,7 @@ describe('initializeUtils', () => {
 
             emptyArrayCases.forEach(([name, input]) => {
                 it(`should return empty array for ${name}`, () => {
-                    const result = getWorkspaceFoldersFromInit(input, consoleStub)
+                    const result = getWorkspaceFoldersFromInit(consoleStub, input)
                     assert.equal(result.length, 0)
                 })
             })

--- a/runtimes/runtimes/lsp/router/initializeUtils.test.ts
+++ b/runtimes/runtimes/lsp/router/initializeUtils.test.ts
@@ -1,0 +1,116 @@
+import { URI } from 'vscode-uri'
+import * as path from 'path'
+import assert = require('assert')
+import sinon = require('sinon')
+import { InitializeParams, WorkspaceFolder } from 'vscode-languageserver-protocol'
+import { getWorkspaceFoldersFromInit } from './initializeUtils'
+import { RemoteConsole } from 'vscode-languageserver'
+
+describe('initializeUtils', () => {
+    let consoleStub: sinon.SinonStubbedInstance<RemoteConsole>
+
+    beforeEach(() => {
+        consoleStub = {
+            log: sinon.stub(),
+            error: sinon.stub(),
+            warn: sinon.stub(),
+            info: sinon.stub(),
+        } as sinon.SinonStubbedInstance<RemoteConsole>
+    })
+
+    describe('getWorkspaceFolders', () => {
+        const sampleWorkspaceUri = 'file:///path/to/folder'
+        const sampleWorkspaceName = 'folder'
+        const sampleWorkspaceFolder: WorkspaceFolder = {
+            name: sampleWorkspaceName,
+            uri: sampleWorkspaceUri,
+        }
+
+        const createParams = (params: Partial<InitializeParams>) => params as InitializeParams
+
+        it('should return workspaceFolders when provided', () => {
+            const workspaceFolders: WorkspaceFolder[] = [
+                sampleWorkspaceFolder,
+                { name: 'folder2', uri: 'file:///path/to/folder2' },
+            ]
+            const params = createParams({ workspaceFolders })
+            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+
+            assert.deepStrictEqual(result, workspaceFolders)
+        })
+
+        describe('should create workspace folder from rootUri when workspaceFolders is not provided', () => {
+            const invalidWorkspaceFolderCases = [
+                ['no workspaceFolder param', { rootUri: sampleWorkspaceUri }],
+                ['empty workspaceFolder param params', { WorkspaceFolders: [], rootUri: sampleWorkspaceUri }],
+            ] as const
+
+            invalidWorkspaceFolderCases.forEach(([name, input]) => {
+                it(`should return root uri for ${name}`, () => {
+                    const params = createParams(input)
+                    const result = getWorkspaceFoldersFromInit(params, consoleStub)
+                    assert.deepStrictEqual(result, [sampleWorkspaceFolder])
+                })
+            })
+            const params = createParams({ rootUri: sampleWorkspaceUri })
+            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+
+            assert.deepStrictEqual(result, [sampleWorkspaceFolder])
+        })
+
+        it('should create workspace folder from rootPath when neither workspaceFolders nor rootUri is provided', () => {
+            const rootPath = '/path/to/folder'
+            const params = createParams({ rootPath: rootPath })
+            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+
+            assert.deepStrictEqual(result, [sampleWorkspaceFolder])
+        })
+
+        it('should use uri as folder name when URI basename is empty', () => {
+            const rootUri = 'file:///'
+            const params = createParams({ rootUri })
+            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+
+            assert.deepStrictEqual(result, [{ name: rootUri, uri: rootUri }])
+        })
+
+        it('should handle Windows paths correctly', () => {
+            const rootPath = 'C:\\Users\\test\\folder'
+            const pathUri = URI.parse(rootPath).toString()
+            const params = createParams({ rootPath })
+
+            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+
+            const expectedName = path.basename(URI.parse(pathUri).fsPath)
+            assert.deepStrictEqual(result, [{ name: expectedName, uri: pathUri }])
+        })
+
+        it('should handle rootUri with special characters', () => {
+            const rootUri = 'file:///path/to/special%20project'
+            const decodedPath = URI.parse(rootUri).path
+            const folderName = path.basename(decodedPath)
+
+            const params = createParams({ rootUri })
+            const result = getWorkspaceFoldersFromInit(params, consoleStub)
+
+            assert.deepStrictEqual(result, [{ name: folderName, uri: rootUri }])
+            assert.equal('special project', result[0].name)
+        })
+
+        describe('should return empty workspaceFolder array', () => {
+            const emptyArrayCases = [
+                ['no params', {} as InitializeParams],
+                ['undefined params', undefined as unknown as InitializeParams],
+                ['null params', null as unknown as InitializeParams],
+                ['empty workspaceFolders', { workspaceFolders: [] } as unknown as InitializeParams],
+            ] as const
+
+            emptyArrayCases.forEach(([name, input]) => {
+                it(`should return empty array for ${name}`, () => {
+                    const result = getWorkspaceFoldersFromInit(input, consoleStub)
+                    assert.equal(result.length, 0)
+                })
+            })
+        })
+    })
+})

--- a/runtimes/runtimes/lsp/router/initializeUtils.ts
+++ b/runtimes/runtimes/lsp/router/initializeUtils.ts
@@ -1,0 +1,32 @@
+import { InitializeParams, WorkspaceFolder } from 'vscode-languageserver-protocol'
+import path from 'path'
+import { URI } from 'vscode-uri'
+import { RemoteConsole } from 'vscode-languageserver'
+
+export function getWorkspaceFoldersFromInit(params?: InitializeParams, console?: RemoteConsole): WorkspaceFolder[] {
+    if (!params) {
+        return []
+    }
+
+    if (params.workspaceFolders && params.workspaceFolders.length > 0) {
+        return params.workspaceFolders
+    }
+    try {
+        const getFolderName = (parsedUri: URI) => path.basename(parsedUri.fsPath) || parsedUri.toString()
+
+        if (params.rootUri) {
+            const parsedUri = URI.parse(params.rootUri)
+            const folderName = getFolderName(parsedUri)
+            return [{ name: folderName, uri: params.rootUri }]
+        }
+        if (params.rootPath) {
+            const parsedUri = URI.parse(params.rootPath)
+            const folderName = getFolderName(parsedUri)
+            return [{ name: folderName, uri: parsedUri.toString() }]
+        }
+        return []
+    } catch (error) {
+        console.log(`Error occurred when determining workspace folders: ${error}`)
+        return []
+    }
+}

--- a/runtimes/runtimes/lsp/router/initializeUtils.ts
+++ b/runtimes/runtimes/lsp/router/initializeUtils.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { URI } from 'vscode-uri'
 import { RemoteConsole } from 'vscode-languageserver'
 
-export function getWorkspaceFoldersFromInit(params?: InitializeParams, console?: RemoteConsole): WorkspaceFolder[] {
+export function getWorkspaceFoldersFromInit(console: RemoteConsole, params?: InitializeParams): WorkspaceFolder[] {
     if (!params) {
         return []
     }

--- a/runtimes/runtimes/lsp/router/initializeUtils.ts
+++ b/runtimes/runtimes/lsp/router/initializeUtils.ts
@@ -26,7 +26,7 @@ export function getWorkspaceFoldersFromInit(console: RemoteConsole, params?: Ini
         }
         return []
     } catch (error) {
-        console.log(`Error occurred when determining workspace folders: ${error}`)
+        console.error(`Error occurred when determining workspace folders: ${error}`)
         return []
     }
 }

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -78,7 +78,7 @@ export class LspRouter {
             )
         }
 
-        this.workspaceFolders = getWorkspaceFoldersFromInit(params, this.lspConnection.console)
+        this.workspaceFolders = getWorkspaceFoldersFromInit(this.lspConnection.console, params)
 
         if (this.workspaceFolders.length === 0) {
             this.lspConnection.console.info('No workspace folders found in initialization parameters')

--- a/runtimes/runtimes/lsp/router/lspServer.test.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.test.ts
@@ -2,6 +2,7 @@ import { LspServer } from './lspServer'
 import {
     CancellationToken,
     DidChangeConfigurationParams,
+    DidChangeWorkspaceFoldersParams,
     ExecuteCommandParams,
     GetConfigurationFromServerParams,
     NotificationFollowupParams,
@@ -201,6 +202,20 @@ describe('LspServer', () => {
                 // @ts-ignore
                 lspServer['notificationRouter']?.send
             )
+        })
+    })
+
+    describe('workspace', () => {
+        it('should handle workspace folder changes', () => {
+            const workspaceHandler = sandbox.stub()
+            const params: DidChangeWorkspaceFoldersParams = {
+                event: { added: [], removed: [] },
+            }
+            lspServer.setDidChangeWorkspaceFoldersHandler(workspaceHandler)
+            lspServer.sendDidChangeWorkspaceFoldersNotification(params)
+
+            assert(workspaceHandler.calledOnce)
+            assert(workspaceHandler.calledWith(params))
         })
     })
 

--- a/runtimes/runtimes/lsp/router/lspServer.ts
+++ b/runtimes/runtimes/lsp/router/lspServer.ts
@@ -19,6 +19,7 @@ import {
     ErrorCodes,
     UpdateConfigurationParams,
     HandlerResult,
+    DidChangeWorkspaceFoldersParams,
 } from '../../../protocol'
 import { InitializeParams, PartialInitializeResult } from '../../../server-interface/lsp'
 import { CredentialsType, Logging, Notification } from '../../../server-interface'
@@ -43,6 +44,7 @@ export class LspServer {
 
     private notificationRouter?: RouterByServerName<NotificationParams, NotificationFollowupParams>
     private notificationFollowupHandler?: NotificationHandler<NotificationFollowupParams>
+    private didChangeWorkspaceFoldersHandler?: NotificationHandler<DidChangeWorkspaceFoldersParams>
 
     constructor(
         private lspConnection: Connection,
@@ -99,6 +101,12 @@ export class LspServer {
         handler: RequestHandler<GetConfigurationFromServerParams, any, void>
     ): void => {
         this.getServerConfigurationHandler = handler
+    }
+
+    public setDidChangeWorkspaceFoldersHandler = (
+        handler: NotificationHandler<DidChangeWorkspaceFoldersParams>
+    ): void => {
+        this.didChangeWorkspaceFoldersHandler = handler
     }
 
     public initialize = async (
@@ -166,6 +174,10 @@ export class LspServer {
 
     public sendDidChangeConfigurationNotification = (params: DidChangeConfigurationParams): void => {
         this.didChangeConfigurationHandler?.(params)
+    }
+
+    public sendDidChangeWorkspaceFoldersNotification = (params: DidChangeWorkspaceFoldersParams): void => {
+        this.didChangeWorkspaceFoldersHandler?.(params)
     }
 
     public sendUpdateConfigurationRequest = async (

--- a/runtimes/runtimes/standalone.test.ts
+++ b/runtimes/runtimes/standalone.test.ts
@@ -156,16 +156,17 @@ describe('standalone', () => {
             describe('getWorkspaceFolder', () => {
                 it('should return undefined when no workspace folders are configured', () => {
                     const fileUri = pathToFileURL('/sample/files').href
-                    lspRouterStub.clientInitializeParams!.workspaceFolders = undefined
-
                     const result = features.workspace.getWorkspaceFolder(fileUri)
 
                     assert.strictEqual(result, undefined)
                 })
 
-                it('should return undefined when workspace folders is empty', () => {
+                it('should return undefined when workspace folders are empty', () => {
                     const fileUri = pathToFileURL('/sample/files').href
-                    lspRouterStub.clientInitializeParams!.workspaceFolders = []
+                    lspRouterStub.getAllWorkspaceFolders = sinon.stub().returns([]) as sinon.SinonStub<
+                        [],
+                        vscodeLanguageServer.WorkspaceFolder[]
+                    >
 
                     const result = features.workspace.getWorkspaceFolder(fileUri)
 
@@ -186,11 +187,32 @@ describe('standalone', () => {
                         uri: pathToFileURL(folder.uri).href,
                     }))
                     // @ts-ignore
-                    lspRouterStub.clientInitializeParams!.workspaceFolders = workspaceFolders
+                    lspRouterStub.getAllWorkspaceFolders = sinon.stub().returns(workspaceFolders)
 
                     const result = features.workspace.getWorkspaceFolder(fileUri)
 
                     assert.strictEqual(result, workspaceFolders[3])
+                })
+            })
+
+            describe('getAllWorkspaceFolders', () => {
+                it('should return workspace folders when configured', () => {
+                    let workspaceFolders = [
+                        { name: 'folder1', uri: '/folder/workspace' },
+                        { name: 'name', uri: '/tmp/tmp' },
+                        { name: 'name1', uri: '/sample/workspace/folder' },
+                        { name: 'workspace', uri: '/sample/workspace' },
+                        { name: 'name2', uri: '/sample' },
+                    ]
+                    workspaceFolders = workspaceFolders.map(folder => ({
+                        name: folder.name,
+                        uri: pathToFileURL(folder.uri).href,
+                    }))
+                    // @ts-ignore
+                    lspRouterStub.getAllWorkspaceFolders = sinon.stub().returns(workspaceFolders)
+                    const result = features.workspace.getAllWorkspaceFolders()
+
+                    assert.strictEqual(result, workspaceFolders)
                 })
             })
         })

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -186,8 +186,8 @@ export const standalone = (props: RuntimeProps) => {
                 const fileUrl = new URL(uri)
                 const normalizedFileUri = fileUrl.pathname || ''
 
-                const folders = lspRouter.clientInitializeParams!.workspaceFolders
-                if (!folders) return undefined
+                const folders = lspRouter.getAllWorkspaceFolders()
+                if (!folders || folders.length === 0) return undefined
 
                 for (const folder of folders) {
                     const folderUrl = new URL(folder.uri)
@@ -196,6 +196,9 @@ export const standalone = (props: RuntimeProps) => {
                         return folder
                     }
                 }
+            },
+            getAllWorkspaceFolders: () => {
+                return lspRouter.getAllWorkspaceFolders()
             },
             fs: {
                 copyFile: async (src, dest, options?) => {
@@ -341,8 +344,7 @@ export const standalone = (props: RuntimeProps) => {
                 workspace: {
                     applyWorkspaceEdit: params => lspConnection.workspace.applyEdit(params),
                     getConfiguration: section => lspConnection.workspace.getConfiguration(section),
-                    onDidChangeWorkspaceFolders: handler =>
-                        lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler),
+                    onDidChangeWorkspaceFolders: lspServer.setDidChangeWorkspaceFoldersHandler,
                     onDidCreateFiles: params => lspConnection.workspace.onDidCreateFiles(params),
                     onDidDeleteFiles: params => lspConnection.workspace.onDidDeleteFiles(params),
                     onDidRenameFiles: params => lspConnection.workspace.onDidRenameFiles(params),

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -19,6 +19,7 @@ export type Workspace = {
     getTextDocument: (uri: string) => Promise<TextDocument | undefined>
     getAllTextDocuments: () => Promise<TextDocument[]>
     getWorkspaceFolder: (uri: string) => WorkspaceFolder | null | undefined
+    getAllWorkspaceFolders: () => WorkspaceFolder[]
     fs: {
         /**
          * Copies a file from src to dest. Dest is overwritten if it already exists.

--- a/runtimes/server-interface/workspace.ts
+++ b/runtimes/server-interface/workspace.ts
@@ -18,7 +18,9 @@ interface Dirent {
 export type Workspace = {
     getTextDocument: (uri: string) => Promise<TextDocument | undefined>
     getAllTextDocuments: () => Promise<TextDocument[]>
+    /** Gets workspace folder associated with the given file uri */
     getWorkspaceFolder: (uri: string) => WorkspaceFolder | null | undefined
+    /** Gets all workspace folders */
     getAllWorkspaceFolders: () => WorkspaceFolder[]
     fs: {
         /**


### PR DESCRIPTION
## Description
Currently in a lot of downstream servers, the `workspace.getWorkspaceFolder` method is used for path resolution. This only relied on the `initializeParams.workspaceFolder` value which did not take into account workspace folder changes(did not listen to `didChangeWorkspaceFolders`) that could have happened during the session.
In addition with VS client as mentioned in https://github.com/aws/language-servers/pull/1210, the workspaceFolder value is not set(more details in that PR) however it does specify that information via `rootUri` and `rootPath`. The utility class from that PR has now been moved centrally to this repo.
A new `getAllWorkspaceFolders()` call has been added as a common utility that servers downstream can use as single source of truth to get latest information of workspaceFolders available to the lsp server.
A follow-up PR to language-servers repo will utilize this change.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
