### PR TITLE
revert: revert: subscription details protocols #620 (#623)"

### DIFF
--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -208,6 +208,8 @@ The runtime supports chat by default
 | Send tab bar action request (e.g., export). | `aws/chat/tabBarAction`          | `TabBarActionParams`          | [Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage) Client to Server | `TabBarActionResult`             |
 | Send request to get serialized chat content in specified format. | `aws/chat/getSerializedChat`          | `GetSerializedChatParams`          | [Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage) Client to Server | `GetSerializedChatResult`             |
 | Send request to open file dialog for file selection. | `aws/chat/openFileDialog`          | `OpenFileDialogParams`          | [Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage) Client to Server | `OpenFileDialogResult`             |
+| Sent to display subscription information in the chat UI | `aws/chat/subscription/details` | SubscriptionDetailsParams | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) Server to Client | n/a |
+| Sent to begin a subscription upgrade | `aws/chat/subscription/upgrade` | SubscriptionUpgradeParams | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) Client to Server | n/a |
 
 
 ```ts

--- a/runtimes/protocol/chat.ts
+++ b/runtimes/protocol/chat.ts
@@ -91,6 +91,10 @@ import {
     LIST_AVAILABLE_MODELS_REQUEST_METHOD,
     ListAvailableModelsResult,
     ListAvailableModelsParams,
+    SUBSCRIPTION_DETAILS_NOTIFICATION_METHOD,
+    SubscriptionDetailsParams,
+    SUBSCRIPTION_UPGRADE_NOTIFICATION_METHOD,
+    SubscriptionUpgradeParams,
 } from './lsp'
 
 export const chatRequestType = new AutoParameterStructuresProtocolRequestType<
@@ -279,3 +283,21 @@ export const listAvailableModelsRequestType = new ProtocolRequestType<
     void,
     void
 >(LIST_AVAILABLE_MODELS_REQUEST_METHOD)
+
+// Subscription Tiers
+
+/**
+ * Subscription Details Notification is sent from server to client, with the expectation that
+ * the client will display the subscription details in the Chat UI.
+ */
+export const subscriptionDetailsNotificationType = new ProtocolNotificationType<SubscriptionDetailsParams, void>(
+    SUBSCRIPTION_DETAILS_NOTIFICATION_METHOD
+)
+
+/**
+ * Subscription Details Notification is sent from Chat UI through client over to server.
+ * Flare will then ask the client to open a URL in the browser.
+ */
+export const subscriptionUpgradeNotificationType = new ProtocolNotificationType<SubscriptionUpgradeParams, void>(
+    SUBSCRIPTION_UPGRADE_NOTIFICATION_METHOD
+)

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -60,6 +60,8 @@ import {
     onPinnedContextRemoveNotificationType,
     openFileDialogRequestType,
     listAvailableModelsRequestType,
+    subscriptionDetailsNotificationType,
+    subscriptionUpgradeNotificationType,
 } from '../protocol'
 import { createConnection } from 'vscode-languageserver/browser'
 import {
@@ -200,6 +202,10 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
         onOpenFileDialog: handler => lspConnection.onRequest(openFileDialogRequestType.method, handler),
         onRuleClick: handler => lspConnection.onRequest(ruleClickRequestType.method, handler),
         onListAvailableModels: handler => lspConnection.onRequest(listAvailableModelsRequestType.method, handler),
+        sendSubscriptionDetails: params =>
+            lspConnection.sendNotification(subscriptionDetailsNotificationType.method, params),
+        onSubscriptionUpgrade: handler =>
+            lspConnection.onNotification(subscriptionUpgradeNotificationType.method, handler),
     }
 
     const identityManagement: IdentityManagement = {

--- a/runtimes/runtimes/chat/baseChat.ts
+++ b/runtimes/runtimes/chat/baseChat.ts
@@ -88,6 +88,10 @@ import {
     ListAvailableModelsParams,
     ListAvailableModelsResult,
     listAvailableModelsRequestType,
+    SubscriptionDetailsParams,
+    subscriptionDetailsNotificationType,
+    subscriptionUpgradeNotificationType,
+    SubscriptionUpgradeParams,
 } from '../../protocol'
 import { Chat } from '../../server-interface'
 
@@ -242,5 +246,13 @@ export class BaseChat implements Chat {
 
     public onListAvailableModels(handler: RequestHandler<ListAvailableModelsParams, ListAvailableModelsResult, void>) {
         this.connection.onRequest(listAvailableModelsRequestType.method, handler)
+    }
+
+    public sendSubscriptionDetails(params: SubscriptionDetailsParams) {
+        this.connection.sendNotification(subscriptionDetailsNotificationType.method, params)
+    }
+
+    public onSubscriptionUpgrade(handler: NotificationHandler<SubscriptionUpgradeParams>) {
+        this.connection.onNotification(subscriptionUpgradeNotificationType.method, handler)
     }
 }

--- a/runtimes/server-interface/chat.ts
+++ b/runtimes/server-interface/chat.ts
@@ -51,6 +51,8 @@ import {
     ActiveEditorChangedParams,
     ListAvailableModelsParams,
     ListAvailableModelsResult,
+    SubscriptionDetailsParams,
+    SubscriptionUpgradeParams,
 } from '../protocol'
 
 /**
@@ -100,4 +102,6 @@ export type Chat = {
     onCreatePrompt: (handler: NotificationHandler<CreatePromptParams>) => void
     onInlineChatResult: (handler: NotificationHandler<InlineChatResultParams>) => void
     onPromptInputOptionChange: (handler: NotificationHandler<PromptInputOptionChangeParams>) => void
+    sendSubscriptionDetails: (params: SubscriptionDetailsParams) => void
+    onSubscriptionUpgrade: (handler: NotificationHandler<SubscriptionUpgradeParams>) => void
 }

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -56,6 +56,11 @@ export const LIST_AVAILABLE_MODELS_REQUEST_METHOD = 'aws/chat/listAvailableModel
 // button ids
 export const OPEN_WORKSPACE_INDEX_SETTINGS_BUTTON_ID = 'open-settings-for-ws-index'
 
+// Subscription Tiers
+export const SUBSCRIPTION_DETAILS_NOTIFICATION_METHOD = 'aws/chat/subscription/details'
+export const SUBSCRIPTION_UPGRADE_NOTIFICATION_METHOD = 'aws/chat/subscription/upgrade'
+export const SUBSCRIPTION_SHOW_COMMAND_METHOD = 'aws/chat/subscription/show'
+
 export interface ChatItemAction {
     pillText: string
     prompt?: string
@@ -276,6 +281,11 @@ export interface ChatOptions {
      * Server signals to Chat Client support of Chat export feature.
      */
     export?: boolean
+
+    /**
+     * Server signals to Client and Chat Client that it supports subscription tier operations
+     */
+    subscriptionDetails?: boolean
 
     /*
         Server signals to Chat Client support of Chat notifications.
@@ -695,3 +705,13 @@ export interface ListAvailableModelsResult {
 export interface ExecuteShellCommandParams {
     id: string
 }
+
+export interface SubscriptionDetailsParams {
+    subscriptionTier: string
+    queryUsage: number
+    queryLimit: number
+    queryOverage: number
+    daysRemaining: number
+}
+
+export interface SubscriptionUpgradeParams {}


### PR DESCRIPTION

This reverts commit 9cec0d7a3ce9001a1ef7f0b3c72a624a1c8919b3 (#623).

#620 was reverted because supporting changes weren't added to language-servers repo in order to prevent a compilation failure. These protocol changes are being developed in a feature branch, so it will be a while before they are integrated into the main repo.

Do not merge this commit until after https://github.com/aws/language-servers/pull/1925 has been merged into the language servers repo. This will prevent the compilation failures by stubbing (omitting) the functions being added to `Chat`


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
