### PR TITLE
feat: adding additional fields to LogInlineCompletionSessionResultsParams

### DIFF
--- a/types/inlineCompletionWithReferences.ts
+++ b/types/inlineCompletionWithReferences.ts
@@ -101,4 +101,13 @@ export interface LogInlineCompletionSessionResultsParams {
      * Length of additional characters inputed by user from when the trigger happens to when the user decision was made
      */
     typeaheadLength?: number
+    /**
+     * The number of new characters of code that will be added by the suggestion if accepted, excluding any characters
+     * from the beginning of the suggestion that the user had typed in after the trigger.
+     */
+    addedCharacterCount?: number
+    /**
+     * The number of characters of existing code that will be removed by the suggestion if accepted.
+     */
+    deletedCharacterCount?: number
 }


### PR DESCRIPTION
## Problem

we need to populate new fields via user decision for NEP

## Solution

adding additional fields to LogInlineCompletionSessionResultsParams for NEP telemetry events

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
