### PR TITLE
fix(runtimes): fix protocol/lsp circular dependency

### DIFF
--- a/runtimes/protocol/inlineCompletionWithReferences.ts
+++ b/runtimes/protocol/inlineCompletionWithReferences.ts
@@ -3,11 +3,11 @@ import {
     InlineCompletionItemWithReferences,
     LogInlineCompletionSessionResultsParams,
     InlineCompletionRegistrationOptions,
-    ProtocolNotificationType,
-    ProtocolRequestType,
     InlineCompletionParams,
     PartialResultParams,
 } from './lsp'
+
+import { ProtocolNotificationType, ProtocolRequestType } from 'vscode-languageserver-protocol'
 
 export type InlineCompletionWithReferencesParams = InlineCompletionParams & PartialResultParams
 

--- a/runtimes/protocol/inlineCompletions.ts
+++ b/runtimes/protocol/inlineCompletions.ts
@@ -2,9 +2,10 @@ import {
     InlineCompletionItem,
     InlineCompletionList,
     InlineCompletionParams,
-    ProtocolRequestType,
     InlineCompletionRegistrationOptions,
 } from './lsp'
+
+import { ProtocolRequestType } from 'vscode-languageserver-protocol'
 
 /**
  * inlineCompletionRequestType defines the custom method that the language client


### PR DESCRIPTION
## Problem
There is a circular dependency between`runtimes/protocol/inlineCompletionWithReference.ts` and `runtimes/protocol/lsp.ts`. And another similar circular dependency between`runtimes/protocol/inlineCompletions.ts` and `runtimes/protocol/lsp.ts`.

It happens as lsp.ts exports * from inlineCompletionWithReference.ts, but inlineCompletionWithReference imports several class from lsp.ts. Same thing happens for inlineCompletions.ts.

## Solution
The classes imported from lsp.ts are essentially from vscode-languaugeserver-protocol. To avoid circular dependency, have inlineCompletionWithReference.ts and inlineCompletions.ts directly import these classes from vscode-languageserver-protocol.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
