### PR TITLE
fix: onDidSaveTextDocument routing

### DIFF
--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -242,7 +242,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
             onDidOpenTextDocument: handler => documentsObserver.callbacks.onDidOpenTextDocument(handler),
             onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),
             onDidCloseTextDocument: handler => lspConnection.onDidCloseTextDocument(handler),
-            onDidSaveTextDocument: lspServer.setDidSaveTextDocumentHandler,
+            onDidSaveTextDocument: handler => documentsObserver.callbacks.onDidSaveTextDocument(handler),
             onExecuteCommand: lspServer.setExecuteCommandHandler,
             onSemanticTokens: handler => lspConnection.onRequest(SemanticTokensRequest.type, handler),
             workspace: {

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -374,7 +374,7 @@ export const standalone = (props: RuntimeProps) => {
                 onDidOpenTextDocument: handler => documentsObserver.callbacks.onDidOpenTextDocument(handler),
                 onDidChangeTextDocument: handler => documentsObserver.callbacks.onDidChangeTextDocument(handler),
                 onDidCloseTextDocument: handler => documentsObserver.callbacks.onDidCloseTextDocument(handler),
-                onDidSaveTextDocument: lspServer.setDidSaveTextDocumentHandler,
+                onDidSaveTextDocument: handler => documentsObserver.callbacks.onDidSaveTextDocument(handler),
                 onExecuteCommand: lspServer.setExecuteCommandHandler,
                 onSemanticTokens: handler => lspConnection.onRequest(SemanticTokensRequest.type, handler),
                 workspace: {


### PR DESCRIPTION
## Problem
- Server could not receive onDidSaveTextDocument event from VSCode

## Solution
- Connect the lspServer to the documentObserver.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## Test
- Linked lsp-runtime and lsp, manually tested. Now WorkspaceContextServer can receive the didSave event:
```2025-06-27 14:37:03.013 [info] [2025-06-27T21:37:03.013Z] Received didSave event for /Volumes/workplace/<*redacted*>```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
