### PR TITLE
refactor: rename fields on getIamCredential params and result

### DIFF
--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -54,11 +54,20 @@ export class AwsResponseError extends ResponseError<AwsResponseErrorData> {
 }
 
 // listProfiles
-export type ProfileKind = 'Unknown' | 'SsoTokenProfile' | 'IamCredentialProfile'
+export type ProfileKind =
+    | 'Unknown'
+    | 'SsoTokenProfile'
+    | 'IamUserProfile'
+    | 'RoleSourceProfile'
+    | 'RoleInstanceProfile'
+    | 'ProcessProfile'
 
 export const ProfileKind = {
     SsoTokenProfile: 'SsoTokenProfile',
-    IamCredentialProfile: 'IamCredentialProfile',
+    IamUserProfile: 'IamUserProfile',
+    RoleSourceProfile: 'RoleSourceProfile',
+    RoleInstanceProfile: 'RoleInstanceProfile',
+    ProcessProfile: 'ProcessProfile',
     Unknown: 'Unknown',
 } as const
 
@@ -76,7 +85,11 @@ export interface Profile {
         aws_secret_access_key?: string
         aws_session_token?: string
         role_arn?: string
+        role_session_name?: string
         credential_process?: string
+        credential_source?: string
+        source_profile?: string
+        mfa_serial?: string
     }
 }
 

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -90,6 +90,7 @@ export interface Profile {
         credential_source?: string
         source_profile?: string
         mfa_serial?: string
+        external_id?: string
     }
 }
 

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -38,10 +38,32 @@ export const AwsErrorCodes = {
     E_STS_CREDENTIAL_EXPIRED: 'E_STS_CREDENTIAL_EXPIRED',
     E_SSO_TOKEN_SOURCE_NOT_SUPPORTED: 'E_SSO_TOKEN_SOURCE_NOT_SUPPORTED',
     E_MFA_REQUIRED: 'E_MFA_REQUIRED',
+    E_PERMISSION_DENIED: 'E_PERMISSION_DENIED',
     E_TIMEOUT: 'E_TIMEOUT',
     E_UNKNOWN: 'E_UNKNOWN',
     E_CANCELLED: 'E_CANCELLED',
 } as const
+
+// Permissions
+export const PermissionSets = {
+    Q: [
+        'q:StartConversation',
+        'q:SendMessage',
+        'q:GetConversation',
+        'q:ListConversations',
+        'q:UpdateConversation',
+        'q:DeleteConversation',
+        'q:PassRequest',
+        'q:StartTroubleshootingAnalysis',
+        'q:StartTroubleshootingResolutionExplanation',
+        'q:GetTroubleshootingResults',
+        'q:UpdateTroubleshootingCommandResult',
+        'q:GetIdentityMetaData',
+        'q:GenerateCodeFromCommands',
+        'q:UsePlugin',
+        'codewhisperer:GenerateRecommendations',
+    ],
+}
 
 export interface AwsResponseErrorData {
     awsErrorCode: string
@@ -253,12 +275,12 @@ export type IamCredentialId = string // Opaque identifier
 
 export interface GetIamCredentialOptions {
     callStsOnInvalidIamCredential?: boolean
-    validatePermissions?: boolean
+    permissionSet?: string[]
 }
 
 export const getIamCredentialOptionsDefaults = {
     callStsOnInvalidIamCredential: true,
-    validatePermissions: true,
+    permissionSet: PermissionSets.Q,
 } satisfies GetIamCredentialOptions
 
 export interface GetIamCredentialParams {
@@ -266,9 +288,13 @@ export interface GetIamCredentialParams {
     options?: GetIamCredentialOptions
 }
 
-export interface GetIamCredentialResult {
-    id: IamCredentialId
+export interface IamCredential {
+    id: string
     credentials: IamCredentials
+}
+
+export interface GetIamCredentialResult {
+    credential: IamCredential
     updateCredentialsParams: UpdateCredentialsParams
 }
 

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -58,17 +58,17 @@ export class AwsResponseError extends ResponseError<AwsResponseErrorData> {
 export type ProfileKind =
     | 'Unknown'
     | 'SsoTokenProfile'
-    | 'IamUserProfile'
-    | 'IamRoleSourceProfile'
-    | 'IamRoleInstanceProfile'
-    | 'IamProcessProfile'
+    | 'IamCredentialsProfile'
+    | 'IamSourceProfileProfile'
+    | 'IamCredentialSourceProfile'
+    | 'IamCredentialProcessProfile'
 
 export const ProfileKind = {
     SsoTokenProfile: 'SsoTokenProfile',
-    IamUserProfile: 'IamUserProfile',
-    IamRoleSourceProfile: 'IamRoleSourceProfile',
-    IamRoleInstanceProfile: 'IamRoleInstanceProfile',
-    IamProcessProfile: 'IamProcessProfile',
+    IamCredentialsProfile: 'IamCredentialsProfile',
+    IamSourceProfileProfile: 'IamSourceProfileProfile',
+    IamCredentialSourceProfile: 'IamCredentialSourceProfile',
+    IamCredentialProcessProfile: 'IamCredentialProcessProfile',
     Unknown: 'Unknown',
 } as const
 
@@ -92,6 +92,8 @@ export interface Profile {
         source_profile?: string
         mfa_serial?: string
         external_id?: string
+        credential_cache?: string
+        credential_cache_location?: string
     }
 }
 
@@ -250,12 +252,12 @@ export const getSsoTokenRequestType = new ProtocolRequestType<
 export type IamCredentialId = string // Opaque identifier
 
 export interface GetIamCredentialOptions {
-    generateOnInvalidStsCredential?: boolean
+    callStsOnInvalidIamCredential?: boolean
     validatePermissions?: boolean
 }
 
 export const getIamCredentialOptionsDefaults = {
-    generateOnInvalidStsCredential: true,
+    callStsOnInvalidIamCredential: true,
     validatePermissions: true,
 } satisfies GetIamCredentialOptions
 

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -54,16 +54,15 @@ export class AwsResponseError extends ResponseError<AwsResponseErrorData> {
 }
 
 // listProfiles
-export type ProfileKind = 'Unknown' | 'SsoTokenProfile' | 'IamCredentialProfile' | 'EmptyProfile'
+export type ProfileKind = 'Unknown' | 'SsoTokenProfile' | 'IamCredentialProfile'
 
 export const ProfileKind = {
     SsoTokenProfile: 'SsoTokenProfile',
     IamCredentialProfile: 'IamCredentialProfile',
-    EmptyProfile: 'EmptyProfile',
     Unknown: 'Unknown',
 } as const
 
-// Profile and SsoSession use 'settings' property as namescope for their settings to avoid future
+// Profile and Session use 'settings' property as namescope for their settings to avoid future
 // name conflicts with 'kinds', 'name', and future properties as well as making some setting
 // iteration operations easier.
 
@@ -77,6 +76,7 @@ export interface Profile {
         aws_secret_access_key?: string
         aws_session_token?: string
         role_arn?: string
+        credential_process?: string
     }
 }
 

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -58,16 +58,16 @@ export type ProfileKind =
     | 'Unknown'
     | 'SsoTokenProfile'
     | 'IamUserProfile'
-    | 'RoleSourceProfile'
-    | 'RoleInstanceProfile'
-    | 'ProcessProfile'
+    | 'IamRoleSourceProfile'
+    | 'IamRoleInstanceProfile'
+    | 'IamProcessProfile'
 
 export const ProfileKind = {
     SsoTokenProfile: 'SsoTokenProfile',
     IamUserProfile: 'IamUserProfile',
-    RoleSourceProfile: 'RoleSourceProfile',
-    RoleInstanceProfile: 'RoleInstanceProfile',
-    ProcessProfile: 'ProcessProfile',
+    IamRoleSourceProfile: 'IamRoleSourceProfile',
+    IamRoleInstanceProfile: 'IamRoleInstanceProfile',
+    IamProcessProfile: 'IamProcessProfile',
     Unknown: 'Unknown',
 } as const
 

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -289,7 +289,8 @@ export interface GetIamCredentialParams {
 }
 
 export interface IamCredential {
-    id: string
+    id: IamCredentialId
+    kinds: ProfileKind[]
     credentials: IamCredentials
 }
 
@@ -344,7 +345,7 @@ export const invalidateSsoTokenRequestType = new ProtocolRequestType<
 
 // invalidateStsCredential
 export interface InvalidateStsCredentialParams {
-    profileName: string
+    iamCredentialId: IamCredentialId
 }
 
 export interface InvalidateStsCredentialResult {

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -157,7 +157,7 @@ export const updateProfileRequestType = new ProtocolRequestType<
 >('aws/identity/updateProfile')
 
 // getSsoToken
-export type CredentialId = string // Opaque identifier
+export type SsoTokenId = string // Opaque identifier
 
 export type IamIdentityCenterSsoTokenSourceKind = 'IamIdentityCenter'
 export type AwsBuilderIdSsoTokenSourceKind = 'AwsBuilderId'
@@ -225,7 +225,7 @@ export interface GetSsoTokenParams {
 }
 
 export interface SsoToken {
-    id: CredentialId
+    id: SsoTokenId
     accessToken: string // This field is encrypted with JWT like 'update'
     // Additional fields captured in token cache file may be added here in the future
 }
@@ -245,6 +245,8 @@ export const getSsoTokenRequestType = new ProtocolRequestType<
 >('aws/identity/getSsoToken')
 
 // getIamCredential
+export type IamCredentialId = string // Opaque identifier
+
 export interface GetIamCredentialOptions {
     generateOnInvalidStsCredential?: boolean
 }
@@ -260,7 +262,7 @@ export interface GetIamCredentialParams {
 }
 
 export interface GetIamCredentialResult {
-    id: CredentialId
+    id: IamCredentialId
     credentials: IamCredentials
     updateCredentialsParams: UpdateCredentialsParams
 }
@@ -275,7 +277,7 @@ export const getIamCredentialRequestType = new ProtocolRequestType<
 
 // invalidateSsoToken
 export interface InvalidateSsoTokenParams {
-    ssoTokenId: CredentialId
+    ssoTokenId: SsoTokenId
 }
 
 export interface InvalidateSsoTokenResult {
@@ -321,7 +323,7 @@ export const SsoTokenChangedKind = {
 
 export interface SsoTokenChangedParams {
     kind: SsoTokenChangedKind
-    ssoTokenId: CredentialId
+    ssoTokenId: SsoTokenId
 }
 
 export const ssoTokenChangedRequestType = new ProtocolNotificationType<SsoTokenChangedParams, void>(
@@ -338,7 +340,7 @@ export const StsCredentialChangedKind = {
 
 export interface StsCredentialChangedParams {
     kind: StsCredentialChangedKind
-    stsCredentialId: CredentialId
+    stsCredentialId: IamCredentialId
 }
 
 export const stsCredentialChangedRequestType = new ProtocolNotificationType<StsCredentialChangedParams, void>(

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -37,6 +37,7 @@ export const AwsErrorCodes = {
     E_SSO_TOKEN_EXPIRED: 'E_SSO_TOKEN_EXPIRED',
     E_STS_CREDENTIAL_EXPIRED: 'E_STS_CREDENTIAL_EXPIRED',
     E_SSO_TOKEN_SOURCE_NOT_SUPPORTED: 'E_SSO_TOKEN_SOURCE_NOT_SUPPORTED',
+    E_MFA_REQUIRED: 'E_MFA_REQUIRED',
     E_TIMEOUT: 'E_TIMEOUT',
     E_UNKNOWN: 'E_UNKNOWN',
     E_CANCELLED: 'E_CANCELLED',
@@ -260,7 +261,6 @@ export const getIamCredentialOptionsDefaults = {
 
 export interface GetIamCredentialParams {
     profileName: string
-    mfaCode?: string
     options?: GetIamCredentialOptions
 }
 
@@ -277,6 +277,23 @@ export const getIamCredentialRequestType = new ProtocolRequestType<
     AwsResponseError,
     void
 >('aws/identity/getIamCredential')
+
+// getMfaCode
+export interface GetMfaCodeParams {
+    // Intentionally left blank
+}
+
+export interface GetMfaCodeResult {
+    code: string
+}
+
+export const getMfaCodeRequestType = new ProtocolRequestType<
+    GetMfaCodeParams,
+    GetMfaCodeResult,
+    never,
+    AwsResponseError,
+    void
+>('aws/identity/getMfaCode')
 
 // invalidateSsoToken
 export interface InvalidateSsoTokenParams {

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -71,7 +71,7 @@ export const ProfileKind = {
     Unknown: 'Unknown',
 } as const
 
-// Profile and Session use 'settings' property as namescope for their settings to avoid future
+// Profile and SsoSession use 'settings' property as namescope for their settings to avoid future
 // name conflicts with 'kinds', 'name', and future properties as well as making some setting
 // iteration operations easier.
 

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -250,10 +250,12 @@ export type IamCredentialId = string // Opaque identifier
 
 export interface GetIamCredentialOptions {
     generateOnInvalidStsCredential?: boolean
+    validatePermissions?: boolean
 }
 
 export const getIamCredentialOptionsDefaults = {
     generateOnInvalidStsCredential: true,
+    validatePermissions: true,
 } satisfies GetIamCredentialOptions
 
 export interface GetIamCredentialParams {

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -1,4 +1,5 @@
 import {
+    IamCredentials,
     LSPErrorCodes,
     ProgressType,
     ProtocolNotificationType,
@@ -15,20 +16,26 @@ export const AwsErrorCodes = {
     E_CANNOT_OVERWRITE_SSO_SESSION: 'E_CANNOT_OVERWRITE_SSO_SESSION',
     E_CANNOT_READ_SHARED_CONFIG: 'E_CANNOT_READ_SHARED_CONFIG',
     E_CANNOT_READ_SSO_CACHE: 'E_CANNOT_READ_SSO_CACHE',
+    E_CANNOT_READ_STS_CACHE: 'E_CANNOT_READ_STS_CACHE',
     E_CANNOT_REFRESH_SSO_TOKEN: 'E_CANNOT_REFRESH_SSO_TOKEN',
+    E_CANNOT_REFRESH_STS_CREDENTIAL: 'E_CANNOT_REFRESH_STS_CREDENTIAL',
     E_CANNOT_REGISTER_CLIENT: 'E_CANNOT_REGISTER_CLIENT',
     E_CANNOT_CREATE_SSO_TOKEN: 'E_CANNOT_CREATE_SSO_TOKEN',
+    E_CANNOT_CREATE_STS_CREDENTIAL: 'E_CANNOT_CREATE_STS_CREDENTIAL',
     E_CANNOT_WRITE_SHARED_CONFIG: 'E_CANNOT_WRITE_SHARED_CONFIG',
     E_CANNOT_WRITE_SSO_CACHE: 'E_CANNOT_WRITE_SSO_CACHE',
+    E_CANNOT_WRITE_STS_CACHE: 'E_CANNOT_WRITE_STS_CACHE',
     E_ENCRYPTION_REQUIRED: 'E_ENCRYPTION_REQUIRED',
     E_INVALID_PROFILE: 'E_INVALID_PROFILE',
     E_INVALID_SSO_CLIENT: 'E_INVALID_SSO_CLIENT',
     E_INVALID_SSO_SESSION: 'E_INVALID_SSO_SESSION',
     E_INVALID_SSO_TOKEN: 'E_INVALID_SSO_TOKEN',
+    E_INVALID_STS_CREDENTIAL: 'E_INVALID_STS_CREDENTIAL',
     E_PROFILE_NOT_FOUND: 'E_PROFILE_NOT_FOUND',
     E_RUNTIME_NOT_SUPPORTED: 'E_RUNTIME_NOT_SUPPORTED',
     E_SSO_SESSION_NOT_FOUND: 'E_SSO_SESSION_NOT_FOUND',
     E_SSO_TOKEN_EXPIRED: 'E_SSO_TOKEN_EXPIRED',
+    E_STS_CREDENTIAL_EXPIRED: 'E_STS_CREDENTIAL_EXPIRED',
     E_SSO_TOKEN_SOURCE_NOT_SUPPORTED: 'E_SSO_TOKEN_SOURCE_NOT_SUPPORTED',
     E_TIMEOUT: 'E_TIMEOUT',
     E_UNKNOWN: 'E_UNKNOWN',
@@ -47,14 +54,16 @@ export class AwsResponseError extends ResponseError<AwsResponseErrorData> {
 }
 
 // listProfiles
-export type ProfileKind = 'Unknown' | 'SsoTokenProfile'
+export type ProfileKind = 'Unknown' | 'SsoTokenProfile' | 'IamCredentialProfile' | 'EmptyProfile'
 
 export const ProfileKind = {
     SsoTokenProfile: 'SsoTokenProfile',
+    IamCredentialProfile: 'IamCredentialProfile',
+    EmptyProfile: 'EmptyProfile',
     Unknown: 'Unknown',
 } as const
 
-// Profile and SsoSession use 'settings' property as namescope for their settings to avoid future
+// Profile and Session use 'settings' property as namescope for their settings to avoid future
 // name conflicts with 'kinds', 'name', and future properties as well as making some setting
 // iteration operations easier.
 
@@ -64,6 +73,10 @@ export interface Profile {
     settings?: {
         region?: string
         sso_session?: string
+        aws_access_key_id?: string
+        aws_secret_access_key?: string
+        aws_session_token?: string
+        role_arn?: string
     }
 }
 
@@ -131,7 +144,7 @@ export const updateProfileRequestType = new ProtocolRequestType<
 >('aws/identity/updateProfile')
 
 // getSsoToken
-export type SsoTokenId = string // Opaque identifier
+export type CredentialId = string // Opaque identifier
 
 export type IamIdentityCenterSsoTokenSourceKind = 'IamIdentityCenter'
 export type AwsBuilderIdSsoTokenSourceKind = 'AwsBuilderId'
@@ -199,7 +212,7 @@ export interface GetSsoTokenParams {
 }
 
 export interface SsoToken {
-    id: SsoTokenId
+    id: CredentialId
     accessToken: string // This field is encrypted with JWT like 'update'
     // Additional fields captured in token cache file may be added here in the future
 }
@@ -218,9 +231,37 @@ export const getSsoTokenRequestType = new ProtocolRequestType<
     void
 >('aws/identity/getSsoToken')
 
+// getIamCredential
+export interface GetIamCredentialOptions {
+    generateOnInvalidStsCredential?: boolean
+}
+
+export const getIamCredentialOptionsDefaults = {
+    generateOnInvalidStsCredential: true,
+} satisfies GetIamCredentialOptions
+
+export interface GetIamCredentialParams {
+    profileName: string
+    options?: GetIamCredentialOptions
+}
+
+export interface GetIamCredentialResult {
+    id: CredentialId
+    credentials: IamCredentials
+    updateCredentialsParams: UpdateCredentialsParams
+}
+
+export const getIamCredentialRequestType = new ProtocolRequestType<
+    GetIamCredentialParams,
+    GetIamCredentialResult,
+    never,
+    AwsResponseError,
+    void
+>('aws/identity/getIamCredential')
+
 // invalidateSsoToken
 export interface InvalidateSsoTokenParams {
-    ssoTokenId: SsoTokenId
+    ssoTokenId: CredentialId
 }
 
 export interface InvalidateSsoTokenResult {
@@ -236,6 +277,23 @@ export const invalidateSsoTokenRequestType = new ProtocolRequestType<
     void
 >('aws/identity/invalidateSsoToken')
 
+// invalidateStsCredential
+export interface InvalidateStsCredentialParams {
+    profileName: string
+}
+
+export interface InvalidateStsCredentialResult {
+    // Intentionally left blank
+}
+
+export const invalidateStsCredentialRequestType = new ProtocolRequestType<
+    InvalidateStsCredentialParams,
+    InvalidateStsCredentialResult,
+    never,
+    AwsResponseError,
+    void
+>('aws/identity/invalidateStsCredential')
+
 // ssoTokenChanged
 export type Expired = 'Expired'
 export type Refreshed = 'Refreshed'
@@ -249,9 +307,26 @@ export const SsoTokenChangedKind = {
 
 export interface SsoTokenChangedParams {
     kind: SsoTokenChangedKind
-    ssoTokenId: SsoTokenId
+    ssoTokenId: CredentialId
 }
 
 export const ssoTokenChangedRequestType = new ProtocolNotificationType<SsoTokenChangedParams, void>(
     'aws/identity/ssoTokenChanged'
+)
+
+// stsCredentialChanged
+export type StsCredentialChangedKind = Refreshed | Expired
+
+export const StsCredentialChangedKind = {
+    Expired: 'Expired',
+    Refreshed: 'Refreshed',
+} as const
+
+export interface StsCredentialChangedParams {
+    kind: StsCredentialChangedKind
+    stsCredentialId: CredentialId
+}
+
+export const stsCredentialChangedRequestType = new ProtocolNotificationType<StsCredentialChangedParams, void>(
+    'aws/identity/stsCredentialChanged'
 )

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -255,6 +255,7 @@ export const getIamCredentialOptionsDefaults = {
 
 export interface GetIamCredentialParams {
     profileName: string
+    mfaCode?: string
     options?: GetIamCredentialOptions
 }
 

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -63,7 +63,7 @@ export const ProfileKind = {
     Unknown: 'Unknown',
 } as const
 
-// Profile and Session use 'settings' property as namescope for their settings to avoid future
+// Profile and SsoSession use 'settings' property as namescope for their settings to avoid future
 // name conflicts with 'kinds', 'name', and future properties as well as making some setting
 // iteration operations easier.
 

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -280,7 +280,8 @@ export const getIamCredentialRequestType = new ProtocolRequestType<
 
 // getMfaCode
 export interface GetMfaCodeParams {
-    // Intentionally left blank
+    mfaSerial: string
+    profileName: string
 }
 
 export interface GetMfaCodeResult {

--- a/runtimes/runtimes/auth/standalone/encryption.ts
+++ b/runtimes/runtimes/auth/standalone/encryption.ts
@@ -124,11 +124,11 @@ export async function encryptIamResultWithKey(
     request: GetIamCredentialResult,
     key: string
 ): Promise<GetIamCredentialResult> {
-    request.credentials = {
-        accessKeyId: await encryptObjectWithKey(request.credentials.accessKeyId, key),
-        secretAccessKey: await encryptObjectWithKey(request.credentials.secretAccessKey, key),
-        ...(request.credentials.sessionToken
-            ? { sessionToken: await encryptObjectWithKey(request.credentials.sessionToken, key) }
+    request.credential.credentials = {
+        accessKeyId: await encryptObjectWithKey(request.credential.credentials.accessKeyId, key),
+        secretAccessKey: await encryptObjectWithKey(request.credential.credentials.secretAccessKey, key),
+        ...(request.credential.credentials.sessionToken
+            ? { sessionToken: await encryptObjectWithKey(request.credential.credentials.sessionToken, key) }
             : {}),
     }
     if (!request.updateCredentialsParams.encrypted) {

--- a/runtimes/runtimes/auth/standalone/encryption.ts
+++ b/runtimes/runtimes/auth/standalone/encryption.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'stream'
 import { CompactEncrypt } from 'jose'
+import { GetIamCredentialResult, GetSsoTokenResult } from '../../../protocol'
 
 export function shouldWaitForEncryptionKey(): boolean {
     return process.argv.some(arg => arg === '--set-credentials-encryption-key')
@@ -96,6 +97,48 @@ export function encryptObjectWithKey(request: Object, key: string, alg?: string,
     return new CompactEncrypt(payload)
         .setProtectedHeader({ alg: alg ?? 'dir', enc: enc ?? 'A256GCM' })
         .encrypt(keyBuffer)
+}
+
+/**
+ * Encrypts the SSO access tokens inside the result object with the provided key
+ */
+export async function encryptSsoResultWithKey(request: GetSsoTokenResult, key: string): Promise<GetSsoTokenResult> {
+    if (request.ssoToken.accessToken) {
+        request.ssoToken.accessToken = await encryptObjectWithKey(request.ssoToken.accessToken, key)
+    }
+    if (request.updateCredentialsParams.data && !request.updateCredentialsParams.encrypted) {
+        request.updateCredentialsParams.data = await encryptObjectWithKey(
+            // decodeCredentialsRequestToken expects nested 'data' fields
+            { data: request.updateCredentialsParams.data },
+            key
+        )
+        request.updateCredentialsParams.encrypted = true
+    }
+    return request
+}
+
+/**
+ * Encrypts the IAM credentials inside the result object with the provided key
+ */
+export async function encryptIamResultWithKey(
+    request: GetIamCredentialResult,
+    key: string
+): Promise<GetIamCredentialResult> {
+    request.credentials = {
+        accessKeyId: await encryptObjectWithKey(request.credentials.accessKeyId, key),
+        secretAccessKey: await encryptObjectWithKey(request.credentials.secretAccessKey, key),
+        ...(request.credentials.sessionToken
+            ? { sessionToken: await encryptObjectWithKey(request.credentials.sessionToken, key) }
+            : {}),
+    }
+    if (!request.updateCredentialsParams.encrypted) {
+        request.updateCredentialsParams.data = await encryptObjectWithKey(
+            { data: request.updateCredentialsParams.data },
+            key
+        )
+        request.updateCredentialsParams.encrypted = true
+    }
+    return request
 }
 
 /**

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -83,11 +83,15 @@ import { observe } from './lsp'
 import { LspRouter } from './lsp/router/lspRouter'
 import { LspServer } from './lsp/router/lspServer'
 import {
+    AwsResponseError,
+    getIamCredentialRequestType,
     getSsoTokenRequestType,
+    invalidateStsCredentialRequestType,
     invalidateSsoTokenRequestType,
     listProfilesRequestType,
     ssoTokenChangedRequestType,
     updateProfileRequestType,
+    stsCredentialChangedRequestType,
 } from '../protocol/identity-management'
 import { IdentityManagement } from '../server-interface/identity-management'
 import { WebBase64Encoding } from './encoding'
@@ -202,8 +206,11 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
         onListProfiles: handler => lspConnection.onRequest(listProfilesRequestType, handler),
         onUpdateProfile: handler => lspConnection.onRequest(updateProfileRequestType, handler),
         onGetSsoToken: handler => lspConnection.onRequest(getSsoTokenRequestType, handler),
+        onGetIamCredential: handler => lspConnection.onRequest(getIamCredentialRequestType, handler),
         onInvalidateSsoToken: handler => lspConnection.onRequest(invalidateSsoTokenRequestType, handler),
+        onInvalidateStsCredential: handler => lspConnection.onRequest(invalidateStsCredentialRequestType, handler),
         sendSsoTokenChanged: params => lspConnection.sendNotification(ssoTokenChangedRequestType, params),
+        sendStsCredentialChanged: params => lspConnection.sendNotification(stsCredentialChangedRequestType, params),
     }
 
     // Set up auth without encryption

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -83,7 +83,6 @@ import { observe } from './lsp'
 import { LspRouter } from './lsp/router/lspRouter'
 import { LspServer } from './lsp/router/lspServer'
 import {
-    AwsResponseError,
     getIamCredentialRequestType,
     getSsoTokenRequestType,
     invalidateStsCredentialRequestType,

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -91,6 +91,7 @@ import {
     ssoTokenChangedRequestType,
     updateProfileRequestType,
     stsCredentialChangedRequestType,
+    getMfaCodeRequestType,
 } from '../protocol/identity-management'
 import { IdentityManagement } from '../server-interface/identity-management'
 import { WebBase64Encoding } from './encoding'
@@ -210,6 +211,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
         onInvalidateStsCredential: handler => lspConnection.onRequest(invalidateStsCredentialRequestType, handler),
         sendSsoTokenChanged: params => lspConnection.sendNotification(ssoTokenChangedRequestType, params),
         sendStsCredentialChanged: params => lspConnection.sendNotification(stsCredentialChangedRequestType, params),
+        sendGetMfaCode: params => lspConnection.sendRequest(getMfaCodeRequestType, params),
     }
 
     // Set up auth without encryption

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -33,6 +33,7 @@ import {
     ShowOpenDialogParams,
     ShowOpenDialogRequestType,
     stsCredentialChangedRequestType,
+    getMfaCodeRequestType,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -325,6 +326,7 @@ export const standalone = (props: RuntimeProps) => {
             onInvalidateStsCredential: handler => lspConnection.onRequest(invalidateStsCredentialRequestType, handler),
             sendSsoTokenChanged: params => lspConnection.sendNotification(ssoTokenChangedRequestType, params),
             sendStsCredentialChanged: params => lspConnection.sendNotification(stsCredentialChangedRequestType, params),
+            sendGetMfaCode: params => lspConnection.sendRequest(getMfaCodeRequestType, params),
         }
 
         const credentialsProvider: CredentialsProvider = auth.getCredentialsProvider()

--- a/runtimes/server-interface/identity-management.ts
+++ b/runtimes/server-interface/identity-management.ts
@@ -10,10 +10,12 @@ import {
     InvalidateStsCredentialResult,
     ListProfilesParams,
     ListProfilesResult,
+    GetMfaCodeParams,
     SsoTokenChangedParams,
     StsCredentialChangedParams,
     UpdateProfileParams,
     UpdateProfileResult,
+    GetMfaCodeResult,
 } from '../protocol/identity-management'
 import { RequestHandler } from '../protocol'
 
@@ -51,4 +53,6 @@ export type IdentityManagement = {
     sendSsoTokenChanged: (params: SsoTokenChangedParams) => void
 
     sendStsCredentialChanged: (params: StsCredentialChangedParams) => void
+
+    sendGetMfaCode: (params: GetMfaCodeParams) => Promise<GetMfaCodeResult>
 }

--- a/runtimes/server-interface/identity-management.ts
+++ b/runtimes/server-interface/identity-management.ts
@@ -1,12 +1,17 @@
 import {
     AwsResponseError,
+    GetIamCredentialParams,
+    GetIamCredentialResult,
     GetSsoTokenParams,
     GetSsoTokenResult,
     InvalidateSsoTokenParams,
     InvalidateSsoTokenResult,
+    InvalidateStsCredentialParams,
+    InvalidateStsCredentialResult,
     ListProfilesParams,
     ListProfilesResult,
     SsoTokenChangedParams,
+    StsCredentialChangedParams,
     UpdateProfileParams,
     UpdateProfileResult,
 } from '../protocol/identity-management'
@@ -27,9 +32,23 @@ export type IdentityManagement = {
         handler: RequestHandler<GetSsoTokenParams, GetSsoTokenResult | undefined | null, AwsResponseError>
     ) => void
 
+    onGetIamCredential: (
+        handler: RequestHandler<GetIamCredentialParams, GetIamCredentialResult | undefined | null, AwsResponseError>
+    ) => void
+
     onInvalidateSsoToken: (
         handler: RequestHandler<InvalidateSsoTokenParams, InvalidateSsoTokenResult | undefined | null, AwsResponseError>
     ) => void
 
+    onInvalidateStsCredential: (
+        handler: RequestHandler<
+            InvalidateStsCredentialParams,
+            InvalidateStsCredentialResult | undefined | null,
+            AwsResponseError
+        >
+    ) => void
+
     sendSsoTokenChanged: (params: SsoTokenChangedParams) => void
+
+    sendStsCredentialChanged: (params: StsCredentialChangedParams) => void
 }

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -2,6 +2,7 @@ export type IamCredentials = {
     readonly accessKeyId: string
     readonly secretAccessKey: string
     readonly sessionToken?: string
+    readonly expiration?: Date
 }
 
 export type BearerCredentials = {

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -2,7 +2,6 @@ export type IamCredentials = {
     readonly accessKeyId: string
     readonly secretAccessKey: string
     readonly sessionToken?: string
-    readonly expiration?: Date
 }
 
 export type BearerCredentials = {


### PR DESCRIPTION
## Problem
The validatePermissions and credentials fields on the getIamCredential handler are difficult to extend.

## Solution
- Rename validatePermissions to permissionSets and make it accept a list of permissions instead validating only 1 set of permissions
- Wrap credentials from getIamCredentialResult into an intermediate object which can have additional properties

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
