### PR TITLE
feat(types): add protocol for open file dialog for import image as context

### DIFF
--- a/chat-client-ui-types/src/uiContracts.ts
+++ b/chat-client-ui-types/src/uiContracts.ts
@@ -8,6 +8,7 @@ import {
     GET_SERIALIZED_CHAT_REQUEST_METHOD,
     GetSerializedChatResult,
     ChatPrompt,
+    OpenFileDialogParams,
 } from '@aws/language-server-runtimes-types'
 export { InsertToCursorPositionParams } from '@aws/language-server-runtimes-types'
 
@@ -30,7 +31,7 @@ export const DISCLAIMER_ACKNOWLEDGED = 'disclaimerAcknowledged'
 export const CHAT_PROMPT_OPTION_ACKNOWLEDGED = 'chatPromptOptionAcknowledged'
 export const STOP_CHAT_RESPONSE = 'stopChatResponse'
 export const OPEN_SETTINGS = 'openSettings'
-
+export const OPEN_FILE_DIALOG = 'openFileDialog'
 /**
  * A message sent from Chat Client to Extension in response to various actions triggered from Chat UI.
  */
@@ -51,6 +52,7 @@ export type UiMessageCommand =
     | typeof CHAT_PROMPT_OPTION_ACKNOWLEDGED
     | typeof STOP_CHAT_RESPONSE
     | typeof OPEN_SETTINGS
+    | typeof OPEN_FILE_DIALOG
 
 export type UiMessageParams =
     | InsertToCursorPositionParams
@@ -63,6 +65,7 @@ export type UiMessageParams =
     | ChatPromptOptionAcknowledgedParams
     | StopChatResponseParams
     | OpenSettingsParams
+    | OpenFileDialogParams
 
 export interface SendToPromptParams {
     selection: string

--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -73,6 +73,9 @@ import {
     McpServerClickParams,
     McpServerClickResult,
     MCP_SERVER_CLICK_REQUEST_METHOD,
+    OPEN_FILE_DIALOG_METHOD,
+    OpenFileDialogParams,
+    OpenFileDialogResult,
 } from './lsp'
 
 export const chatRequestType = new AutoParameterStructuresProtocolRequestType<
@@ -82,6 +85,13 @@ export const chatRequestType = new AutoParameterStructuresProtocolRequestType<
     void,
     void
 >(CHAT_REQUEST_METHOD)
+export const openFileDialogRequestType = new AutoParameterStructuresProtocolRequestType<
+    OpenFileDialogParams,
+    OpenFileDialogResult | string,
+    OpenFileDialogResult | string,
+    void,
+    void
+>(OPEN_FILE_DIALOG_METHOD)
 export const inlineChatRequestType = new AutoParameterStructuresProtocolRequestType<
     InlineChatParams | EncryptedChatParams,
     InlineChatResult | string,

--- a/runtimes/protocol/window.ts
+++ b/runtimes/protocol/window.ts
@@ -3,6 +3,9 @@ import {
     SHOW_SAVE_FILE_DIALOG_REQUEST_METHOD,
     ShowSaveFileDialogParams,
     ShowSaveFileDialogResult,
+    ShowOpenDialogResult,
+    ShowOpenDialogParams,
+    SHOW_OPEN_FILE_DIALOG_REQUEST_METHOD,
 } from './lsp'
 
 /**
@@ -16,3 +19,11 @@ export const ShowSaveFileDialogRequestType = new ProtocolRequestType<
     void,
     void
 >(SHOW_SAVE_FILE_DIALOG_REQUEST_METHOD)
+
+export const ShowOpenDialogRequestType = new ProtocolRequestType<
+    ShowOpenDialogParams,
+    ShowOpenDialogResult,
+    never,
+    void,
+    void
+>(SHOW_OPEN_FILE_DIALOG_REQUEST_METHOD)

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -33,6 +33,7 @@ import {
     ShowMessageNotification,
     ShowMessageRequest,
     ShowDocumentRequest,
+    ShowOpenDialogRequestType,
     openTabRequestType,
     openFileDiffNotificationType,
     selectWorkspaceItemRequestType,
@@ -51,6 +52,7 @@ import {
     buttonClickRequestType,
     listMcpServersRequestType,
     mcpServerClickRequestType,
+    openFileDialogRequestType,
 } from '../protocol'
 import { createConnection } from 'vscode-languageserver/browser'
 import {
@@ -177,6 +179,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
         onTabBarAction: handler => lspConnection.onRequest(tabBarActionRequestType.method, handler),
         onPromptInputOptionChange: handler =>
             lspConnection.onNotification(promptInputOptionChangeNotificationType.method, handler),
+        onOpenFileDialog: handler => lspConnection.onRequest(openFileDialogRequestType.method, handler),
     }
 
     const identityManagement: IdentityManagement = {
@@ -244,6 +247,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
                 showMessageRequest: params => lspConnection.sendRequest(ShowMessageRequest.method, params),
                 showDocument: params => lspConnection.sendRequest(ShowDocumentRequest.method, params),
                 showSaveFileDialog: params => lspConnection.sendRequest(ShowSaveFileDialogRequestType.method, params),
+                showOpenDialog: params => lspConnection.sendRequest(ShowOpenDialogRequestType.method, params),
             },
             publishDiagnostics: params => lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),
             sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {

--- a/runtimes/runtimes/chat/baseChat.ts
+++ b/runtimes/runtimes/chat/baseChat.ts
@@ -70,6 +70,9 @@ import {
     McpServerClickParams,
     McpServerClickResult,
     mcpServerClickRequestType,
+    OpenFileDialogParams,
+    OpenFileDialogResult,
+    openFileDialogRequestType,
 } from '../../protocol'
 import { Chat } from '../../server-interface'
 
@@ -78,6 +81,12 @@ export class BaseChat implements Chat {
 
     public onChatPrompt(handler: RequestHandler<ChatParams, ChatResult | null | undefined, ChatResult>) {
         this.connection.onRequest(chatRequestType.method, handler)
+    }
+
+    public onOpenFileDialog(
+        handler: RequestHandler<OpenFileDialogParams, OpenFileDialogResult | null | undefined, OpenFileDialogResult>
+    ) {
+        this.connection.onRequest(openFileDialogRequestType.method, handler)
     }
 
     public onInlineChatPrompt(

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -28,6 +28,8 @@ import {
     didWriteFileNotificationType,
     didAppendFileNotificationType,
     didCreateDirectoryNotificationType,
+    ShowOpenDialogParams,
+    ShowOpenDialogRequestType,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -393,6 +395,8 @@ export const standalone = (props: RuntimeProps) => {
                     showDocument: params => lspConnection.sendRequest(ShowDocumentRequest.method, params),
                     showSaveFileDialog: (params: ShowSaveFileDialogParams) =>
                         lspConnection.sendRequest(ShowSaveFileDialogRequestType.method, params),
+                    showOpenDialog: (params: ShowOpenDialogParams) =>
+                        lspConnection.sendRequest(ShowOpenDialogRequestType.method, params),
                 },
                 publishDiagnostics: params =>
                     lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),

--- a/runtimes/server-interface/chat.ts
+++ b/runtimes/server-interface/chat.ts
@@ -41,6 +41,8 @@ import {
     ListMcpServersResult,
     McpServerClickResult,
     McpServerClickParams,
+    OpenFileDialogParams,
+    OpenFileDialogResult,
 } from '../protocol'
 
 /**
@@ -62,6 +64,9 @@ export type Chat = {
     onConversationClick: (handler: RequestHandler<ConversationClickParams, ConversationClickResult, void>) => void
     onTabBarAction: (handler: RequestHandler<TabBarActionParams, TabBarActionResult, void>) => void
     getSerializedChat: (params: GetSerializedChatParams) => Promise<GetSerializedChatResult>
+    onOpenFileDialog: (
+        handler: RequestHandler<OpenFileDialogParams, OpenFileDialogResult | undefined | null, OpenFileDialogResult>
+    ) => void
     // Notifications
     onSendFeedback: (handler: NotificationHandler<FeedbackParams>) => void
     onReady: (handler: NotificationHandler<void>) => void

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -59,6 +59,8 @@ import {
     SelectWorkspaceItemResult,
     ShowSaveFileDialogParams,
     ShowSaveFileDialogResult,
+    ShowOpenDialogParams,
+    ShowOpenDialogResult,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -151,6 +153,7 @@ export type Lsp = {
         showMessageRequest: (params: ShowMessageRequestParams) => Promise<MessageActionItem | null>
         showDocument: (params: ShowDocumentParams) => Promise<ShowDocumentResult>
         showSaveFileDialog: (params: ShowSaveFileDialogParams) => Promise<ShowSaveFileDialogResult>
+        showOpenDialog: (params: ShowOpenDialogParams) => Promise<ShowOpenDialogResult>
     }
     extensions: {
         onInlineCompletionWithReferences: (

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -22,6 +22,7 @@ export const INLINE_CHAT_REQUEST_METHOD = 'aws/chat/sendInlineChatPrompt'
 export const TAB_BAR_ACTION_REQUEST_METHOD = 'aws/chat/tabBarAction'
 export const CHAT_OPTIONS_UPDATE_NOTIFICATION_METHOD = 'aws/chat/chatOptionsUpdate'
 export const PROMPT_INPUT_OPTION_CHANGE_METHOD = 'aws/chat/promptInputOptionChange'
+export const OPEN_FILE_DIALOG_METHOD = 'aws/chat/openFileDialog'
 // context
 export const CONTEXT_COMMAND_NOTIFICATION_METHOD = 'aws/chat/sendContextCommands'
 export const CREATE_PROMPT_NOTIFICATION_METHOD = 'aws/chat/createPrompt'
@@ -398,7 +399,7 @@ export interface ContextCommandGroup {
 export interface ContextCommand extends QuickActionCommand {
     id?: string
     route?: string[]
-    label?: 'file' | 'folder' | 'code'
+    label?: 'file' | 'folder' | 'code' | 'image'
     children?: ContextCommandGroup[]
 }
 
@@ -408,6 +409,16 @@ export interface ContextCommandParams {
 
 export interface CreatePromptParams {
     promptName: string
+}
+
+export interface OpenFileDialogParams {
+    tabId: string
+    type: 'image' | ''
+}
+
+export interface OpenFileDialogResult {
+    tabId: string
+    filePaths: string[]
 }
 
 export interface ProgrammingLanguage {

--- a/types/window.ts
+++ b/types/window.ts
@@ -1,7 +1,7 @@
 import { URI } from 'vscode-languageserver-types'
 
 export const SHOW_SAVE_FILE_DIALOG_REQUEST_METHOD = 'aws/showSaveFileDialog'
-
+export const SHOW_OPEN_FILE_DIALOG_REQUEST_METHOD = 'aws/showOpenFileDialog'
 export interface ShowSaveFileDialogParams {
     // Using untyped string to avoid locking this too strictly.
     // TODO: Migrate to LanguageKind when it is released in 3.18.0
@@ -12,4 +12,18 @@ export interface ShowSaveFileDialogParams {
 
 export interface ShowSaveFileDialogResult {
     targetUri: URI
+}
+
+// bridge to consume ide's api
+export interface ShowOpenDialogParams {
+    canSelectFiles?: boolean
+    canSelectFolders?: boolean
+    canSelectMany?: boolean
+    filters?: { [key: string]: string[] }
+    defaultUri?: URI
+    title?: string
+}
+
+export interface ShowOpenDialogResult {
+    uris: URI[]
 }


### PR DESCRIPTION
## Problem
To enable the import image in context feature, new protocol is added
Flow:
onOpenFileDialog(Chat client outbound) -> OpenFileDialog (Language-severs-runtime) -> language server -> lsp.window.showOpenDialog -> extension's API

After the user select an image

extension API -> language server -> OpenFileDialogResult (Language-severs-runtime) -> updatePrompt (Chat client inbound)

## Solution
`onOpenFileDialog`(Chat client outbound) -> `OpenFileDialog` (Language-severs-runtime) -> language server -> `lsp.window.showOpenDialog` -> extension's API

After the user select an image

extension API -> language server -> `OpenFileDialogResult` (Language-severs-runtime) -> updatePrompt (Chat client inbound)
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
