### PR TITLE
feat: adding nextToken to InlineCompletionWithReferencesParams

### DIFF
--- a/runtimes/protocol/inlineCompletionWithReferences.ts
+++ b/runtimes/protocol/inlineCompletionWithReferences.ts
@@ -9,7 +9,10 @@ import {
 
 import { ProtocolNotificationType, ProtocolRequestType } from 'vscode-languageserver-protocol'
 
-export type InlineCompletionWithReferencesParams = InlineCompletionParams & PartialResultParams
+export type InlineCompletionWithReferencesParams = InlineCompletionParams &
+    PartialResultParams & {
+        nextToken?: string
+    }
 
 export const inlineCompletionWithReferencesRequestType = new ProtocolRequestType<
     InlineCompletionWithReferencesParams,


### PR DESCRIPTION
## Problem

adding nextToken to InlineCompletionWithReferencesParams for NEP trigger via user acceptance

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
