### PR TITLE
refactor(runtimes): make type parameter optional in credentialsProvider

### DIFF
--- a/runtimes/runtimes/standalone.test.ts
+++ b/runtimes/runtimes/standalone.test.ts
@@ -53,6 +53,7 @@ describe('standalone', () => {
             authStub.getCredentialsProvider.returns({
                 hasCredentials: sinon.stub().returns(false),
                 getCredentials: sinon.stub().returns(undefined),
+                getCredentialsType: sinon.stub().returns(undefined),
                 getConnectionMetadata: sinon.stub().returns(undefined),
                 getConnectionType: sinon.stub().returns('none'),
                 onCredentialsDeleted: sinon.stub(),
@@ -91,6 +92,7 @@ describe('standalone', () => {
             authStub.getCredentialsProvider.returns({
                 hasCredentials: sinon.stub().returns(false),
                 getCredentials: sinon.stub().returns(undefined),
+                getCredentialsType: sinon.stub().returns(undefined),
                 getConnectionMetadata: sinon.stub().returns(undefined),
                 getConnectionType: sinon.stub().returns('none'),
                 onCredentialsDeleted: sinon.stub(),

--- a/runtimes/server-interface/auth.ts
+++ b/runtimes/server-interface/auth.ts
@@ -8,8 +8,9 @@ export type Credentials = IamCredentials | BearerCredentials
 export type SsoConnectionType = 'builderId' | 'identityCenter' | 'none'
 
 export interface CredentialsProvider {
-    hasCredentials: (type: CredentialsType) => boolean
-    getCredentials: (type: CredentialsType) => Credentials | undefined
+    hasCredentials: (type?: CredentialsType) => boolean
+    getCredentials: (type?: CredentialsType) => Credentials | undefined
+    getCredentialsType: () => CredentialsType | undefined
     getConnectionMetadata: () => ConnectionMetadata | undefined
     getConnectionType: () => SsoConnectionType
     onCredentialsDeleted: (handler: (type: CredentialsType) => void) => void

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -2,6 +2,7 @@ export type IamCredentials = {
     readonly accessKeyId: string
     readonly secretAccessKey: string
     readonly sessionToken?: string
+    readonly expiration?: Date
 }
 
 export type BearerCredentials = {


### PR DESCRIPTION
## Problem
To help consolidate the token and IAM implementations of aws-lsp-codewhisperer, the type argument should be optional when retrieving a credential from the credentialsProvider. This would allow the codewhisperer LSP to figure out the appropriate clients to construct based on the return type of getCredentials (either IamCredentials or BearerCredentials), since the Q developer streaming client only allows IAM credentials authentication and the CodeWhisperer streaming client only allows SSO authentication. This would in turn eliminate the need to separate the codewhisperer LSP into IAM and Token bundles, since it will be able to switch between authorization methods at runtime instead of only at compile-time.

## Solution
This is part of #572 

This PR refactors the Auth class to use a single set of credentials called currentCredentials instead of iamCredentials and bearerCredentials. This makes the hasCredentials and getCredentials well-defined when they are not provided a type parameter; they will simply return currentCredentials. If these methods are provided with a type parameter, they will perform a type check and return the appropriate response.

This PR assumes the iamCredentials and bearerCredentials are never used simultaneously at runtime.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
