### PR TITLE
fix: add open tab params to inline completion protocol 

### DIFF
--- a/runtimes/protocol/inlineCompletionWithReferences.ts
+++ b/runtimes/protocol/inlineCompletionWithReferences.ts
@@ -18,7 +18,7 @@ interface DocumentChangeParams {
 }
 
 interface OpenTabParams {
-    openTabFilepaths?: string
+    openTabFilepaths?: string[]
 }
 
 export type InlineCompletionWithReferencesParams = InlineCompletionParams &


### PR DESCRIPTION
## Problem
This is to fix a typo in https://github.com/aws/language-server-runtimes/pull/638/files.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
