### PR TITLE
feat: add types for shared config file watcher

### DIFF
--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -400,3 +400,13 @@ export interface StsCredentialChangedParams {
 export const stsCredentialChangedRequestType = new ProtocolNotificationType<StsCredentialChangedParams, void>(
     'aws/identity/stsCredentialChanged'
 )
+
+// profileChanged
+export interface ProfileChangedParams {
+    profiles: Profile[]
+    ssoSessions: SsoSession[]
+}
+
+export const profileChangedRequestType = new ProtocolNotificationType<ProfileChangedParams, void>(
+    'aws/identity/stsCredentialChanged'
+)

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -94,6 +94,7 @@ import {
     updateProfileRequestType,
     stsCredentialChangedRequestType,
     getMfaCodeRequestType,
+    profileChangedRequestType,
 } from '../protocol/identity-management'
 import { IdentityManagement } from '../server-interface/identity-management'
 import { WebBase64Encoding } from './encoding'
@@ -217,6 +218,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
         onInvalidateStsCredential: handler => lspConnection.onRequest(invalidateStsCredentialRequestType, handler),
         sendSsoTokenChanged: params => lspConnection.sendNotification(ssoTokenChangedRequestType, params),
         sendStsCredentialChanged: params => lspConnection.sendNotification(stsCredentialChangedRequestType, params),
+        sendProfileChanged: params => lspConnection.sendNotification(profileChangedRequestType, params),
         sendGetMfaCode: params => lspConnection.sendRequest(getMfaCodeRequestType, params),
     }
 

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -34,6 +34,7 @@ import {
     ShowOpenDialogRequestType,
     stsCredentialChangedRequestType,
     getMfaCodeRequestType,
+    profileChangedRequestType,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -331,6 +332,7 @@ export const standalone = (props: RuntimeProps) => {
             onInvalidateStsCredential: handler => lspConnection.onRequest(invalidateStsCredentialRequestType, handler),
             sendSsoTokenChanged: params => lspConnection.sendNotification(ssoTokenChangedRequestType, params),
             sendStsCredentialChanged: params => lspConnection.sendNotification(stsCredentialChangedRequestType, params),
+            sendProfileChanged: params => lspConnection.sendNotification(profileChangedRequestType, params),
             sendGetMfaCode: params => lspConnection.sendRequest(getMfaCodeRequestType, params),
         }
 

--- a/runtimes/server-interface/identity-management.ts
+++ b/runtimes/server-interface/identity-management.ts
@@ -16,6 +16,7 @@ import {
     UpdateProfileParams,
     UpdateProfileResult,
     GetMfaCodeResult,
+    ProfileChangedParams,
 } from '../protocol/identity-management'
 import { RequestHandler } from '../protocol'
 
@@ -53,6 +54,8 @@ export type IdentityManagement = {
     sendSsoTokenChanged: (params: SsoTokenChangedParams) => void
 
     sendStsCredentialChanged: (params: StsCredentialChangedParams) => void
+
+    sendProfileChanged: (params: ProfileChangedParams) => void
 
     sendGetMfaCode: (params: GetMfaCodeParams) => Promise<GetMfaCodeResult>
 }


### PR DESCRIPTION
## Problem
The IAM type changes are behind the changes in https://github.com/aws/language-servers/pull/2021. As a result, the language-servers PRs are unable to compile.

## Solution
- Add types and handler for profile change notification

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
