### PR TITLE
fix: use logging instead of lspConsole

### DIFF
--- a/runtimes/runtimes/operational-telemetry/operational-telemetry-service.test.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry-service.test.ts
@@ -80,7 +80,7 @@ describe('OperationalTelemetryService with OpenTelemetry SDK', () => {
         return {
             serviceName: mockServiceName,
             serviceVersion: mockServiceVersion,
-            lspConsole: {
+            logging: {
                 debug: () => {},
                 error: () => {},
                 info: () => {},

--- a/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
@@ -3,9 +3,8 @@ import { OperationalEventAttributes, OperationalTelemetry } from './operational-
 import { diag, DiagLogLevel, metrics } from '@opentelemetry/api'
 import { Resource, resourceFromAttributes } from '@opentelemetry/resources'
 import { randomUUID } from 'crypto'
-import { RemoteConsole } from 'vscode-languageserver'
 import { logs } from '@opentelemetry/api-logs'
-import { ExtendedClientInfo } from '../../server-interface'
+import { ExtendedClientInfo, Logging } from '../../server-interface'
 import { OperationalTelemetryResource, MetricName } from './types/generated/telemetry'
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
@@ -16,7 +15,7 @@ type OperationalTelemetryConfig = {
     serviceName: string
     serviceVersion?: string
     extendedClientInfo?: ExtendedClientInfo
-    lspConsole: RemoteConsole
+    logging: Logging
     endpoint: string
     telemetryOptOut: boolean
     exportIntervalMillis?: number
@@ -34,7 +33,7 @@ export class OperationalTelemetryService implements OperationalTelemetry {
     private readonly scheduledDelayMillis: number
     private loggerProvider: LoggerProvider | null = null
     private meterProvider: MeterProvider | null = null
-    private readonly lspConsole: RemoteConsole
+    private readonly logging: Logging
 
     static getInstance(config: OperationalTelemetryConfig): OperationalTelemetryService {
         if (!OperationalTelemetryService.instance) {
@@ -47,7 +46,7 @@ export class OperationalTelemetryService implements OperationalTelemetry {
         this.exportIntervalMillis = config.exportIntervalMillis ?? this.FIVE_MINUTES
         this.scheduledDelayMillis = config.scheduledDelayMillis ?? this.FIVE_MINUTES
 
-        this.lspConsole = config.lspConsole
+        this.logging = config.logging
 
         const operationalTelemetryResource: OperationalTelemetryResource = {
             'server.name': config.serviceName,
@@ -135,11 +134,11 @@ export class OperationalTelemetryService implements OperationalTelemetry {
     private startApi() {
         diag.setLogger(
             {
-                debug: message => this.lspConsole.debug(message),
-                error: message => this.lspConsole.error(message),
-                info: message => this.lspConsole.info(message),
-                verbose: message => this.lspConsole.log(message),
-                warn: message => this.lspConsole.warn(message),
+                debug: message => this.logging.debug(message),
+                error: message => this.logging.error(message),
+                info: message => this.logging.info(message),
+                verbose: message => this.logging.log(message),
+                warn: message => this.logging.warn(message),
             },
             DiagLogLevel.ALL
         )

--- a/runtimes/runtimes/util/telemetryLspServer.ts
+++ b/runtimes/runtimes/util/telemetryLspServer.ts
@@ -45,19 +45,22 @@ export function getTelemetryLspServer(
 
     lspServer.setInitializeHandler(async (params: InitializeParams): Promise<InitializeResult> => {
         const optOut = params.initializationOptions?.telemetryOptOut ?? true // telemetry disabled if option not provided
-
         const endpoint = runtime.getConfiguration('TELEMETRY_GATEWAY_ENDPOINT') ?? DEFAULT_TELEMETRY_ENDPOINT
+
+        logging.debug(`Configuring Runtimes OperationalTelemetry with endpoint: ${endpoint}`)
 
         const optel = OperationalTelemetryService.getInstance({
             serviceName: props.name,
             serviceVersion: props.version,
             extendedClientInfo: params.initializationOptions?.aws?.clientInfo,
-            lspConsole: lspConnection.console,
+            logging: logging,
             endpoint: endpoint,
             telemetryOptOut: optOut,
         })
 
         OperationalTelemetryProvider.setTelemetryInstance(optel)
+
+        logging.info(`Initialized Runtimes OperationalTelemetry with optOut=${optOut}`)
 
         setServerCrashTelemetryListeners()
         setMemoryUsageTelemetry()
@@ -73,6 +76,7 @@ export function getTelemetryLspServer(
         })
 
         if (typeof optOut === 'boolean') {
+            logging.info(`Updating Runtimes OperationalTelemetry with optOut=${optOut}`)
             OperationalTelemetryProvider.getTelemetryForScope('').toggleOptOut(optOut)
             setMemoryUsageTelemetry()
         }


### PR DESCRIPTION
## Problem
Using Logging feature allows to set log level in the initialize request and modify it in the configuration request.

### Testing
Tested with language-server extensions and verified log level modifications.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
