### PR TITLE
fix: support nested mcp server click param option values

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -517,10 +517,16 @@ export interface ConversationClickResult extends ConversationClickParams {
     success: boolean
 }
 
+interface OptionValueItem {
+    [key: string]: string
+}
+
+type OptionValueType = string | OptionValueItem[]
+
 export interface McpServerClickParams {
     id: string
     title?: string
-    optionsValues?: Record<string, string>
+    optionsValues?: Record<string, OptionValueType>
 }
 
 export interface McpServerClickResult extends McpServerClickParams {


### PR DESCRIPTION
## Problem

The MCPServer click item can be 

```
{
    "id": "save-mcp",
    "title": "Save configuration",
    "optionsValues": {
        "scope": "",
        "name": "p",
        "transport": "yes",
        "command": "npx",
        "args": [{ "arg_key": "@playwright/mcp@latest" }],
        "env_variables": [{ "env_var_name": "", "env_var_value": "" }],
        "timeout": "60"
    }
}
```
that current protocol cannot parse. It happens when you add a MCP server with args and env variables. 

## Solution

Support JSON data as mentioned above. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
