### PR TITLE
fix: replace path.basename with custom browser-safe implementation

### DIFF
--- a/runtimes/runtimes/lsp/router/initializeUtils.test.ts
+++ b/runtimes/runtimes/lsp/router/initializeUtils.test.ts
@@ -1,5 +1,6 @@
 import { URI } from 'vscode-uri'
 import * as path from 'path'
+import os from 'os'
 import assert = require('assert')
 import sinon = require('sinon')
 import { InitializeParams, WorkspaceFolder } from 'vscode-languageserver-protocol'
@@ -80,8 +81,15 @@ describe('initializeUtils', () => {
             const params = createParams({ rootPath })
 
             const result = getWorkspaceFoldersFromInit(consoleStub, params)
+            let expectedName
+            if (os.platform() === 'win32') {
+                expectedName = path.basename(URI.parse(pathUri).fsPath)
+            } else {
+                // using path.basename on unix with a windows path
+                // will cause it to return \\Users\\test\\folder instead
+                expectedName = 'folder'
+            }
 
-            const expectedName = path.basename(URI.parse(pathUri).fsPath)
             assert.deepStrictEqual(result, [{ name: expectedName, uri: pathUri }])
         })
 

--- a/runtimes/runtimes/lsp/router/initializeUtils.ts
+++ b/runtimes/runtimes/lsp/router/initializeUtils.ts
@@ -1,5 +1,5 @@
 import { InitializeParams, WorkspaceFolder } from 'vscode-languageserver-protocol'
-import * as path from 'path'
+import { basenamePath } from '../../util/pathUtil'
 import { URI } from 'vscode-uri'
 import { RemoteConsole } from 'vscode-languageserver'
 
@@ -12,7 +12,7 @@ export function getWorkspaceFoldersFromInit(console: RemoteConsole, params?: Ini
         return params.workspaceFolders
     }
     try {
-        const getFolderName = (parsedUri: URI) => path.basename(parsedUri.fsPath) || parsedUri.toString()
+        const getFolderName = (parsedUri: URI) => basenamePath(parsedUri.fsPath) || parsedUri.toString()
 
         if (params.rootUri) {
             const parsedUri = URI.parse(params.rootUri)

--- a/runtimes/runtimes/util/pathUtil.test.ts
+++ b/runtimes/runtimes/util/pathUtil.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { joinUnixPaths } from './pathUtil'
+import { joinUnixPaths, basenamePath } from './pathUtil'
 
 describe('joinUnixPaths', function () {
     it('handles basic joining', function () {
@@ -53,5 +53,84 @@ describe('joinUnixPaths', function () {
     it('handles paths with multiple consecutive dots', function () {
         assert.strictEqual(joinUnixPaths('foo', '...', 'bar'), 'foo/.../bar')
         assert.strictEqual(joinUnixPaths('foo/...bar'), 'foo/...bar')
+    })
+})
+
+describe('basenameUnixPath', function () {
+    it('handles basic filename extraction', function () {
+        assert.strictEqual(basenamePath('/path/to/file.txt'), 'file.txt')
+        assert.strictEqual(basenamePath('path/to/file.txt'), 'file.txt')
+        assert.strictEqual(basenamePath('file.txt'), 'file.txt')
+        assert.strictEqual(basenamePath('filename'), 'filename')
+    })
+
+    it('handles directory paths', function () {
+        assert.strictEqual(basenamePath('/path/to/dir/'), 'dir')
+        assert.strictEqual(basenamePath('/path/to/dir'), 'dir')
+        assert.strictEqual(basenamePath('path/to/dir/'), 'dir')
+        assert.strictEqual(basenamePath('dir/'), 'dir')
+    })
+
+    it('handles root and empty paths', function () {
+        assert.strictEqual(basenamePath('/'), '')
+        assert.strictEqual(basenamePath(''), '')
+        assert.strictEqual(basenamePath('//'), '')
+        assert.strictEqual(basenamePath('///'), '')
+    })
+
+    it('handles extension removal', function () {
+        assert.strictEqual(basenamePath('/path/to/file.txt', '.txt'), 'file')
+        assert.strictEqual(basenamePath('/path/to/file.txt', 'txt'), 'file.')
+        assert.strictEqual(basenamePath('file.js', '.js'), 'file')
+        assert.strictEqual(basenamePath('file.js', 'js'), 'file.')
+    })
+
+    it('handles extension removal edge cases', function () {
+        assert.strictEqual(basenamePath('file.txt', '.js'), 'file.txt')
+        assert.strictEqual(basenamePath('file', '.txt'), 'file')
+        assert.strictEqual(basenamePath('file.txt.bak', '.txt'), 'file.txt.bak')
+        assert.strictEqual(basenamePath('file.txt.bak', '.bak'), 'file.txt')
+    })
+
+    it('handles Windows-style paths', function () {
+        assert.strictEqual(basenamePath('C:\\path\\to\\file.txt'), 'file.txt')
+        assert.strictEqual(basenamePath('path\\to\\file.txt'), 'file.txt')
+        assert.strictEqual(basenamePath('C:\\path\\to\\dir\\'), 'dir')
+    })
+
+    it('handles mixed path separators', function () {
+        assert.strictEqual(basenamePath('/path\\to/file.txt'), 'file.txt')
+        assert.strictEqual(basenamePath('path/to\\dir/'), 'dir')
+    })
+
+    it('handles multiple consecutive slashes', function () {
+        assert.strictEqual(basenamePath('/path//to///file.txt'), 'file.txt')
+        assert.strictEqual(basenamePath('path///to//dir///'), 'dir')
+        assert.strictEqual(basenamePath('///path///file.txt'), 'file.txt')
+    })
+
+    it('handles special filenames', function () {
+        assert.strictEqual(basenamePath('/path/to/.hidden'), '.hidden')
+        assert.strictEqual(basenamePath('/path/to/..'), '..')
+        assert.strictEqual(basenamePath('/path/to/.'), '.')
+        assert.strictEqual(basenamePath('/path/to/...'), '...')
+    })
+
+    it('handles invalid inputs', function () {
+        assert.strictEqual(basenamePath(null as any), '')
+        assert.strictEqual(basenamePath(undefined as any), '')
+        assert.strictEqual(basenamePath(123 as any), '')
+    })
+
+    it('handles complex extension scenarios', function () {
+        assert.strictEqual(basenamePath('file.tar.gz', '.gz'), 'file.tar')
+        assert.strictEqual(basenamePath('file.tar.gz', '.tar.gz'), 'file')
+        assert.strictEqual(basenamePath('archive.tar.gz', 'tar.gz'), 'archive.')
+    })
+
+    it('handles files without extensions', function () {
+        assert.strictEqual(basenamePath('/path/to/README'), 'README')
+        assert.strictEqual(basenamePath('/path/to/Makefile'), 'Makefile')
+        assert.strictEqual(basenamePath('LICENSE', '.txt'), 'LICENSE')
     })
 })

--- a/runtimes/runtimes/util/pathUtil.ts
+++ b/runtimes/runtimes/util/pathUtil.ts
@@ -26,3 +26,53 @@ export function joinUnixPaths(...segments: string[]): string {
 
     return result.join('/')
 }
+
+/**
+ * Simplified version of path.basename that can be safely used on web
+ * It should match the behaviour of the original
+ * @param path The path to extract the basename from
+ * @param ext Optional extension to remove from the result
+ * @returns The last portion of the path, optionally with extension removed
+ */
+export function basenamePath(path: string, ext?: string): string {
+    if (!path || typeof path !== 'string' || path === '') {
+        return ''
+    }
+
+    // Helper function to remove extension from basename
+    const removeExtension = (basename: string, extension: string): string => {
+        if (!extension || !basename.endsWith(extension) || basename === extension) {
+            return basename
+        }
+
+        if (extension.startsWith('.')) {
+            return basename.slice(0, -extension.length)
+        } else {
+            const dotExt = '.' + extension
+            if (basename.endsWith(dotExt) && basename !== dotExt) {
+                return basename.slice(0, -extension.length) // Keep the dot
+            } else if (basename.endsWith(extension)) {
+                return basename.slice(0, -extension.length)
+            }
+        }
+        return basename
+    }
+
+    // Handle Windows paths that start with \ but not \\
+    if (path.startsWith('\\') && !path.startsWith('\\\\')) {
+        return removeExtension(path, ext || '')
+    }
+
+    // Normalize path separators and remove trailing slashes
+    const normalizedPath = path.replace(/\\/g, '/').replace(/\/+$/, '')
+
+    if (!normalizedPath || normalizedPath === '/') {
+        return ''
+    }
+
+    // Find the last segment
+    const lastSlashIndex = normalizedPath.lastIndexOf('/')
+    const basename = lastSlashIndex === -1 ? normalizedPath : normalizedPath.slice(lastSlashIndex + 1)
+
+    return basename ? removeExtension(basename, ext || '') : ''
+}

--- a/runtimes/runtimes/util/pathUtil.ts
+++ b/runtimes/runtimes/util/pathUtil.ts
@@ -39,30 +39,6 @@ export function basenamePath(path: string, ext?: string): string {
         return ''
     }
 
-    // Helper function to remove extension from basename
-    const removeExtension = (basename: string, extension: string): string => {
-        if (!extension || !basename.endsWith(extension) || basename === extension) {
-            return basename
-        }
-
-        if (extension.startsWith('.')) {
-            return basename.slice(0, -extension.length)
-        } else {
-            const dotExt = '.' + extension
-            if (basename.endsWith(dotExt) && basename !== dotExt) {
-                return basename.slice(0, -extension.length) // Keep the dot
-            } else if (basename.endsWith(extension)) {
-                return basename.slice(0, -extension.length)
-            }
-        }
-        return basename
-    }
-
-    // Handle Windows paths that start with \ but not \\
-    if (path.startsWith('\\') && !path.startsWith('\\\\')) {
-        return removeExtension(path, ext || '')
-    }
-
     // Normalize path separators and remove trailing slashes
     const normalizedPath = path.replace(/\\/g, '/').replace(/\/+$/, '')
 
@@ -74,5 +50,19 @@ export function basenamePath(path: string, ext?: string): string {
     const lastSlashIndex = normalizedPath.lastIndexOf('/')
     const basename = lastSlashIndex === -1 ? normalizedPath : normalizedPath.slice(lastSlashIndex + 1)
 
-    return basename ? removeExtension(basename, ext || '') : ''
+    if (!basename || !ext) {
+        return basename
+    }
+
+    // Remove extension if it matches
+    if (ext.startsWith('.')) {
+        return basename.endsWith(ext) && basename !== ext ? basename.slice(0, -ext.length) : basename
+    } else {
+        // For extensions without dot, check both with and without dot
+        if (basename.endsWith(ext) && basename !== ext) {
+            return basename.slice(0, -ext.length)
+        }
+        const dotExt = '.' + ext
+        return basename.endsWith(dotExt) && basename !== dotExt ? basename.slice(0, -dotExt.length) : basename
+    }
 }


### PR DESCRIPTION
## Problem
`getWorkspaceFoldersFromInit` function is using the node-only `path` module. It is imported by `base-runtime.ts` which in turn is used in `webworker`. This causes consumers to require using polyfills, which is not always an option as it is an unmaintained package.

https://github.com/aws/language-server-runtimes/issues/588

## Solution
Implement a custom platform-agnostic implementation of the `path.basename` function, similar of the `joinUnixPaths` made to replace `path.join`. This should match the behaviour of the original function and thus not break the functionality of `getWorkspaceFoldersFromInit`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
