### PR TITLE
feat(runtimes): add auto-discovery for OS proxy settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
                 "typescript": "^5.8.3"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=18.0.0",
+                "npm": ">=7.0.0 <11.0.0"
             }
         },
         "chat-client-ui-types": {
@@ -1169,7 +1170,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -1200,6 +1200,59 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "license": "ISC"
+        },
+        "node_modules/are-we-there-yet": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+            "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+            "deprecated": "This package is no longer supported.",
+            "license": "ISC",
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+            }
+        },
+        "node_modules/are-we-there-yet/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "license": "MIT"
+        },
+        "node_modules/are-we-there-yet/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/are-we-there-yet/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "license": "MIT"
+        },
+        "node_modules/are-we-there-yet/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
             }
         },
         "node_modules/argparse": {
@@ -1235,7 +1288,6 @@
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "possible-typed-array-names": "^1.0.0"
@@ -1249,7 +1301,6 @@
         },
         "node_modules/aws-sdk": {
             "version": "2.1692.0",
-            "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1272,7 +1323,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
             "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
@@ -1285,7 +1335,6 @@
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -1312,6 +1361,64 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bl/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/bl/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/bl/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/brace-expansion": {
@@ -1342,7 +1449,6 @@
         },
         "node_modules/buffer": {
             "version": "4.9.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.0.2",
@@ -1358,12 +1464,10 @@
         },
         "node_modules/buffer/node_modules/isarray": {
             "version": "1.0.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/call-bind": {
             "version": "1.0.7",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0",
@@ -1453,6 +1557,12 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "license": "ISC"
+        },
         "node_modules/cliui": {
             "version": "7.0.4",
             "dev": true,
@@ -1461,6 +1571,15 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/color-convert": {
@@ -1492,6 +1611,12 @@
             "version": "0.0.1",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/console-control-strings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+            "license": "ISC"
         },
         "node_modules/conventional-changelog-angular": {
             "version": "7.0.0",
@@ -1606,7 +1731,6 @@
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/cosmiconfig": {
@@ -1709,9 +1833,29 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/decompress-response": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/define-data-property": {
             "version": "1.1.4",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0",
@@ -1741,6 +1885,24 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+            "license": "MIT"
+        },
+        "node_modules/detect-libc": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+            "license": "Apache-2.0",
+            "bin": {
+                "detect-libc": "bin/detect-libc.js"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
         "node_modules/diff": {
             "version": "5.2.0",
             "dev": true,
@@ -1763,14 +1925,12 @@
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
@@ -1798,7 +1958,6 @@
         },
         "node_modules/es-define-property": {
             "version": "1.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "get-intrinsic": "^1.2.4"
@@ -1809,7 +1968,6 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -1837,10 +1995,18 @@
         },
         "node_modules/events": {
             "version": "1.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.x"
+            }
+        },
+        "node_modules/expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "license": "(MIT OR WTFPL)",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -1927,11 +2093,16 @@
         },
         "node_modules/for-each": {
             "version": "0.3.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-callable": "^1.1.3"
             }
+        },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "license": "MIT"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -1953,10 +2124,73 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/gauge": {
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+            "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+            "deprecated": "This package is no longer supported.",
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+            }
+        },
+        "node_modules/gauge/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gauge/node_modules/is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+            "license": "MIT",
+            "dependencies": {
+                "number-is-nan": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gauge/node_modules/string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+            "license": "MIT",
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gauge/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/get-caller-file": {
@@ -1969,7 +2203,6 @@
         },
         "node_modules/get-intrinsic": {
             "version": "1.2.4",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -2002,6 +2235,12 @@
             "engines": {
                 "node": ">=16"
             }
+        },
+        "node_modules/github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+            "license": "MIT"
         },
         "node_modules/glob": {
             "version": "8.1.0",
@@ -2051,7 +2290,6 @@
         },
         "node_modules/gopd": {
             "version": "1.1.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "get-intrinsic": "^1.2.4"
@@ -2073,7 +2311,6 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0"
@@ -2084,7 +2321,6 @@
         },
         "node_modules/has-proto": {
             "version": "1.1.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7"
@@ -2098,7 +2334,6 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2109,7 +2344,6 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
@@ -2121,9 +2355,14 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+            "license": "ISC"
+        },
         "node_modules/hasown": {
             "version": "2.0.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -2164,7 +2403,6 @@
         },
         "node_modules/ieee754": {
             "version": "1.1.13",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
@@ -2226,7 +2464,6 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/ini": {
@@ -2251,7 +2488,6 @@
         },
         "node_modules/is-arguments": {
             "version": "1.1.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -2285,7 +2521,6 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2322,7 +2557,6 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -2330,7 +2564,6 @@
         },
         "node_modules/is-generator-function": {
             "version": "1.0.10",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
@@ -2416,7 +2649,6 @@
         },
         "node_modules/is-typed-array": {
             "version": "1.1.13",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "which-typed-array": "^1.1.14"
@@ -2462,7 +2694,6 @@
         },
         "node_modules/jmespath": {
             "version": "0.16.0",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">= 0.6.0"
@@ -2668,6 +2899,12 @@
                 "undici": "^6.16.1"
             }
         },
+        "node_modules/mac-system-proxy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mac-system-proxy/-/mac-system-proxy-1.0.4.tgz",
+            "integrity": "sha512-IAkNLxXZrYuM99A2OhPrvUoAxohsxQciJh2D2xnD+R6vypn/AVyOYLsbZsMVCS/fEbLIe67nQ8krEAfqP12BVg==",
+            "license": "Apache-2.0"
+        },
         "node_modules/make-dir": {
             "version": "1.3.0",
             "license": "MIT",
@@ -2729,6 +2966,18 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/mimic-response": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/minimatch": {
             "version": "5.1.6",
             "dev": true,
@@ -2743,7 +2992,6 @@
         },
         "node_modules/minimist": {
             "version": "1.2.8",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2760,6 +3008,12 @@
             "bin": {
                 "mkdirp": "bin/cmd.js"
             }
+        },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "license": "MIT"
         },
         "node_modules/mocha": {
             "version": "10.8.2",
@@ -2823,6 +3077,36 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/napi-build-utils": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+            "license": "MIT"
+        },
+        "node_modules/node-abi": {
+            "version": "2.30.1",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+            "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^5.4.1"
+            }
+        },
+        "node_modules/node-abi/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/node-addon-api": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+            "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+            "license": "MIT"
+        },
         "node_modules/node-forge": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -2841,11 +3125,48 @@
                 "readable-stream": "~1.0.31"
             }
         },
+        "node_modules/noop-logger": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+            "integrity": "sha512-6kM8CLXvuW5crTxsAtva2YLrRrDaiTIkIePWs9moLHqbFWT94WpNFjwS/5dfLfECg5i/lkmw3aoqVidxt23TEQ==",
+            "license": "MIT"
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
             "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npmlog": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "deprecated": "This package is no longer supported.",
+            "license": "ISC",
+            "dependencies": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+            }
+        },
+        "node_modules/number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2892,10 +3213,19 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
+            }
+        },
+        "node_modules/os-proxy-config": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/os-proxy-config/-/os-proxy-config-1.1.2.tgz",
+            "integrity": "sha512-sV7htE8y6NQORU0oKOUGTwQYe1gSFK3a3Z1i4h6YaqdrA9C0JIsUPQAqEkO8ejjYbRrQ+jsnks5qjtisr7042Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "mac-system-proxy": "^1.0.0",
+                "windows-system-proxy": "^1.0.0"
             }
         },
         "node_modules/p-finally": {
@@ -3022,10 +3352,38 @@
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/prebuild-install": {
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
+            "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^1.0.3",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^1.0.1",
+                "node-abi": "^2.7.0",
+                "noop-logger": "^0.1.1",
+                "npmlog": "^4.0.1",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^3.0.3",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0",
+                "which-pm-runs": "^1.0.0"
+            },
+            "bin": {
+                "prebuild-install": "bin.js"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/prettier": {
@@ -3084,7 +3442,6 @@
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/protobufjs": {
@@ -3124,7 +3481,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
             "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
@@ -3133,12 +3489,10 @@
         },
         "node_modules/punycode": {
             "version": "1.3.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/querystring": {
             "version": "0.2.0",
-            "dev": true,
             "engines": {
                 "node": ">=0.4.x"
             }
@@ -3171,6 +3525,36 @@
             "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "license": "ISC"
+        },
+        "node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/readable-stream": {
@@ -3206,6 +3590,17 @@
             },
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/registry-js": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/registry-js/-/registry-js-1.16.1.tgz",
+            "integrity": "sha512-pQ2kD36lh+YNtpaXm6HCCb0QZtV/zQEeKnkfEIj5FDSpF/oFts7pwizEUkWSvP8IbGb4A4a5iBhhS9eUearMmQ==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-addon-api": "^3.2.1",
+                "prebuild-install": "^5.3.5"
             }
         },
         "node_modules/require-directory": {
@@ -3295,7 +3690,6 @@
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3310,12 +3704,10 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/sax": {
             "version": "1.2.1",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/semver": {
@@ -3340,9 +3732,14 @@
                 "randombytes": "^2.1.0"
             }
         },
+        "node_modules/set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+            "license": "ISC"
+        },
         "node_modules/set-function-length": {
             "version": "1.2.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "define-data-property": "^1.1.4",
@@ -3478,8 +3875,38 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
-            "dev": true,
             "license": "ISC"
+        },
+        "node_modules/simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/simple-get": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+            "license": "MIT",
+            "dependencies": {
+                "decompress-response": "^4.2.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
+            }
         },
         "node_modules/sinon": {
             "version": "20.0.0",
@@ -3564,7 +3991,6 @@
         },
         "node_modules/string-width": {
             "version": "4.2.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -3577,7 +4003,6 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -3632,6 +4057,57 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tar-fs": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+            "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+            "license": "MIT",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tar-stream/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/tar-stream/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/text-extensions": {
@@ -3907,6 +4383,18 @@
             "version": "2.8.1",
             "license": "0BSD"
         },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/type-detect": {
             "version": "4.0.8",
             "dev": true,
@@ -3930,7 +4418,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.21.1",
+            "version": "6.21.3",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+            "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.17"
@@ -3965,7 +4455,6 @@
         },
         "node_modules/url": {
             "version": "0.10.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "punycode": "1.3.2",
@@ -3974,7 +4463,6 @@
         },
         "node_modules/util": {
             "version": "0.12.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -3986,7 +4474,6 @@
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/vscode-jsonrpc": {
@@ -4041,9 +4528,17 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/which-pm-runs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+            "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/which-typed-array": {
             "version": "1.1.16",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
@@ -4059,6 +4554,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/wide-align": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^1.0.2 || 2 || 3 || 4"
+            }
+        },
         "node_modules/win-ca": {
             "version": "3.5.1",
             "hasInstallScript": true,
@@ -4068,6 +4572,15 @@
                 "make-dir": "^1.3.0",
                 "node-forge": "^1.2.1",
                 "split": "^1.0.1"
+            }
+        },
+        "node_modules/windows-system-proxy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/windows-system-proxy/-/windows-system-proxy-1.0.0.tgz",
+            "integrity": "sha512-qd1WfyX9gjAqI36RHt95di2+FBr74DhvELd1EASgklCGScjwReHnWnXfUyabp/CJWl/IdnkUzG0Ub6Cv2R4KJQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "registry-js": "^1.15.1"
             }
         },
         "node_modules/workerpool": {
@@ -4094,12 +4607,10 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/xml2js": {
             "version": "0.6.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sax": ">=0.6.0",
@@ -4111,7 +4622,6 @@
         },
         "node_modules/xmlbuilder": {
             "version": "11.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4.0"
@@ -4213,6 +4723,7 @@
                 "hpagent": "^1.2.0",
                 "jose": "^5.9.6",
                 "mac-ca": "^3.1.1",
+                "os-proxy-config": "^1.1.2",
                 "rxjs": "^7.8.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-protocol": "^3.17.5",
@@ -4225,7 +4736,6 @@
                 "@types/node": "^22.15.17",
                 "@types/node-forge": "^1.3.11",
                 "assert": "^2.0.0",
-                "aws-sdk": "^2.1692.0",
                 "copyfiles": "^2.4.1",
                 "husky": "^9.1.7",
                 "json-schema-to-typescript": "^15.0.4",

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -41,15 +41,16 @@
         "@opentelemetry/sdk-metrics": "^2.0.1",
         "@smithy/node-http-handler": "^4.0.4",
         "ajv": "^8.17.1",
+        "aws-sdk": "^2.1692.0",
         "hpagent": "^1.2.0",
         "jose": "^5.9.6",
         "mac-ca": "^3.1.1",
+        "os-proxy-config": "^1.1.2",
         "rxjs": "^7.8.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-protocol": "^3.17.5",
-        "win-ca": "^3.5.1",
-        "aws-sdk": "^2.1692.0",
-        "vscode-uri": "^3.1.0"
+        "vscode-uri": "^3.1.0",
+        "win-ca": "^3.5.1"
     },
     "devDependencies": {
         "@types/mocha": "^10.0.9",

--- a/runtimes/runtimes/util/standalone/experimentalProxyUtil.test.ts
+++ b/runtimes/runtimes/util/standalone/experimentalProxyUtil.test.ts
@@ -96,9 +96,9 @@ describe('ProxyConfigManager', function () {
         assert.strictEqual(getAgentSpy.firstCall.returnValue, getAgentSpy.secondCall.returnValue)
     })
 
-    describe('getProxyUrl', () => {
+    describe('getProxyUrlFromEnv', () => {
         it('should return undefined when no proxy environment variables are set', () => {
-            const proxyUrl = proxyManager.getProxyUrl()
+            const proxyUrl = proxyManager.getProxyUrlFromEnv()
             assert.strictEqual(proxyUrl, undefined)
         })
 
@@ -108,7 +108,7 @@ describe('ProxyConfigManager', function () {
             process.env.HTTP_PROXY = 'http://proxy3.example.com'
             process.env.http_proxy = 'http://proxy4.example.com'
 
-            const proxyUrl = proxyManager.getProxyUrl()
+            const proxyUrl = proxyManager.getProxyUrlFromEnv()
             assert.strictEqual(proxyUrl, 'https://proxy1.example.com')
         })
 
@@ -117,7 +117,7 @@ describe('ProxyConfigManager', function () {
             process.env.HTTP_PROXY = 'http://proxy3.example.com'
             process.env.http_proxy = 'http://proxy4.example.com'
 
-            const proxyUrl = proxyManager.getProxyUrl()
+            const proxyUrl = proxyManager.getProxyUrlFromEnv()
             assert.strictEqual(proxyUrl, 'https://proxy2.example.com')
         })
 
@@ -125,14 +125,14 @@ describe('ProxyConfigManager', function () {
             process.env.HTTP_PROXY = 'http://proxy3.example.com'
             process.env.http_proxy = 'http://proxy4.example.com'
 
-            const proxyUrl = proxyManager.getProxyUrl()
+            const proxyUrl = proxyManager.getProxyUrlFromEnv()
             assert.strictEqual(proxyUrl, 'http://proxy3.example.com')
         })
 
         it('should use http_proxy when it is the only proxy set', () => {
             process.env.http_proxy = 'http://proxy4.example.com'
 
-            const proxyUrl = proxyManager.getProxyUrl()
+            const proxyUrl = proxyManager.getProxyUrlFromEnv()
             assert.strictEqual(proxyUrl, 'http://proxy4.example.com')
         })
 
@@ -140,7 +140,7 @@ describe('ProxyConfigManager', function () {
             process.env.HTTPS_PROXY = 'invalid-url'
             process.env.HTTP_PROXY = 'http://valid.example.com'
 
-            const proxyUrl = proxyManager.getProxyUrl()
+            const proxyUrl = proxyManager.getProxyUrlFromEnv()
             assert.strictEqual(proxyUrl, 'http://valid.example.com')
         })
     })
@@ -274,7 +274,7 @@ describe('ProxyConfigManager', function () {
             readLinuxCertificatesStub.returns(sysCerts)
         })
 
-        it('should create HttpsAgent when no proxy set (transparent proxy)', () => {
+        it('should create HttpsAgent when no proxy set', () => {
             const agent = proxyManager.createSecureAgent()
 
             assert(agent instanceof HttpsAgent)
@@ -287,7 +287,7 @@ describe('ProxyConfigManager', function () {
                     name: 'runtime_httpProxyConfiguration',
                     result: 'Succeeded',
                     data: {
-                        proxyMode: 'Transparent',
+                        proxyMode: 'NoProxy',
                         certificatesNumber: 3 + validTlsRootCertificates.length,
                     },
                 })


### PR DESCRIPTION
## Problem
Standalone runtime is only able to use proxies when the user explicitly set the HTTP(S)_PROXY environment variables. 

Users on corporate networks use Transparent proxies configured on Network level. Retrieving the OS certificates trust store is not enough. As a result of this, customers requests to Q Agentic Chat fail as they do not pass through their corporate proxy.

## Solution

We embedded automatic system‑proxy discovery into the standalone language‑server by adding the lightweight [os‑proxy-config](https://www.npmjs.com/package/os-proxy-config?activeTab=readme) package and a tiny synchronous shim that runs it in a child Node process when no HTTP(S)_PROXY env‑vars are set. The shim was used to keep the method synchronous, so that the async changes would not ripple through every SDK-client factory and the many call-sites where these methods are used.

The server now transparently picks up the same proxy/PAC settings the OS and browsers use, falls back to direct connections only when no proxy exists, and reports the mode via telemetry. Outbound calls now honor their OS proxy without any manual settings.


## Future Work

This is a short-term solution to unblock customers. Long-term we should investigate a more robust solution for discovering proxies

## Testing

Tested by simulating customer environment on MacOS and Windows and using Charles Proxy:

Logs:

```
[Trace - 11:43:05 PM] Received notification 'window/logMessage'.
Params: {
    "type": 4,
    "message": "Fall back to OS auto‑detect (HTTP or HTTPS only)"
}


Fall back to OS auto‑detect (HTTP or HTTPS only)
[Trace - 11:43:05 PM] Received notification 'window/logMessage'.
Params: {
    "type": 4,
    "message": "os-proxy-config output: {\"proxyUrl\":\"http://127.0.0.1:8888\",\"noProxy\":[]}\n"
}


os-proxy-config output: {"proxyUrl":"http://127.0.0.1:8888","noProxy":[]}

[Trace - 11:43:05 PM] Received notification 'telemetry/event'.
Params: {
    "name": "runtime_httpProxyConfiguration",
    "result": "Succeeded",
    "data": {
        "proxyMode": "AutoDetect",
        "certificatesNumber": 328,
        "proxyUrl": "http://127.0.0.1:8888"
    }
}
```

Proxy:

<img width="882" alt="Screenshot 2025-06-09 at 12 06 21 AM" src="https://github.com/user-attachments/assets/11f829d7-ef1c-4015-8b94-acf1c58d488b" />


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
