### PR TITLE
fix: improve diffs array error msg

### DIFF
--- a/runtimes/runtimes/agent.test.ts
+++ b/runtimes/runtimes/agent.test.ts
@@ -90,11 +90,14 @@ describe('Agent Tools', () => {
         await assert.rejects(
             async () => {
                 await AGENT.runTool(TOOL_SPEC_WITH_ARRAY_TYPE.name, {
-                    diffs: '[{"oldStr": "toReplace"}, {"newStr": "newContet"}]',
+                    diffs: '[{"oldStr": "toReplace", "newStr": "newContet"}]',
                 })
             },
             (error: Error) => {
-                assert.ok(error.message === 'fsReplace tool input validation failed: /diffs: must be array')
+                assert.ok(
+                    error.message ===
+                        'fsReplace tool input validation failed: /diffs: must be array in JSON format without quotation marks'
+                )
                 return true
             }
         )

--- a/runtimes/runtimes/agent.ts
+++ b/runtimes/runtimes/agent.ts
@@ -63,11 +63,19 @@ export const newAgent = (): Agent => {
 
             const validateResult = tool.validate(input, token)
             if (validateResult !== true) {
+                const errors = (validateResult as ValidateFunction['errors']) || []
                 const errorDetails =
-                    ((validateResult as ValidateFunction['errors']) || [])
-                        .map((err: ErrorObject) => `${err.instancePath || 'root'}: ${err.message}`)
-                        .join('\n') || `\nReceived: ${input}`
-
+                    errors.map((err: ErrorObject) => `${err.instancePath || 'root'}: ${err.message}`).join('\n') ||
+                    `\nReceived: ${input}`
+                if (
+                    errors.length === 1 &&
+                    errors.at(0)?.instancePath === '/diffs' &&
+                    errors.at(0)?.message === 'must be array'
+                ) {
+                    throw new Error(
+                        `${toolName} tool input validation failed: ${errorDetails} in JSON format without quotation marks`
+                    )
+                }
                 throw new Error(`${toolName} tool input validation failed: ${errorDetails}`)
             }
 


### PR DESCRIPTION
## Problem
- Sometimes LLM still cannot auto correct issues with diffs array type mismatch

## Solution
- Further improve error message to allow LLM auto recover better
<img width="386" height="481" alt="Screenshot 2025-07-30 at 3 48 26 PM" src="https://github.com/user-attachments/assets/7d67e1df-ceb9-4831-aa7b-3a84f1138dc9" />


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
