### PR TITLE
fix: avoid duplicate url with forward slash in the end

### DIFF
--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -691,7 +691,6 @@ describe('LspRouter', () => {
                     { name: 'new', uri: 'file:///new' },
                     { name: 'duplicate', uri: 'file:///existing' }, // duplicate URI
                     { name: 'duplicate', uri: 'file:///existing/' }, // duplicate URI with /
-                    { name: 'new', uri: 'file:///new/' },
                 ],
                 removed: [],
             }

--- a/runtimes/runtimes/lsp/router/lspRouter.test.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.test.ts
@@ -690,6 +690,8 @@ describe('LspRouter', () => {
                 added: [
                     { name: 'new', uri: 'file:///new' },
                     { name: 'duplicate', uri: 'file:///existing' }, // duplicate URI
+                    { name: 'duplicate', uri: 'file:///existing/' }, // duplicate URI with /
+                    { name: 'new', uri: 'file:///new/' },
                 ],
                 removed: [],
             }

--- a/runtimes/runtimes/lsp/router/lspRouter.ts
+++ b/runtimes/runtimes/lsp/router/lspRouter.ts
@@ -145,7 +145,12 @@ ${JSON.stringify({ ...result.capabilities, ...result.awsServerCapabilities })}`
             folder => !event.removed.some(removed => removed.uri === folder.uri)
         )
         this.workspaceFolders.push(
-            ...event.added.filter(added => !this.workspaceFolders.some(existing => existing.uri === added.uri))
+            ...event.added.filter(
+                added =>
+                    !this.workspaceFolders.some(
+                        existing => existing.uri.replace(/\/$/, '') === added.uri.replace(/\/$/, '')
+                    )
+            )
         )
         const params: DidChangeWorkspaceFoldersParams = { event }
 


### PR DESCRIPTION
## Problem
Previous solution only avoids exact the same URL but sometimes the URL is the same but some with '/' in the end that causes duplicates in rules.

## Solution
Remove the forward slash and then compare the values. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
