### PR TITLE
feat: add modelId to chatOptionsUpdateParams

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -368,6 +368,7 @@ export interface ChatUpdateParams {
  */
 export interface ChatOptionsUpdateParams {
     chatNotifications?: ChatMessage[]
+    modelId?: string
 }
 
 export type FileAction = 'accept-change' | 'reject-change'


### PR DESCRIPTION
## Problem

Server needs to be able to tell chat client what the latest selected modelId was

## Solution

Add `modelId` to the existing `ChatOptionsUpdateParams`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
