### PR TITLE
fix: remove the supports workspace check for didChangeWorkspaceFolder event

### DIFF
--- a/runtimes/runtimes/auth/auth.test.ts
+++ b/runtimes/runtimes/auth/auth.test.ts
@@ -83,6 +83,7 @@ const serverLspConnectionMock = {
         onDidCreateFiles: (handler: any) => {},
         onDidDeleteFiles: (handler: any) => {},
         onDidRenameFiles: (handler: any) => {},
+        onDidChangeWorkspaceFolders: (handler: any) => {},
     },
     onDidSaveTextDocument: (handler: NotificationHandler<DidSaveTextDocumentParams>) => {},
     onDidChangeConfiguration: (handler: NotificationHandler<DidChangeConfigurationParams>) => {},

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -231,8 +231,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
             workspace: {
                 applyWorkspaceEdit: params => lspConnection.workspace.applyEdit(params),
                 getConfiguration: section => lspConnection.workspace.getConfiguration(section),
-                onDidChangeWorkspaceFolders: handler =>
-                    lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.method, handler),
+                onDidChangeWorkspaceFolders: lspServer.setDidChangeWorkspaceFoldersHandler,
                 onDidCreateFiles: lspServer.setDidCreateFilesHandler,
                 onDidDeleteFiles: lspServer.setDidDeleteFilesHandler,
                 onDidRenameFiles: lspServer.setDidRenameFilesHandler,

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -952,6 +952,7 @@ describe('LspRouter', () => {
                 onDidCreateFiles: (handler: any) => {},
                 onDidDeleteFiles: (handler: any) => {},
                 onDidRenameFiles: (handler: any) => {},
+                onDidChangeWorkspaceFolders: (handler: any) => {},
             },
             onDidSaveTextDocument: (handler: any) => {},
             onInitialize: (handler: any) => {},

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -643,28 +643,6 @@ describe('LspRouter', () => {
     })
 
     describe('didChangeWorkspaceFolders', () => {
-        it('should warn and return when client does not support workspace folders', () => {
-            lspRouter.clientInitializeParams = {
-                capabilities: {
-                    workspace: {
-                        workspaceFolders: false,
-                    },
-                },
-            } as InitializeParams
-
-            const event = {
-                added: [{ name: 'added', uri: 'file:///added' }],
-                removed: [],
-            }
-
-            lspRouter.didChangeWorkspaceFolders(event)
-
-            sinon.assert.calledWith(
-                lspConnection.console.warn as sinon.SinonStub,
-                "Client doesn't support sending workspace folder change events. Ignoring workspace folder changes."
-            )
-        })
-
         it('should update workspace folders and route notification to servers', () => {
             const initialFolders = [
                 { name: 'initial', uri: 'file:///initial' },

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -59,6 +59,7 @@ export class LspRouter {
         lspConnection.workspace.onDidCreateFiles(this.didCreateFiles)
         lspConnection.workspace.onDidDeleteFiles(this.didDeleteFiles)
         lspConnection.workspace.onDidRenameFiles(this.didRenameFiles)
+        // Note: Using raw notification instead of workspace.OnDidWorkspaceChange to avoid downstream VSCode language server errors when workspaceFolders is undefined(clients like VS)
         lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.type, params => {
             this.didChangeWorkspaceFolders(params.event)
         })

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -29,6 +29,7 @@ import {
     DeleteFilesParams,
     RenameFilesParams,
     DidSaveTextDocumentParams,
+    DidChangeWorkspaceFoldersNotification,
 } from '../../../protocol'
 import { Connection } from 'vscode-languageserver/node'
 import { LspServer } from './lspServer'
@@ -58,6 +59,9 @@ export class LspRouter {
         lspConnection.workspace.onDidCreateFiles(this.didCreateFiles)
         lspConnection.workspace.onDidDeleteFiles(this.didDeleteFiles)
         lspConnection.workspace.onDidRenameFiles(this.didRenameFiles)
+        lspConnection.onNotification(DidChangeWorkspaceFoldersNotification.type, params => {
+            this.didChangeWorkspaceFolders(params.event)
+        })
         lspConnection.onDidSaveTextDocument(this.didSaveTextDocument)
     }
 
@@ -215,12 +219,6 @@ ${JSON.stringify({ ...result.capabilities, ...result.awsServerCapabilities })}`
             // Ask the client to notify the server on configuration changes
             this.lspConnection.client.register(DidChangeConfigurationNotification.type, undefined)
         }
-
-        // Register for workspace folder changes only if supported
-        if (workspaceCapabilities?.workspaceFolders === true) {
-            this.lspConnection.workspace.onDidChangeWorkspaceFolders(this.didChangeWorkspaceFolders)
-        }
-
         this.routeNotificationToAllServers((server, params) => server.sendInitializedNotification(params), params)
     }
 

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -136,15 +136,6 @@ ${JSON.stringify({ ...result.capabilities, ...result.awsServerCapabilities })}`
     }
 
     didChangeWorkspaceFolders = (event: WorkspaceFoldersChangeEvent): void => {
-        const supportsWorkspaceFolders = this.clientInitializeParams?.capabilities.workspace?.workspaceFolders === true
-
-        if (!supportsWorkspaceFolders) {
-            this.lspConnection.console.warn(
-                "Client doesn't support sending workspace folder change events. Ignoring workspace folder changes."
-            )
-            return
-        }
-
         this.workspaceFolders = this.workspaceFolders.filter(
             folder => !event.removed.some(removed => removed.uri === folder.uri)
         )


### PR DESCRIPTION
## Problem
PR #509 added a check to validate whether the client supports workspaceFolders before handling the didChangeWorkspaceFolders event. This fails for VS as VS does not send the workspaceFolder value
## Solution
Check has been removed as it is now assumed that whenever this is invoked clients intentionally want to send this event.
This also unblocks VS which sends the workspaceFolder information with rootUri of the initializeParams
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
