### PR TITLE
fix: add document change params to inline completion params

### DIFF
--- a/runtimes/protocol/inlineCompletionWithReferences.ts
+++ b/runtimes/protocol/inlineCompletionWithReferences.ts
@@ -7,9 +7,17 @@ import {
     PartialResultParams,
 } from './lsp'
 
-import { ProtocolNotificationType, ProtocolRequestType } from 'vscode-languageserver-protocol'
+import {
+    DidChangeTextDocumentParams,
+    ProtocolNotificationType,
+    ProtocolRequestType,
+} from 'vscode-languageserver-protocol'
 
-export type InlineCompletionWithReferencesParams = InlineCompletionParams & PartialResultParams
+interface DocumentChangeParams {
+    documentChangeParams?: DidChangeTextDocumentParams
+}
+
+export type InlineCompletionWithReferencesParams = InlineCompletionParams & PartialResultParams & DocumentChangeParams
 
 export const inlineCompletionWithReferencesRequestType = new ProtocolRequestType<
     InlineCompletionWithReferencesParams,


### PR DESCRIPTION
## Problem

In VSC and JB, we rely on DocumentChangeEvent as the input triggering condition for auto triggers and use the exact user input for the auto trigger classifier. Guessing the input character is not accurate, and as you can see in the source code the TODO has been there for a year or longer. When it comes to deleting characters, the input is empty but Flare is guessing user input last left char. When user copied multi characters, the input is a multi char string but Flare guessing user input last left char. This will make the classifier output incorrect values passing or lower than the threshold

See https://github.com/aws/language-servers/blob/586877dcebe2d9f912a703193b35c60f78d66734/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts#L325


## Solution

Add document change event in the inline completion params.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
