### PR TITLE
chore: update SubscriptionDetailsParams fields

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -708,10 +708,11 @@ export interface ExecuteShellCommandParams {
 
 export interface SubscriptionDetailsParams {
     subscriptionTier: string
+    subscriptionPeriodReset: Date
+    isOverageEnabled: boolean
     queryUsage: number
     queryLimit: number
     queryOverage: number
-    daysRemaining: number
 }
 
 export interface SubscriptionUpgradeParams {}


### PR DESCRIPTION
This change updates part of the subscription protocol based on recent developments and requests.

SubscriptionDetailsParams is being updated so that
- we can tell if the subscription has overages enabled
- when the subscription period ends

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
