### PR TITLE
fix(runtimes): timeout for exiting to emit logs

### DIFF
--- a/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
+++ b/runtimes/runtimes/operational-telemetry/operational-telemetry-service.ts
@@ -74,7 +74,10 @@ export class OperationalTelemetryService implements OperationalTelemetry {
         process.on('uncaughtException', async () => {
             // Telemetry signals are force flushed to their exporters on shutdown.
             await this.shutdownApi()
-            process.exit(1)
+            // Wait 30 seconds to allow telemetry and logging to be processed
+            setTimeout(() => {
+                process.exit(1)
+            }, 30000)
         })
 
         process.on('beforeExit', async () => {


### PR DESCRIPTION
## Problem
LSP was exiting on Uncaught Exception before the error message could be logged, making it difficult to debug root cause
## Solution
Add a timeout for the exit process to let the server emit telemetry and log the error before exiting
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
