### PR TITLE
fix: in standalone, log uncaughtException errors directly to stderr

### DIFF
--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -86,6 +86,8 @@ import { makeProxyConfigv2Standalone, makeProxyConfigv3Standalone } from './util
 import { newAgent } from './agent'
 import { ShowSaveFileDialogRequestType } from '../protocol/window'
 import { getTelemetryReasonDesc } from './util/shared'
+import { writeSync } from 'fs'
+import { format } from 'util'
 
 // Honor shared aws config file
 if (checkAWSConfigFile()) {
@@ -105,7 +107,10 @@ function setupCrashMonitoring(telemetryEmitter?: (metric: MetricEvent) => void) 
     }
 
     process.on('uncaughtExceptionMonitor', (err, origin) => {
+        // also emit to stderr in case stdout does not completely drain
+        // console error is monkey-patched by vscode-languageserver in stdio mode to log to client instead of stderr
         console.error('Uncaught Exception:', err.message, getTopStackFrames(err))
+        writeSync(process.stderr.fd, `Uncaught exception: ${format(err)}\n` + `Exception origin: ${origin}\n`)
 
         if (telemetryEmitter) {
             try {


### PR DESCRIPTION
## Problem
when server is exiting unexpectedly,
there is no guarantee that console.log will propagate back to LSP client

## Solution
log directly to stderr

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
