### PR TITLE
chore: add timeout to ensure error flushes to stdout/err on auth failure

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -184,7 +184,11 @@ export const standalone = (props: RuntimeProps) => {
                     },
                     error => {
                         console.error(error)
-                        process.exit(10)
+                        // arbitrary 5 second timeout to ensure console.error flushes before process exit
+                        // note: webpacked version may output exclusively to stdout, not stderr.
+                        setTimeout(() => {
+                            process.exit(10)
+                        }, 5000)
                     }
                 )
                 .catch((error: Error) => {


### PR DESCRIPTION
## Problem
No log output for initializeAuth failure

## Solution
Add a timeout before process kill to ensure the buffer flushes

Tested locally by directly modifying the prod artifact. Note that the webpacked version appears to only output to `stdout` (instead of `stderr`, which should be expected with a `console.error`
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
