### PR TITLE
feat(types): make the insertPosition optional in OpenFileDialogParams and OpenFileDialogResult

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -420,6 +420,7 @@ export interface ContextCommand extends QuickActionCommand {
     route?: string[]
     label?: 'file' | 'folder' | 'code' | 'image'
     children?: ContextCommandGroup[]
+    content?: Uint8Array
 }
 
 export interface ContextCommandParams {

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -440,7 +440,7 @@ export interface CreatePromptParams {
 export interface OpenFileDialogParams {
     tabId: string
     fileType: 'image' | ''
-    insertPosition: number
+    insertPosition?: number
 }
 
 export interface OpenFileDialogResult {
@@ -448,7 +448,7 @@ export interface OpenFileDialogResult {
     fileType: 'image' | ''
     filePaths: string[]
     errorMessage?: string
-    insertPosition: number
+    insertPosition?: number
 }
 
 export interface DropFilesParams {


### PR DESCRIPTION
## Problem
As the MynahUI code is refactored, change the protocol accordingly
 
## Solution

* Add additional field `content` for image context added by drag & drop to store the image content
* Make the `insertPosition` optional field

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
