### PR TITLE
fix: remove duplicate uri of workspace paths sent by VS

### DIFF
--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -678,6 +678,31 @@ describe('LspRouter', () => {
             assert.deepStrictEqual(lspRouter.getAllWorkspaceFolders(), expectedFolders)
             assert(didChangeWorkspaceFoldersSpy.calledWith({ event }))
         })
+
+        it('should filter out duplicate workspace folder URIs when adding', () => {
+            const initialFolders = [
+                { name: 'existing', uri: 'file:///existing' },
+                { name: 'another', uri: 'file:///another' },
+            ]
+            lspRouter['workspaceFolders'] = initialFolders
+
+            const event = {
+                added: [
+                    { name: 'new', uri: 'file:///new' },
+                    { name: 'duplicate', uri: 'file:///existing' }, // duplicate URI
+                ],
+                removed: [],
+            }
+
+            lspRouter.didChangeWorkspaceFolders(event)
+
+            const expectedFolders = [
+                { name: 'existing', uri: 'file:///existing' },
+                { name: 'another', uri: 'file:///another' },
+                { name: 'new', uri: 'file:///new' },
+            ]
+            assert.deepStrictEqual(lspRouter.getAllWorkspaceFolders(), expectedFolders)
+        })
     })
 
     describe('didCreateFiles', () => {

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -144,7 +144,9 @@ ${JSON.stringify({ ...result.capabilities, ...result.awsServerCapabilities })}`
         this.workspaceFolders = this.workspaceFolders.filter(
             folder => !event.removed.some(removed => removed.uri === folder.uri)
         )
-        this.workspaceFolders.push(...event.added)
+        this.workspaceFolders.push(
+            ...event.added.filter(added => !this.workspaceFolders.some(existing => existing.uri === added.uri))
+        )
         const params: DidChangeWorkspaceFoldersParams = { event }
 
         this.routeNotificationToAllServers((server, params) => {


### PR DESCRIPTION
## Problem
Visual Studio was sending duplicate workspace folder URIs in workspace change events, which caused duplicate rules to appear when listing rules.

## Solution
Added deduplication filter to check existing workspace folder URIs before adding new ones, preventing duplicates from being stored in the workspaceFolders array.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
