### PR TITLE
feat: enable operational telemetry

### DIFF
--- a/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
@@ -27,7 +27,6 @@ export class OperationalTelemetryService implements OperationalTelemetry {
     private static instance: OperationalTelemetryService
     private readonly RUNTIMES_SCOPE_NAME = 'language-server-runtimes'
     private readonly FIVE_MINUTES = 300000
-    private readonly FIVE_SECONDS = 5000
     private readonly baseResource: Resource
     private readonly endpoint: string
     private telemetryOptOut: boolean
@@ -46,7 +45,7 @@ export class OperationalTelemetryService implements OperationalTelemetry {
 
     private constructor(config: OperationalTelemetryConfig) {
         this.exportIntervalMillis = config.exportIntervalMillis ?? this.FIVE_MINUTES
-        this.scheduledDelayMillis = config.scheduledDelayMillis ?? this.FIVE_SECONDS
+        this.scheduledDelayMillis = config.scheduledDelayMillis ?? this.FIVE_MINUTES
 
         this.lspConsole = config.lspConsole
 

--- a/runtimes/runtimes/util/telemetryLspServer.ts
+++ b/runtimes/runtimes/util/telemetryLspServer.ts
@@ -7,8 +7,9 @@ import { RuntimeProps } from '../runtime'
 import { InitializeParams, InitializeResult } from '../../protocol'
 import { Runtime } from '../../server-interface'
 import { totalmem } from 'os'
+import { OperationalTelemetryService } from '../operational-telemetry/operational-telemetry-service'
 
-const DEFAULT_TELEMETRY_GATEWAY_ENDPOINT = ''
+const DEFAULT_TELEMETRY_ENDPOINT = 'https://telemetry.aws-language-servers.us-east-1.amazonaws.com'
 
 function setMemoryUsageTelemetry() {
     const optel = OperationalTelemetryProvider.getTelemetryForScope(TELEMETRY_SCOPES.RUNTIMES)
@@ -45,18 +46,18 @@ export function getTelemetryLspServer(
     lspServer.setInitializeHandler(async (params: InitializeParams): Promise<InitializeResult> => {
         const optOut = params.initializationOptions?.telemetryOptOut ?? true // telemetry disabled if option not provided
 
-        const endpoint = runtime.getConfiguration('TELEMETRY_GATEWAY_ENDPOINT') ?? DEFAULT_TELEMETRY_GATEWAY_ENDPOINT
+        const endpoint = runtime.getConfiguration('TELEMETRY_GATEWAY_ENDPOINT') ?? DEFAULT_TELEMETRY_ENDPOINT
 
-        // const optel = OperationalTelemetryService.getInstance({
-        //     serviceName: props.name,
-        //     serviceVersion: props.version,
-        //     extendedClientInfo: params.initializationOptions?.aws?.clientInfo,
-        //     lspConsole: lspConnection.console,
-        //     endpoint: endpoint,
-        //     telemetryOptOut: optOut,
-        // })
+        const optel = OperationalTelemetryService.getInstance({
+            serviceName: props.name,
+            serviceVersion: props.version,
+            extendedClientInfo: params.initializationOptions?.aws?.clientInfo,
+            lspConsole: lspConnection.console,
+            endpoint: endpoint,
+            telemetryOptOut: optOut,
+        })
 
-        // OperationalTelemetryProvider.setTelemetryInstance(optel)
+        OperationalTelemetryProvider.setTelemetryInstance(optel)
 
         setServerCrashTelemetryListeners()
         setMemoryUsageTelemetry()


### PR DESCRIPTION
## Problem
We need to begin sending operational telemetry for users of our runtime. Telemetry sharing is disabled by default when no configuration is specified.

## Solution
* Initialized OperationalTelemetryService during LSP initialization
* Increased interval for exporting logs to backend
* Added telemetry endpoint

## Testing
Manually tested with "CodeWhisperer Agentic Server Token" extension in [language-servers](https://github.com/aws/language-servers/blob/main/.vscode/launch.json). Used `TELEMETRY_GATEWAY_ENDPOINT` to direct telemetry to a non-prod endpoint. Added 'telemetryOptOut' in `initializationOptions` in [activation.ts](https://github.com/aws/language-servers/blob/main/client/vscode/src/activation.ts) file.
Tested scenarios:
* `telemetryOptOut: true` - OpenTelemetry SDK is not initialized and telemetry is not exported to the backend.
* `telemetryOptOut: false` -  OpenTelemetry SDK logs appear at Debug level, indicating successful SDK initialization. Metrics are sent to the backend at the desired interval and are accepted in the expected format.
* `telemetryOptOut` not specified - Results were the same as `telemetryOptOut: true`.

Additionally, confirmed that sending data to the actual prod telemetry endpoint works.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
