### PR TITLE
fix: adding summary to ChatMessage

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -420,24 +420,23 @@ export interface InlineChatResultParams {
 }
 
 // history
-export type TextBasedFilterOption = {
-    type: 'textarea' | 'textinput' | 'numericinput'
+export interface FilterOptionBase {
     placeholder?: string
     title?: string
     description?: string
     icon?: IconType
 }
 
-export type OptionBasedFilterOption = {
+export type TextBasedFilterOption = FilterOptionBase & {
+    type: 'textarea' | 'textinput' | 'numericinput'
+}
+
+export type OptionBasedFilterOption = FilterOptionBase & {
     type: 'select' | 'radiogroup'
-    placeholder?: string
-    title?: string
-    description?: string
     options: Array<{
         value: string
         label: string
     }>
-    icon?: IconType
 }
 
 export type BaseFilterOption = TextBasedFilterOption | OptionBasedFilterOption

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -149,6 +149,10 @@ export interface ChatMessage {
         title?: string
         content: SourceLink[]
     }
+    summary?: {
+        content?: ChatMessage
+        collapsedContent?: ChatMessage[]
+    } | null
     followUp?: {
         text?: string
         options?: ChatItemAction[]

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -152,7 +152,7 @@ export interface ChatMessage {
     summary?: {
         content?: ChatMessage
         collapsedContent?: ChatMessage[]
-    } | null
+    }
     followUp?: {
         text?: string
         options?: ChatItemAction[]

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -421,18 +421,28 @@ export interface InlineChatResultParams {
 
 // history
 export type TextBasedFilterOption = {
-    type: 'textarea' | 'textinput' | 'select' | 'numericinput' | 'radiogroup'
+    type: 'textarea' | 'textinput' | 'numericinput'
     placeholder?: string
     title?: string
     description?: string
-    options?: Array<{
+    icon?: IconType
+}
+
+export type OptionBasedFilterOption = {
+    type: 'select' | 'radiogroup'
+    placeholder?: string
+    title?: string
+    description?: string
+    options: Array<{
         value: string
         label: string
     }>
     icon?: IconType
 }
+
+export type BaseFilterOption = TextBasedFilterOption | OptionBasedFilterOption
 export type FilterValue = string
-export type FilterOption = { id: string } & TextBasedFilterOption
+export type FilterOption = { id: string } & BaseFilterOption
 export interface Action {
     id: string
     icon?: IconType
@@ -506,6 +516,8 @@ export interface ConversationClickResult extends ConversationClickParams {
 
 export interface McpServerClickParams {
     id: string
+    title?: string
+    optionsValues?: Record<string, string>
 }
 
 export interface McpServerClickResult extends McpServerClickParams {

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -421,8 +421,14 @@ export interface InlineChatResultParams {
 
 // history
 export type TextBasedFilterOption = {
-    type: 'textarea' | 'textinput'
+    type: 'textarea' | 'textinput' | 'select' | 'numericinput' | 'radiogroup'
     placeholder?: string
+    title?: string
+    description?: string
+    options?: Array<{
+        value: string
+        label: string
+    }>
     icon?: IconType
 }
 export type FilterValue = string
@@ -468,11 +474,14 @@ export interface DetailedListItem {
     title: string
     description?: string
     groupActions?: boolean
+    children?: DetailedListGroup[]
 }
 
 export interface DetailedListGroup {
     groupName?: string
     children?: DetailedListItem[]
+    actions?: Action[]
+    icon?: IconType
 }
 
 export interface ListMcpServersResult {
@@ -500,7 +509,21 @@ export interface McpServerClickParams {
 }
 
 export interface McpServerClickResult extends McpServerClickParams {
-    success: boolean
+    filterOptions?: FilterOption[] | null
+    filterActions?: Button[]
+    list?: DetailedListGroup[]
+    header?: {
+        title?: string
+        icon?: IconType
+        status?: {
+            icon?: IconType
+            title?: string
+            description?: string
+            status?: Status
+        }
+        description?: string
+        actions?: Action[]
+    }
 }
 
 export type TabBarAction = 'export'


### PR DESCRIPTION
## Notes
- Adding missing `summary` field to `ChatMessage` for MCP chat summary UX.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
