### PR TITLE
feat: add tabId to ChatOptionsUpdateParams

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -366,6 +366,7 @@ export interface ChatUpdateParams {
  * Server-initiated chat metadata updates.
  */
 export interface ChatOptionsUpdateParams {
+    tabId: string
     /**
      * Processes changes of developer profiles.
      */


### PR DESCRIPTION
## Problem

ChatOptionsUpdate notification needs to be able to set options for a specific tab

## Solution

Add tabId to `ChatOptionsUpdateParams`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
