### PR TITLE
fix: add open tab params to inline completion protocol

### DIFF
--- a/runtimes/protocol/inlineCompletionWithReferences.ts
+++ b/runtimes/protocol/inlineCompletionWithReferences.ts
@@ -17,7 +17,14 @@ interface DocumentChangeParams {
     documentChangeParams?: DidChangeTextDocumentParams
 }
 
-export type InlineCompletionWithReferencesParams = InlineCompletionParams & PartialResultParams & DocumentChangeParams
+interface OpenTabParams {
+    openTabFilepaths?: string
+}
+
+export type InlineCompletionWithReferencesParams = InlineCompletionParams &
+    PartialResultParams &
+    DocumentChangeParams &
+    OpenTabParams
 
 export const inlineCompletionWithReferencesRequestType = new ProtocolRequestType<
     InlineCompletionWithReferencesParams,


### PR DESCRIPTION
## Problem

https://github.com/aws/language-servers/pull/2011

This is a follow up of the above PR. 

The workspace.getAllTextDocuments() API only returns the open tabs that were clicked during this IDE session. If you open, close, reopen IDE, this API returns empty unless user re-click those files again.

So we need to let IDE compute the list of open tab files and send it to language server

## Solution

Add open tab params in InlineCompletionWithReferencesParams

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
