### PR TITLE
feat: support visibleName in fileDetails props

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -138,6 +138,7 @@ export interface FileDetails {
         deleted?: number
         total?: number
     }
+    visibleName?: string
 }
 
 export interface FileList {


### PR DESCRIPTION
## Problem

Not able to set visibleName of files

## Solution

Expose `visibleName` prop 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
