### PR TITLE
feat(types): add types for quickSettings to update permission in tool executions

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -183,6 +183,23 @@ export interface ChatMessage {
     codeReference?: ReferenceTrackerInformation[]
     fileList?: FileList
     contextList?: FileList
+    quickSettings?: {
+        type: 'select' | 'checkbox' | 'radio'
+        description?: string
+        descriptionLink?: {
+            id: string
+            text: string
+            destination: string
+        }
+        messageId: string
+        tabId: string
+        options: {
+            id: string
+            label: string
+            value: string
+            selected?: boolean | undefined
+        }[]
+    }
 }
 
 /**
@@ -384,6 +401,7 @@ export interface ButtonClickParams {
     tabId: string
     messageId: string
     buttonId: string
+    metadata: Record<string, string>
 }
 
 export interface ButtonClickResult {


### PR DESCRIPTION
## Problem

Require new field to attach to ChatResult to render the dropdown component for quickSettings

Require a extra data field for ButtonClickParams for the functionality to work

## Solution

Add quickSettings prop to ChatMessage

Add metadata field in ButtonClickParams. It's a map for re-useable purpose

## Example Usage

```ts
const metadata: Record<string, string> = {}
const option = value[0]
const [serverName, toolName] = option.value.split('@')
const new_permission = option.id

metadata['toolName'] = toolName
metadata['serverName'] = serverName
metadata['permission'] = new_permission

const payload: ButtonClickParams = {
    tabId,
    messageId,
    buttonId: 'trust-command',
    metadata,
 }

```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
