### PR TITLE
feat: adding isInlineEdit to LogInlineCompletionSessionResultsParams

### DIFF
--- a/types/inlineCompletionWithReferences.ts
+++ b/types/inlineCompletionWithReferences.ts
@@ -110,4 +110,8 @@ export interface LogInlineCompletionSessionResultsParams {
      * The number of characters of existing code that will be removed by the suggestion if accepted.
      */
     deletedCharacterCount?: number
+    /**
+     * Flag to indicate this is an edit suggestion rather than a standard inline completion.
+     */
+    isInlineEdit?: boolean
 }


### PR DESCRIPTION
## Problem

adding isInlineEdit to LogInlineCompletionSessionResultsParams

## Solution

adding isInlineEdit to LogInlineCompletionSessionResultsParams

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
