### PR TITLE
fix: make test independent of sdk version

### DIFF
--- a/runtimes/runtimes/operational-telemetry/operational-telemetry-service.test.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry-service.test.ts
@@ -63,21 +63,16 @@ describe('OperationalTelemetryService with OpenTelemetry SDK', () => {
         await promisify(server.close.bind(server))()
     })
 
-    function makeMetricsRequestDeterministic(jsonStr: string): string {
+    function makeRequestDeterministic(jsonStr: string): string {
         return jsonStr
-            .replace(/"(startTimeUnixNano|timeUnixNano)":"[0-9]+"/g, '"$1":"1746710710801000000"')
-            .replace(
-                /"key":"sessionId","value":{"stringValue":"[^"]+"/g,
-                '"key":"sessionId","value":{"stringValue":"80fd44e9-55e5-4b80-a08a-4f2bcaf2e1b9"'
-            )
-    }
-
-    function makeLogsRequestDeterministic(jsonStr: string): string {
-        return jsonStr
-            .replace(/"(timeUnixNano|observedTimeUnixNano)":"[0-9]+"/g, '"$1":"1746710710801000000"')
+            .replace(/"(startTimeUnixNano|timeUnixNano|observedTimeUnixNano)":"[0-9]+"/g, '"$1":"1746710710801000000"')
             .replace(
                 /"key":"sessionId","value":{"stringValue":"[^"]+"}}/g,
                 '"key":"sessionId","value":{"stringValue":"80fd44e9-55e5-4b80-a08a-4f2bcaf2e1b9"}}'
+            )
+            .replace(
+                /"key":"telemetry.sdk.version","value":{"stringValue":"[^"]+"/g,
+                '"key":"telemetry.sdk.version","value":{"stringValue":"2.0.0"' // Changes with the version of the sdk in package.json
             )
     }
 
@@ -130,7 +125,7 @@ describe('OperationalTelemetryService with OpenTelemetry SDK', () => {
         assert(request.method === 'POST', 'Request should use POST method')
 
         const requestBodyStr = JSON.stringify(request.body)
-        const normalizedBody = makeMetricsRequestDeterministic(requestBodyStr)
+        const normalizedBody = makeRequestDeterministic(requestBodyStr)
         assert.deepStrictEqual(JSON.parse(normalizedBody), resourceMetrics)
     })
 
@@ -151,7 +146,7 @@ describe('OperationalTelemetryService with OpenTelemetry SDK', () => {
         assert(request.method === 'POST', 'Request should use POST method')
         const requestBodyStr = JSON.stringify(request.body)
 
-        const normalizedBody = makeLogsRequestDeterministic(requestBodyStr)
+        const normalizedBody = makeRequestDeterministic(requestBodyStr)
 
         assert.deepStrictEqual(JSON.parse(normalizedBody), resourceLogs)
     })


### PR DESCRIPTION
## Problem
We currently need to update test values whenever we update OpenTelemetry SDK dependencies.

## Solution
Assigned constant values to test requests to make them independent of SDK versions.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
