### PR TITLE
fix: align proxy detection with Node.js CLI behavior in Windows

### DIFF
--- a/runtimes/runtimes/util/standalone/experimentalProxyUtil.ts
+++ b/runtimes/runtimes/util/standalone/experimentalProxyUtil.ts
@@ -89,10 +89,9 @@ export class ProxyConfigManager {
                 })();
             `
 
-            const raw = execFileSync(process.execPath, [], {
-                input: snippet,
+            const raw = execFileSync(process.execPath, ['-e', snippet], {
                 encoding: 'utf8',
-                stdio: ['pipe', 'pipe', 'inherit'],
+                stdio: ['ignore', 'pipe', 'inherit'],
             })
 
             console.debug(`os-proxy-config output: ${raw}`)


### PR DESCRIPTION
## Problem

The current implementation of `getSystemProxySync()` fails to correctly detect system 
proxy settings on Windows, resulting in an empty object being returned even when a 
proxy is configured. This occurs due to inconsistencies in how the Node.js sub-process 
is executed across different platforms.

## Solution

Use `execFileSync` with the '-e' flag to execute the script, matching the command-line approach.


## Testing
Ran this command in my windows terminal:

```
PS C:\Users\tsmithsz> & "C:\Program Files\nodejs\node.exe" `
>>   -e "import('os-proxy-config').then(m=>m.getSystemProxy()).then(console.log).catch(console.error)"
{
  proxyUrl: 'http://localhost:8888/',
  noProxy: [ 'localhost', '127.0.0.1', '::1' ]
}
```
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
