### PR TITLE
fix: refactor auto-discovery for OS proxy settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1422,7 +1422,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.1",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -1680,7 +1682,9 @@
             }
         },
         "node_modules/copyfiles/node_modules/brace-expansion": {
-            "version": "1.1.11",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2545,6 +2549,8 @@
         },
         "node_modules/is-electron": {
             "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+            "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
             "license": "MIT"
         },
         "node_modules/is-extglob": {
@@ -2892,21 +2898,19 @@
             "license": "Apache-2.0"
         },
         "node_modules/mac-ca": {
-            "version": "3.1.1",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/mac-ca/-/mac-ca-3.1.3.tgz",
+            "integrity": "sha512-yAdth+3TAfAyYYxNlnIJxKJbNOVvn9ZiQ1C9XJAj8ThKBBd5hu581sFjld3wr4DSrHcQwn7rt+t6dLiB+vFEFQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "node-forge": "^1.3.1",
                 "undici": "^6.16.1"
             }
         },
-        "node_modules/mac-system-proxy": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mac-system-proxy/-/mac-system-proxy-1.0.4.tgz",
-            "integrity": "sha512-IAkNLxXZrYuM99A2OhPrvUoAxohsxQciJh2D2xnD+R6vypn/AVyOYLsbZsMVCS/fEbLIe67nQ8krEAfqP12BVg==",
-            "license": "Apache-2.0"
-        },
         "node_modules/make-dir": {
             "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "license": "MIT",
             "dependencies": {
                 "pify": "^3.0.0"
@@ -3218,16 +3222,6 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/os-proxy-config": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/os-proxy-config/-/os-proxy-config-1.1.2.tgz",
-            "integrity": "sha512-sV7htE8y6NQORU0oKOUGTwQYe1gSFK3a3Z1i4h6YaqdrA9C0JIsUPQAqEkO8ejjYbRrQ+jsnks5qjtisr7042Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "mac-system-proxy": "^1.0.0",
-                "windows-system-proxy": "^1.0.0"
-            }
-        },
         "node_modules/p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -3345,6 +3339,8 @@
         },
         "node_modules/pify": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -3966,6 +3962,8 @@
         },
         "node_modules/split": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
             "license": "MIT",
             "dependencies": {
                 "through": "2"
@@ -4565,6 +4563,8 @@
         },
         "node_modules/win-ca": {
             "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/win-ca/-/win-ca-3.5.1.tgz",
+            "integrity": "sha512-RNy9gpBS6cxWHjfbqwBA7odaHyT+YQNhtdpJZwYCFoxB/Dq22oeOZ9YCXMwjhLytKpo7JJMnKdJ/ve7N12zzfQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -4572,15 +4572,6 @@
                 "make-dir": "^1.3.0",
                 "node-forge": "^1.2.1",
                 "split": "^1.0.1"
-            }
-        },
-        "node_modules/windows-system-proxy": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/windows-system-proxy/-/windows-system-proxy-1.0.0.tgz",
-            "integrity": "sha512-qd1WfyX9gjAqI36RHt95di2+FBr74DhvELd1EASgklCGScjwReHnWnXfUyabp/CJWl/IdnkUzG0Ub6Cv2R4KJQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "registry-js": "^1.15.1"
             }
         },
         "node_modules/workerpool": {
@@ -4723,7 +4714,7 @@
                 "hpagent": "^1.2.0",
                 "jose": "^5.9.6",
                 "mac-ca": "^3.1.1",
-                "os-proxy-config": "^1.1.2",
+                "registry-js": "^1.16.1",
                 "rxjs": "^7.8.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-protocol": "^3.17.5",

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -45,12 +45,12 @@
         "hpagent": "^1.2.0",
         "jose": "^5.9.6",
         "mac-ca": "^3.1.1",
-        "os-proxy-config": "^1.1.2",
         "rxjs": "^7.8.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-uri": "^3.1.0",
-        "win-ca": "^3.5.1"
+        "win-ca": "^3.5.1",
+        "registry-js": "^1.16.1"
     },
     "devDependencies": {
         "@types/mocha": "^10.0.9",

--- a/runtimes/runtimes/util/standalone/getProxySettings/getMacProxySettings.test.ts
+++ b/runtimes/runtimes/util/standalone/getProxySettings/getMacProxySettings.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Based on mac-system-proxy 1.0.2 (Apache-2.0). Modified for synchronous use
+ * https://github.com/httptoolkit/mac-system-proxy/blob/main/test/index.spec.ts
+ */
+import * as assert from 'assert'
+import { getMacSystemProxy } from './getMacProxySettings'
+
+describe('getMacSystemProxy', () => {
+    it('can get the Mac system proxy', function () {
+        if (process.platform !== 'darwin') return this.skip()
+
+        const result = getMacSystemProxy()
+        assert.ok(result === undefined || (typeof result === 'object' && result !== null))
+
+        if (result) {
+            assert.strictEqual(typeof result.proxyUrl, 'string')
+            assert.ok(Array.isArray(result.noProxy))
+        }
+    })
+
+    it('returns undefined on non-Mac platforms', function () {
+        if (process.platform === 'darwin') return this.skip()
+
+        const result = getMacSystemProxy()
+        assert.strictEqual(result, undefined)
+    })
+
+    it('handles scutil command failure gracefully', function () {
+        // This test verifies the function doesn't throw
+        assert.doesNotThrow(() => getMacSystemProxy())
+    })
+
+    it('returns undefined when no proxy is configured', function () {
+        if (process.platform !== 'darwin') return this.skip()
+
+        const result = getMacSystemProxy()
+        if (result) {
+            assert.strictEqual(typeof result.proxyUrl, 'string')
+            assert.ok(Array.isArray(result.noProxy))
+        }
+    })
+})

--- a/runtimes/runtimes/util/standalone/getProxySettings/getMacProxySettings.ts
+++ b/runtimes/runtimes/util/standalone/getProxySettings/getMacProxySettings.ts
@@ -1,0 +1,59 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Based on mac-system-proxy 1.0.2 (Apache-2.0). Modified for synchronous use
+ * https://github.com/httptoolkit/mac-system-proxy/blob/main/src/index.ts
+ */
+import { spawnSync } from 'child_process'
+import { parseScutilOutput } from './parseScutil'
+
+export interface ProxyConfig {
+    proxyUrl: string
+    noProxy: string[]
+}
+
+export function getMacSystemProxy(): ProxyConfig | undefined {
+    // Invoke `scutil --proxy` synchronously
+    console.debug('Executing scutil --proxy to retrieve Mac system proxy settings')
+    const result = spawnSync('scutil', ['--proxy'], { encoding: 'utf8' })
+    if (result.error || result.status !== 0) {
+        console.warn(`scutil --proxy failed: ${result.error?.message ?? 'exit code ' + result.status}`)
+        return undefined
+    }
+    console.debug('Successfully retrieved scutil output')
+
+    let settings: Record<string, any>
+    try {
+        settings = parseScutilOutput(result.stdout)
+    } catch (e: any) {
+        console.warn(`Failed to parse scutil output: ${e.message}`)
+        return undefined
+    }
+
+    const noProxy = settings.ExceptionsList ?? []
+
+    // Honor PAC URL first if configured
+    if (settings.ProxyAutoConfigEnable === '1' && settings.ProxyAutoConfigURLString) {
+        console.debug(`Using PAC URL: ${settings.ProxyAutoConfigURLString}`)
+        return { proxyUrl: settings.ProxyAutoConfigURLString, noProxy }
+    }
+
+    // Otherwise pick the first enabled protocol
+    console.debug('Checking for enabled proxy protocols')
+    if (settings.HTTPEnable === '1' && settings.HTTPProxy && settings.HTTPPort) {
+        console.debug(`Using HTTP proxy: ${settings.HTTPProxy}:${settings.HTTPPort}`)
+        return { proxyUrl: `http://${settings.HTTPProxy}:${settings.HTTPPort}`, noProxy }
+    }
+    if (settings.HTTPSEnable === '1' && settings.HTTPSProxy && settings.HTTPSPort) {
+        console.debug(`Using HTTPS proxy: ${settings.HTTPSProxy}:${settings.HTTPSPort}`)
+        return { proxyUrl: `http://${settings.HTTPSProxy}:${settings.HTTPSPort}`, noProxy }
+    }
+    // TODO: Enable support for SOCKS Proxy
+    // if (settings.SOCKSEnable === '1' && settings.SOCKSProxy && settings.SOCKSPort) {
+    //     console.debug(`Using SOCKS proxy: ${settings.SOCKSProxy}:${settings.SOCKSPort}`)
+    //     return { proxyUrl: `socks://${settings.SOCKSProxy}:${settings.SOCKSPort}`, noProxy }
+    // }
+
+    return undefined
+}

--- a/runtimes/runtimes/util/standalone/getProxySettings/getWindowsProxySettings.test.ts
+++ b/runtimes/runtimes/util/standalone/getProxySettings/getWindowsProxySettings.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Based on windows-system-proxy 1.0.0 (Apache-2.0).
+ * https://github.com/httptoolkit/windows-system-proxy/blob/main/test/index.spec.ts
+ */
+import * as assert from 'assert'
+import { getWindowsSystemProxy } from './getWindowsProxySettings'
+
+describe('getWindowsSystemProxy', () => {
+    it('can get the Windows system proxy', function () {
+        if (process.platform !== 'win32') return this.skip()
+
+        const result = getWindowsSystemProxy()
+        assert.ok(result === undefined || (typeof result === 'object' && result !== null))
+
+        if (result) {
+            assert.strictEqual(typeof result.proxyUrl, 'string')
+            assert.ok(Array.isArray(result.noProxy))
+        }
+    })
+
+    it('returns undefined on non-Windows platforms', function () {
+        if (process.platform === 'win32') return this.skip()
+
+        const result = getWindowsSystemProxy()
+        assert.strictEqual(result, undefined)
+    })
+
+    it('handles registry access failure gracefully', function () {
+        // This test verifies the function doesn't throw
+        assert.doesNotThrow(() => getWindowsSystemProxy())
+    })
+})

--- a/runtimes/runtimes/util/standalone/getProxySettings/getWindowsProxySettings.ts
+++ b/runtimes/runtimes/util/standalone/getProxySettings/getWindowsProxySettings.ts
@@ -1,0 +1,82 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Based on windows-system-proxy 1.0.0 (Apache-2.0). Modified for synchronous use
+ * https://github.com/httptoolkit/windows-system-proxy/blob/main/src/index.ts
+ */
+import { enumerateValues, HKEY, RegistryValue } from 'registry-js'
+
+export interface ProxyConfig {
+    proxyUrl: string
+    noProxy: string[]
+}
+
+export function getWindowsSystemProxy(): ProxyConfig | undefined {
+    const proxyValues = enumerateValues(
+        HKEY.HKEY_CURRENT_USER,
+        'Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings'
+    )
+    console.debug(`Retrieved ${proxyValues.length} registry values for proxy settings`)
+
+    const proxyEnabled = getValue(proxyValues, 'ProxyEnable')
+    const proxyServer = getValue(proxyValues, 'ProxyServer')
+
+    if (!proxyEnabled || !proxyEnabled.data || !proxyServer || !proxyServer.data) {
+        console.debug('Proxy not enabled or server not configured')
+        return undefined
+    }
+
+    // Build noProxy list from ProxyOverride (semicolon-separated, with <local> → localhost,127.0.0.1,::1)
+    const proxyOverride = getValue(proxyValues, 'ProxyOverride')?.data
+    const noProxy = (proxyOverride ? (proxyOverride as string).split(';') : []).flatMap(host =>
+        host === '<local>' ? ['localhost', '127.0.0.1', '::1'] : [host]
+    )
+
+    // Parse proxy configuration which can be in multiple formats
+    const proxyConfigString = proxyServer.data as string
+
+    if (proxyConfigString.startsWith('http://') || proxyConfigString.startsWith('https://')) {
+        console.debug('Using full URL format proxy configuration')
+        // Handle full URL format (documented in Microsoft registry configuration guide)
+        // https://docs.microsoft.com/en-us/troubleshoot/windows-client/networking/configure-client-proxy-server-settings-by-registry-file
+        return {
+            proxyUrl: proxyConfigString,
+            noProxy,
+        }
+    } else if (proxyConfigString.includes('=')) {
+        console.debug('Using protocol-specific format proxy configuration')
+        // Handle protocol-specific format: protocol=host;protocol=host pairs
+        // Prefer HTTPS, then HTTP, then SOCKS proxy
+        const proxies = Object.fromEntries(
+            proxyConfigString.split(';').map(proxyPair => proxyPair.split('=') as [string, string])
+        )
+
+        const proxyUrl = proxies['https']
+            ? `https://${proxies['https']}`
+            : proxies['http']
+              ? `http://${proxies['http']}`
+              : // TODO: Enable support for SOCKS Proxy
+                // proxies['socks'] ? `socks://${proxies['socks']}`:
+                undefined
+
+        if (!proxyUrl) {
+            throw new Error(`Could not get usable proxy URL from ${proxyConfigString}`)
+        }
+        console.debug(`Selected proxy URL: ${proxyUrl}`)
+
+        return {
+            proxyUrl,
+            noProxy,
+        }
+    } else {
+        console.debug('Using bare hostname format, defaulting to HTTP')
+        // Handle bare hostname format, default to HTTP
+        return {
+            proxyUrl: `http://${proxyConfigString}`,
+            noProxy,
+        }
+    }
+}
+
+const getValue = (values: readonly RegistryValue[], name: string) => values.find(value => value?.name === name)

--- a/runtimes/runtimes/util/standalone/getProxySettings/parseScutil.test.ts
+++ b/runtimes/runtimes/util/standalone/getProxySettings/parseScutil.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Based on mac-system-proxy 1.0.2 (Apache-2.0).
+ * https://github.com/httptoolkit/mac-system-proxy/blob/main/test/parse-scutil.spec.ts
+ */
+import * as assert from 'assert'
+import { parseScutilOutput } from './parseScutil'
+
+describe('parseScutilOutput', () => {
+    it('should parse totally blank scutil output', () => {
+        const parsed = parseScutilOutput('')
+        assert.deepStrictEqual(parsed, {})
+    })
+
+    it('should parse an empty proxy configuration', () => {
+        const parsed = parseScutilOutput(
+            `<dictionary> {
+}
+`
+        )
+        assert.deepStrictEqual(parsed, {})
+    })
+
+    it('should parse a disabled proxy configuration', () => {
+        const parsed = parseScutilOutput(
+            `<dictionary> {
+    HTTPEnable : 0
+    HTTPSEnable : 0
+}
+`
+        )
+        assert.deepStrictEqual(parsed, {
+            HTTPEnable: '0',
+            HTTPSEnable: '0',
+        })
+    })
+
+    it('should parse an empty proxy configuration with an exceptions array', () => {
+        const parsed = parseScutilOutput(
+            `<dictionary> {
+    ExceptionsList : <array> {
+        0 : localhost
+        1 : 127.0.0.1
+    }
+    ExcludeSimpleHostnames : 1
+    HTTPEnable : 0
+    HTTPSEnable : 0
+}
+`
+        )
+        assert.deepStrictEqual(parsed, {
+            ExceptionsList: ['localhost', '127.0.0.1'],
+            ExcludeSimpleHostnames: '1',
+            HTTPEnable: '0',
+            HTTPSEnable: '0',
+        })
+    })
+
+    it('should parse an empty proxy configuration with blank auth details', () => {
+        const parsed = parseScutilOutput(
+            `<dictionary> {
+    HTTPEnable : 0
+    HTTPSEnable : 0
+    HTTPSUser :${' '}
+    HTTPUser :${' '}
+}
+`
+        )
+        assert.deepStrictEqual(parsed, {
+            HTTPEnable: '0',
+            HTTPSEnable: '0',
+            HTTPSUser: '',
+            HTTPUser: '',
+        })
+    })
+
+    it('should parse an HTTP and HTTPS proxy configuration', () => {
+        const parsed = parseScutilOutput(
+            `<dictionary> {
+    ExcludeSimpleHostnames : 1
+    HTTPEnable : 1
+    HTTPPort : 8000
+    HTTPProxy : 127.0.0.1
+    HTTPSEnable : 1
+    HTTPSPort : 8443
+    HTTPSProxy : 127.0.0.1
+    HTTPSUser : domain\\user
+    SOCKSEnable : 0
+    SOCKSUser : user
+}
+`
+        )
+        assert.deepStrictEqual(parsed, {
+            ExcludeSimpleHostnames: '1',
+            HTTPEnable: '1',
+            HTTPPort: '8000',
+            HTTPProxy: '127.0.0.1',
+            HTTPSEnable: '1',
+            HTTPSPort: '8443',
+            HTTPSProxy: '127.0.0.1',
+            HTTPSUser: 'domain\\user',
+            SOCKSEnable: '0',
+            SOCKSUser: 'user',
+        })
+    })
+
+    it('should parse values containing commas', () => {
+        const parsed = parseScutilOutput(
+            `<dictionary> {
+    ExceptionsList : <array> {
+        0 : *.local, 169.254/16
+    }
+}
+`
+        )
+        assert.deepStrictEqual(parsed, {
+            ExceptionsList: ['*.local, 169.254/16'],
+        })
+    })
+
+    it('should parse an WPAD PAC proxy configuration', () => {
+        const parsed = parseScutilOutput(
+            `<dictionary> {
+    ExceptionsList : <array> {
+        0 : localhost
+        1 : 127.0.0.1
+    }
+    ExcludeSimpleHostnames : 1
+    HTTPEnable : 0
+    HTTPSEnable : 0
+    ProxyAutoConfigEnable : 1
+    ProxyAutoConfigURLString : http://wpad/wpad.dat
+    ProxyAutoDiscoveryEnable : 1
+}
+`
+        )
+        assert.deepStrictEqual(parsed, {
+            ExceptionsList: ['localhost', '127.0.0.1'],
+            ExcludeSimpleHostnames: '1',
+            HTTPEnable: '0',
+            HTTPSEnable: '0',
+            ProxyAutoConfigEnable: '1',
+            ProxyAutoConfigURLString: 'http://wpad/wpad.dat',
+            ProxyAutoDiscoveryEnable: '1',
+        })
+    })
+
+    it('should parse a SOCKS proxy configuration', () => {
+        const parsed = parseScutilOutput(
+            `<dictionary> {
+    ExcludeSimpleHostnames : 1
+    HTTPEnable : 0
+    HTTPSEnable : 0
+    SOCKSEnable : 1
+    SOCKSPort : 2020
+    SOCKSProxy : 127.0.0.1
+    SOCKSUser : user
+}
+`
+        )
+        assert.deepStrictEqual(parsed, {
+            ExcludeSimpleHostnames: '1',
+            HTTPEnable: '0',
+            HTTPSEnable: '0',
+            SOCKSEnable: '1',
+            SOCKSPort: '2020',
+            SOCKSProxy: '127.0.0.1',
+            SOCKSUser: 'user',
+        })
+    })
+
+    it('should parse an explicit PAC configuration', () => {
+        const parsed = parseScutilOutput(
+            `<dictionary> {
+    ExcludeSimpleHostnames : 1
+    HTTPEnable : 0
+    HTTPSEnable : 0
+    ProxyAutoConfigEnable : 1
+    ProxyAutoConfigURLString : http://example.com/proxy.pac
+}
+`
+        )
+        assert.deepStrictEqual(parsed, {
+            ExcludeSimpleHostnames: '1',
+            HTTPEnable: '0',
+            HTTPSEnable: '0',
+            ProxyAutoConfigEnable: '1',
+            ProxyAutoConfigURLString: 'http://example.com/proxy.pac',
+        })
+    })
+
+    it('should parse a complex made-up output structure', () => {
+        const parsed = parseScutilOutput(
+            `<dictionary> {
+    InitialValue : :value:
+    FirstArray : <array> {
+    }
+    SecondArray : <array> {
+        0 : .
+    }
+    ThirdArray : <array> {
+        0 : <dictionary> {
+            inner-value : special{value}
+        }
+    }
+    Value : <dictionary> {
+        a : b
+        c : d
+    }
+}
+`
+        )
+        assert.deepStrictEqual(parsed, {
+            InitialValue: ':value:',
+            FirstArray: [],
+            SecondArray: ['.'],
+            ThirdArray: [{ 'inner-value': 'special{value}' }],
+            Value: {
+                a: 'b',
+                c: 'd',
+            },
+        })
+    })
+
+    it('should clearly error given invalid input', () => {
+        assert.throws(() => parseScutilOutput('{'), /Unexpected scutil proxy output format/)
+    })
+
+    it('should clearly error given incomplete value', () => {
+        assert.throws(
+            () =>
+                parseScutilOutput(
+                    `<dictionary> {
+    IncompleteValue :
+}
+`
+                ),
+            /Unexpected scutil proxy output format/
+        )
+    })
+
+    it('should handle corrupted local user file data', () => {
+        assert.throws(() => parseScutilOutput('corrupted\x00\x01data'), /Unexpected scutil proxy output format/)
+    })
+})

--- a/runtimes/runtimes/util/standalone/getProxySettings/parseScutil.ts
+++ b/runtimes/runtimes/util/standalone/getProxySettings/parseScutil.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Based on mac-system-proxy 1.0.2 (Apache-2.0).
+ * https://github.com/httptoolkit/mac-system-proxy/blob/main/src/parse-scutil.ts
+ */
+const TYPE_KEY = '__scutil__type__'
+
+// Quick hacky parser, which translates output into valid JSON:
+export function parseScutilOutput(output: string): {} {
+    try {
+        // Unclear how this happens, but it seems that it can in some cases:
+        if (output === '') return {}
+
+        const unquotedJsonString = output
+            // Reduce type markers to just an inline __scutil__type__ marker on array objects:
+            .replace(/<dictionary> /g, '')
+            .replace(/<array> {/g, `{\n${TYPE_KEY} : array`)
+            .trim()
+
+        // Turn unquoted key/value string into a string of quote key values (but with no commas).
+        // We effectively parse by splitting on the first " : " in each line, if present.
+        const jsonKeyValues = unquotedJsonString.split('\n').map(line => {
+            const [key, value] = line.split(/ : (.*)/)
+
+            if (value === undefined) return key.trim()
+            else if (value === '{') return `"${key.trim()}": {`
+            else return `"${key.trim()}": ${JSON.stringify(value.trim())}`
+        })
+
+        // Insert commas everywhere they're needed
+        const jsonFormattedString = jsonKeyValues.reduce((jsonString, nextValue) => {
+            if (!jsonString || jsonString.endsWith('{') || nextValue === '}') {
+                // JSON has no commas after/before object {} tokens or
+                // at the very start of the string:
+                return jsonString + nextValue
+            } else {
+                return jsonString + ', ' + nextValue
+            }
+        }, '')
+
+        const data = JSON.parse(jsonFormattedString, (key, value) => {
+            // Convert array-tagged objects back into arrays:
+            if (value[TYPE_KEY] === 'array') {
+                delete value[TYPE_KEY]
+                return Object.values(value)
+            } else {
+                return value
+            }
+        })
+
+        return data
+    } catch (e) {
+        throw Object.assign(
+            new Error('Unexpected scutil proxy output format'),
+            { scutilOutput: output } // Attach output for debugging elsewhere
+        )
+    }
+}


### PR DESCRIPTION
# Problem

Related PR:
- https://github.com/aws/language-server-runtimes/pull/553

We originally bolted on an exec-time shim that `require.resolve’d` [os-proxy-config](https://www.npmjs.com/package/os-proxy-config) and ran it in a child-process so we could keep `ProxyConfigManager.getSystemProxySync()` fully synchronous. This avoided a ripple-effect async refactor through every SDK-initialisation call-chain and let us ship quickly, but it also meant the code was never picked up by Webpack, so the proxy lookup silently no-oped inside the bundled LSP.


## Solution

- Vendored the tiny os-proxy-config implementation directly  (`getMacProxySettings.ts`, `getWindowsProxySettings.ts`) and removed the child-process shim.
   - Reference Code: [os-proxy-config](https://github.com/httptoolkit/os-proxy-config), [windows-system-proxy](https://github.com/httptoolkit/windows-system-proxy/tree/main), [mac-system-proxy](https://github.com/httptoolkit/mac-system-proxy/tree/main)
- Re-wrote the Windows & macOS helpers to expose sync variants (registry reads with `registry-js` sync API, `scutil --proxy` via `spawnSync`) so `getSystemProxy()` remains blocking.
- Behaviour is unchanged for callers, but proxy auto-detect now runs in all packed LSPs because the code is part of the bundle.

## TODO
- Add support for SOCKS Proxy

## Testing

Simulated customer proxy environments on Windows and Mac and tested plugin build:

- #### Mac

Proxy is being auto-detected and requests are going through proxy:

<img width="1244" alt="Screenshot 2025-07-01 at 12 44 15 AM" src="https://github.com/user-attachments/assets/53989ccb-c39b-4276-b447-ff3f50cf867a" />


- #### Windows

Proxy is being auto-detected and requests are going through proxy:

```
Using bare hostname format, defaulting to HTTP
[Trace - 6:30:06 PM] Received notification 'telemetry/event'.
Params: {
    "name": "runtime_httpProxyConfiguration",
    "result": "Succeeded",
    "data": {
        "proxyMode": "AutoDetect",
        "certificatesNumber": 208,
        "proxyUrl": "http://localhost:8888/"
    }
}
```

<img width="1287" alt="Screenshot 2025-07-01 at 6 32 53 PM" src="https://github.com/user-attachments/assets/494b264c-7049-4a52-81d3-c0b94f91a2ac" />


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
