### PR TITLE
fix: set versions for build tools due to inconsistencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0",
+        "npm": ">=7.0.0 <11.0.0"
     },
     "scripts": {
         "clean": "ts-node ./script/clean.ts",


### PR DESCRIPTION
## Problem
Build environments across development machines were inconsistent due to undefined npm version requirements. This led to potential build failures and unexpected behavior when developers used different npm versions.

## Solution
• Added explicit npm version constraint in package.json (>=7.0.0 <11.0.0)
• Added .npmrc with engine-strict=true to enforce version requirements

These changes ensure that all developers use compatible npm versions, preventing build issues caused by incompatible tool versions.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.