### PR TITLE
feat: add modelUnavailable to ChatUpdateParams

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -360,10 +360,10 @@ export interface ChatUpdateParams {
     tabId: string
     state?: TabState
     data?: TabData
-    /** 
+    /**
      * Special parameter that triggers an error card display when the model is unavailable.
      */
-    modelUnavailable?: boolean;
+    modelUnavailable?: boolean
 }
 
 /**

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -360,6 +360,10 @@ export interface ChatUpdateParams {
     tabId: string
     state?: TabState
     data?: TabData
+    /** 
+     * Special parameter that triggers an error card display when the model is unavailable.
+     */
+    modelUnavailable?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Problem

ChatUpdateParams need to be able to show model error card when appropriate for a specific tab

## Solution

Add `modelUnavailable` to `ChatUpdateParams`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
