### PR TITLE
Revert "fix: support nested mcp server click param option values"

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -517,16 +517,10 @@ export interface ConversationClickResult extends ConversationClickParams {
     success: boolean
 }
 
-interface OptionValueItem {
-    [key: string]: string
-}
-
-type OptionValueType = string | OptionValueItem[]
-
 export interface McpServerClickParams {
     id: string
     title?: string
-    optionsValues?: Record<string, OptionValueType>
+    optionsValues?: Record<string, string>
 }
 
 export interface McpServerClickResult extends McpServerClickParams {


### PR DESCRIPTION
Reverts aws/language-server-runtimes#523

In the language server, we are parsing the string to get env var and arg key

See 
```
 // Handle the case where argsValue might be a direct array or another type
        try {
            // Try to safely access and process the value
            const argsArray = Array.isArray(argsValue) ? argsValue : []
            args = argsArray
                .map((item: any) => {
                    return typeof item === 'object' && item !== null && 'arg_key' in item ? String(item.arg_key) : ''
                })
                .filter(Boolean)
        } catch (e) {
            this.#features.logging.warn(`Failed to process args: ${e}`)
        }

        // Process env_variables to Record<string, string>
        let env: Record<string, string> = {}
        const envValue = params.optionsValues.env_variables

        // Handle the case where envValue might be a direct array or another type
        try {
            // Try to safely access and process the value
            const envArray = Array.isArray(envValue) ? envValue : []
            env = envArray.reduce((acc: Record<string, string>, item: any) => {
                if (item && typeof item === 'object' && 'env_var_name' in item && 'env_var_value' in item) {
                    acc[String(item.env_var_name)] = String(item.env_var_value)
                }
                return acc
            }, {})
        } catch (e) {
            this.#features.logging.warn(`Failed to process env variables: ${e}`)
        }


```