### PR TITLE
fix: add PII filtering for process crash error reporting

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -84,6 +84,7 @@ import { getClientInitializeParamsHandlerFactory } from './util/lspCacheUtil'
 import { makeProxyConfigv2Standalone, makeProxyConfigv3Standalone } from './util/standalone/proxyUtil'
 import { newAgent } from './agent'
 import { ShowSaveFileDialogRequestType } from '../protocol/window'
+import { getTelemetryReasonDesc } from './util/shared'
 
 // Honor shared aws config file
 if (checkAWSConfigFile()) {
@@ -111,8 +112,10 @@ function setupCrashMonitoring(telemetryEmitter?: (metric: MetricEvent) => void) 
                     name: 'runtime_processCrash',
                     result: 'Failed',
                     errorData: {
-                        reason: err.toString(),
-                        errorCode: origin,
+                        reason: origin,
+                    },
+                    data: {
+                        reasonDesc: getTelemetryReasonDesc(err),
                     },
                 })
             } catch (telemetryError) {

--- a/runtimes/runtimes/util/shared.ts
+++ b/runtimes/runtimes/util/shared.ts
@@ -1,0 +1,109 @@
+/**
+ * Partial port of implementation in AWS Toolkit for VSCode
+ * https://github.com/aws/aws-toolkit-vscode/blob/c22efa03e73b241564c8051c35761eb8620edb83/packages/core/src/shared/errors.ts#L455
+ *
+ * Gets the (partial) error message detail for the `reasonDesc` field.
+ *
+ * @param err Error object, or message text
+ */
+export function getTelemetryReasonDesc(err: Error | undefined): string | undefined {
+    if (err === undefined) {
+        return undefined
+    }
+
+    const msg = scrubNames(err.message || '')
+
+    // Truncate message as these strings can be very long.
+    return msg && msg.length > 0 ? msg.substring(0, 350) : undefined
+}
+
+/**
+ * Port of implementation in AWS Toolkit for VSCode
+ * https://github.com/aws/aws-toolkit-vscode/blob/c22efa03e73b241564c8051c35761eb8620edb83/packages/core/src/shared/errors.ts#L379
+ *
+ * Removes potential PII from a string, for logging/telemetry.
+ *
+ * Examples:
+ * - "Failed to save c:/fooß/bar/baz.txt" => "Failed to save c:/xß/x/x.txt"
+ * - "EPERM for dir c:/Users/user1/.aws/sso/cache/abc123.json" => "EPERM for dir c:/Users/x/.aws/sso/cache/x.json"
+ */
+export function scrubNames(s: string, username?: string) {
+    let r = ''
+    const fileExtRe = /\.[^.\/]+$/
+    const slashdot = /^[~.]*[\/\\]*/
+
+    /** Allowlisted filepath segments. */
+    const keep = new Set<string>([
+        '~',
+        '.',
+        '..',
+        '.aws',
+        'aws',
+        'sso',
+        'cache',
+        'credentials',
+        'config',
+        'Users',
+        'users',
+        'home',
+        'tmp',
+        'aws-toolkit-vscode',
+        'globalStorage', // from vscode globalStorageUri
+        crashMonitoringDirName, // from vscode extension https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/shared/constants.ts#L196
+    ])
+
+    if (username && username.length > 2) {
+        s = s.replaceAll(username, 'x')
+    }
+
+    // Replace contiguous whitespace with 1 space.
+    s = s.replace(/\s+/g, ' ')
+
+    // 1. split on whitespace.
+    // 2. scrub words that match username or look like filepaths.
+    const words = s.split(/\s+/)
+    for (const word of words) {
+        const pathSegments = word.split(/[\/\\]/)
+        if (pathSegments.length < 2) {
+            // Not a filepath.
+            r += ' ' + word
+            continue
+        }
+
+        // Replace all (non-allowlisted) ASCII filepath segments with "x".
+        // "/foo/bar/aws/sso/" => "/x/x/aws/sso/"
+        let scrubbed = ''
+        // Get the frontmatter ("/", "../", "~/", or "./").
+        const start = word.trimStart().match(slashdot)?.[0] ?? ''
+        pathSegments[0] = pathSegments[0].trimStart().replace(slashdot, '')
+        for (const seg of pathSegments) {
+            if (driveLetterRegex.test(seg)) {
+                scrubbed += seg
+            } else if (keep.has(seg)) {
+                scrubbed += '/' + seg
+            } else {
+                // Save the first non-ASCII (unicode) char, if any.
+                const nonAscii = seg.match(/[^\p{ASCII}]/u)?.[0] ?? ''
+                // Replace all chars (except [^…]) with "x" .
+                const ascii = seg.replace(/[^$[\](){}:;'" ]+/g, 'x')
+                scrubbed += `/${ascii}${nonAscii}`
+            }
+        }
+
+        // includes leading '.', eg: '.json'
+        const fileExt = pathSegments[pathSegments.length - 1].match(fileExtRe) ?? ''
+        r += ` ${start.replace(/\\/g, '/')}${scrubbed.replace(/^[\/\\]+/, '')}${fileExt}`
+    }
+
+    return r.trim()
+}
+
+/**
+ * Names of directories relevant to the crash reporting functionality.
+ *
+ * Moved here to resolve circular dependency issues.
+ */
+const crashMonitoringDirName = 'crashMonitoring'
+
+/** Matches Windows drive letter ("C:"). */
+const driveLetterRegex = /^[a-zA-Z]\:/

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "CommonJS",
-        "target": "ES2016",
+        "target": "ES2021",
         "declaration": true,
         "sourceMap": true,
         "skipLibCheck": true,


### PR DESCRIPTION
## Problem
Process crash telemetry missed PII filtering when reporting error message.

## Solution
Updated `runtime_processCrash` format to:
* emit origin in `errorData.reason` field
* emit error message in `data.reasonDesc` field and apply PII filtering to it.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
