### PR TITLE
fix: add methods to fetch builtIn and builtInWrite tools

### DIFF
--- a/runtimes/runtimes/agent.test.ts
+++ b/runtimes/runtimes/agent.test.ts
@@ -1,4 +1,4 @@
-import { Agent } from '../server-interface'
+import { Agent, ToolClassification } from '../server-interface'
 import { newAgent } from './agent'
 import * as assert from 'assert'
 
@@ -177,5 +177,31 @@ describe('Agent Tools', () => {
         AGENT.addTool(SOME_TOOL_SPEC, SOME_TOOL_HANDLER)
         AGENT.removeTool(SOME_TOOL_SPEC.name)
         await assert.rejects(() => AGENT.runTool(SOME_TOOL_SPEC.name, { test: 'test' }), /not found/)
+    })
+
+    it('should track built-in tools', () => {
+        AGENT.addTool(SOME_TOOL_SPEC, SOME_TOOL_HANDLER, ToolClassification.BuiltIn)
+        AGENT.addTool({ ...SOME_TOOL_SPEC, name: 'regular' }, SOME_TOOL_HANDLER)
+
+        const builtInTools = AGENT.getBuiltInToolNames()
+        assert.equal(builtInTools.length, 1)
+        assert.equal(builtInTools[0], SOME_TOOL_SPEC.name)
+    })
+
+    it('should track built-in write tools', () => {
+        AGENT.addTool(SOME_TOOL_SPEC, SOME_TOOL_HANDLER, ToolClassification.BuiltInCanWrite)
+        AGENT.addTool({ ...SOME_TOOL_SPEC, name: 'readOnly' }, SOME_TOOL_HANDLER, ToolClassification.BuiltIn)
+
+        const builtInTools = AGENT.getBuiltInToolNames()
+        const builtInWriteTools = AGENT.getBuiltInWriteToolNames()
+
+        assert.equal(builtInTools.length, 2)
+        assert.equal(builtInWriteTools.length, 1)
+        assert.equal(builtInWriteTools[0], SOME_TOOL_SPEC.name)
+    })
+
+    it('should return empty arrays for built-in tools when none are added', () => {
+        assert.equal(AGENT.getBuiltInToolNames().length, 0)
+        assert.equal(AGENT.getBuiltInWriteToolNames().length, 0)
     })
 })

--- a/runtimes/server-interface/agent.ts
+++ b/runtimes/server-interface/agent.ts
@@ -112,6 +112,12 @@ export type BedrockTools = {
     toolSpecification: Omit<ToolSpec, 'inputSchema'> & { inputSchema: { json: ToolSpec['inputSchema'] } }
 }[]
 
+export enum ToolClassification {
+    BuiltIn = 'builtIn',
+    BuiltInCanWrite = 'builtInCanWrite',
+    MCP = 'mcp',
+}
+
 export type Agent = {
     /**
      * Add a tool to the local tool repository. Tools with the same name will be overwritten.
@@ -123,7 +129,8 @@ export type Agent = {
      */
     addTool: <T extends InferSchema<S['inputSchema']>, S extends ToolSpec, R>(
         spec: S,
-        handler: (input: T, token?: CancellationToken, updates?: WritableStream) => Promise<R>
+        handler: (input: T, token?: CancellationToken, updates?: WritableStream) => Promise<R>,
+        toolClassification?: ToolClassification
     ) => void
 
     /**
@@ -150,4 +157,16 @@ export type Agent = {
      * @param toolName The name of the tool to remove
      */
     removeTool: (toolName: string) => void
+
+    /**
+     * Get the list of built-in tool names in the local tool repository.
+     * @returns The list of built-in tool names
+     */
+    getBuiltInToolNames: () => string[]
+
+    /**
+     * Get the list of built-in write tool names in the local tool repository.
+     * @returns The list of built-in write tool names
+     */
+    getBuiltInWriteToolNames: () => string[]
 }


### PR DESCRIPTION
## Problem
- LS is now hardcoding the list of tool names which is error prone when we update it
  - https://github.com/aws/language-servers/pull/1756


## Solution
- Add support to fetch the list of tool names

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
