### PR TITLE
fix: improve tool input validation logic to return specific error message

### DIFF
--- a/runtimes/runtimes/agent.test.ts
+++ b/runtimes/runtimes/agent.test.ts
@@ -94,7 +94,7 @@ describe('Agent Tools', () => {
                 })
             },
             (error: Error) => {
-                assert.ok(error.message === 'fsReplace tool input validation failed: diffs: must be array')
+                assert.ok(error.message === 'fsReplace tool input validation failed: /diffs: must be array')
                 return true
             }
         )
@@ -105,7 +105,7 @@ describe('Agent Tools', () => {
                 await AGENT.runTool(SOME_TOOL_SPEC.name, { test: 1 })
             },
             (error: Error) => {
-                assert.ok(error.message === 'test tool input validation failed: test: must be string')
+                assert.ok(error.message === 'test tool input validation failed: /test: must be string')
                 return true
             }
         )

--- a/runtimes/runtimes/agent.test.ts
+++ b/runtimes/runtimes/agent.test.ts
@@ -34,6 +34,32 @@ describe('Agent Tools', () => {
     } as const
     const SOME_TOOL_HANDLER = async (_: { test: string }) => true
 
+    const TOOL_SPEC_WITH_ARRAY_TYPE = {
+        name: 'fsReplace',
+        description: 'test',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                diffs: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            oldStr: {
+                                type: 'string',
+                            },
+                            newStr: {
+                                type: 'string',
+                            },
+                        },
+                    },
+                },
+            },
+            required: ['diffs'],
+        },
+    } as const
+    const DIFFS_TOOL_HANDLER = async (_: { diffs: [] }) => true
+
     beforeEach(() => {
         AGENT = newAgent()
     })
@@ -59,11 +85,30 @@ describe('Agent Tools', () => {
         }, Error)
     })
 
-    it('should throw if the tool input does not validate', async () => {
+    it('should throw specific message if the tool input does not validate', async () => {
+        AGENT.addTool(TOOL_SPEC_WITH_ARRAY_TYPE, DIFFS_TOOL_HANDLER)
+        await assert.rejects(
+            async () => {
+                await AGENT.runTool(TOOL_SPEC_WITH_ARRAY_TYPE.name, {
+                    diffs: '[{"oldStr": "toReplace"}, {"newStr": "newContet"}]',
+                })
+            },
+            (error: Error) => {
+                assert.ok(error.message === 'fsReplace tool input validation failed: diffs: must be array')
+                return true
+            }
+        )
+
         AGENT.addTool(SOME_TOOL_SPEC, SOME_TOOL_HANDLER)
-        assert.rejects(async () => {
-            await AGENT.runTool(SOME_TOOL_SPEC.name, { test: 1 })
-        }, Error)
+        await assert.rejects(
+            async () => {
+                await AGENT.runTool(SOME_TOOL_SPEC.name, { test: 1 })
+            },
+            (error: Error) => {
+                assert.ok(error.message === 'test tool input validation failed: test: must be string')
+                return true
+            }
+        )
     })
 
     it('should execute the named tool if multiple are available', async () => {


### PR DESCRIPTION

## Problem
- When model passes incorrect type for the toolUse input, the error msg is not clear enough to allow auto correction
```
"toolResults": [
              {
                "toolUseId": "tooluse_f3iftfAAQ8uhRCHp1oJQCg",
                "status": "error",
                "content": [
                  {
                    "json": {
                      "error": "Input for tool fsReplace is invalid"
                    }
                  }
                ]
              }
            ]
```

## Solution
- improve tool input validation logic to return specific error message


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
