### PR TITLE
feat: encrypt updateProfile and listProfiles endpoints

### DIFF
--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -141,7 +141,7 @@ export interface ListProfilesResult {
 // Potential error codes: E_UNKNOWN | E_TIMEOUT | E_RUNTIME_NOT_SUPPORTED | E_CANNOT_READ_SHARED_CONFIG
 export const listProfilesRequestType = new ProtocolRequestType<
     ListProfilesParams,
-    ListProfilesResult,
+    ListProfilesResult | string,
     never,
     AwsResponseError,
     void

--- a/runtimes/protocol/identity-management.ts
+++ b/runtimes/protocol/identity-management.ts
@@ -400,3 +400,13 @@ export interface StsCredentialChangedParams {
 export const stsCredentialChangedRequestType = new ProtocolNotificationType<StsCredentialChangedParams, void>(
     'aws/identity/stsCredentialChanged'
 )
+
+// profileChanged
+export interface ProfileChangedParams {
+    profiles: Profile[]
+    ssoSessions: SsoSession[]
+}
+
+export const profileChangedRequestType = new ProtocolNotificationType<ProfileChangedParams, void>(
+    'aws/identity/stsCredentialChanged'
+)

--- a/runtimes/runtimes/auth/standalone/encryption.ts
+++ b/runtimes/runtimes/auth/standalone/encryption.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream'
-import { compactDecrypt, CompactEncrypt } from 'jose'
+import { CompactEncrypt } from 'jose'
 import { GetIamCredentialResult, GetSsoTokenResult } from '../../../protocol'
 
 export function shouldWaitForEncryptionKey(): boolean {
@@ -100,15 +100,6 @@ export function encryptObjectWithKey(request: Object, key: string, alg?: string,
 }
 
 /**
- * Decrypt an object with the provided key
- */
-export async function decryptObjectWithKey<T>(request: string, key: string, alg?: string, enc?: string): Promise<T> {
-    const keyBuffer = Buffer.from(key, 'base64')
-    const result = await compactDecrypt(request, keyBuffer)
-    return JSON.parse(new TextDecoder().decode(result.plaintext)) as T
-}
-
-/**
  * Encrypts the SSO access tokens inside the result object with the provided key
  */
 export async function encryptSsoResultWithKey(request: GetSsoTokenResult, key: string): Promise<GetSsoTokenResult> {
@@ -133,12 +124,12 @@ export async function encryptIamResultWithKey(
     request: GetIamCredentialResult,
     key: string
 ): Promise<GetIamCredentialResult> {
-    const { accessKeyId, secretAccessKey, sessionToken, expiration } = request.credential.credentials
     request.credential.credentials = {
-        accessKeyId: await encryptObjectWithKey(accessKeyId, key),
-        secretAccessKey: await encryptObjectWithKey(secretAccessKey, key),
-        sessionToken: sessionToken ? await encryptObjectWithKey(sessionToken, key) : undefined,
-        expiration: expiration,
+        accessKeyId: await encryptObjectWithKey(request.credential.credentials.accessKeyId, key),
+        secretAccessKey: await encryptObjectWithKey(request.credential.credentials.secretAccessKey, key),
+        ...(request.credential.credentials.sessionToken
+            ? { sessionToken: await encryptObjectWithKey(request.credential.credentials.sessionToken, key) }
+            : {}),
     }
     if (!request.updateCredentialsParams.encrypted) {
         request.updateCredentialsParams.data = await encryptObjectWithKey(

--- a/runtimes/runtimes/auth/standalone/encryption.ts
+++ b/runtimes/runtimes/auth/standalone/encryption.ts
@@ -102,7 +102,7 @@ export function encryptObjectWithKey(request: Object, key: string, alg?: string,
 /**
  * Decrypt an object with the provided key
  */
-export async function decryptObjectWithKey<T>(request: string, key: string, alg?: string, enc?: string): Promise<T> {
+export async function decryptObjectWithKey<T>(request: string, key: string): Promise<T> {
     const keyBuffer = Buffer.from(key, 'base64')
     const result = await compactDecrypt(request, keyBuffer)
     return JSON.parse(new TextDecoder().decode(result.plaintext)) as T

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -94,6 +94,7 @@ import {
     updateProfileRequestType,
     stsCredentialChangedRequestType,
     getMfaCodeRequestType,
+    profileChangedRequestType,
 } from '../protocol/identity-management'
 import { IdentityManagement } from '../server-interface/identity-management'
 import { WebBase64Encoding } from './encoding'
@@ -218,6 +219,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
         onInvalidateStsCredential: handler => lspConnection.onRequest(invalidateStsCredentialRequestType, handler),
         sendSsoTokenChanged: params => lspConnection.sendNotification(ssoTokenChangedRequestType, params),
         sendStsCredentialChanged: params => lspConnection.sendNotification(stsCredentialChangedRequestType, params),
+        sendProfileChanged: params => lspConnection.sendNotification(profileChangedRequestType, params),
         sendGetMfaCode: params => lspConnection.sendRequest(getMfaCodeRequestType, params),
     }
 

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -35,9 +35,11 @@ import {
     stsCredentialChangedRequestType,
     getMfaCodeRequestType,
     profileChangedRequestType,
+    UpdateProfileParams,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
+    decryptObjectWithKey,
     encryptIamResultWithKey,
     EncryptionInitialization,
     encryptObjectWithKey,
@@ -306,7 +308,15 @@ export const standalone = (props: RuntimeProps) => {
 
         const identityManagement: IdentityManagement = {
             onListProfiles: handler => lspConnection.onRequest(listProfilesRequestType, handler),
-            onUpdateProfile: handler => lspConnection.onRequest(updateProfileRequestType, handler),
+            onUpdateProfile: handler =>
+                lspConnection.onRequest(
+                    updateProfileRequestType,
+                    async (params: UpdateProfileParams | string, token: CancellationToken) => {
+                        const decrypted: UpdateProfileParams =
+                            typeof params === 'string' ? await decryptObjectWithKey(params, encryptionKey!) : params
+                        return await handler(decrypted, token)
+                    }
+                ),
             onGetSsoToken: handler =>
                 lspConnection.onRequest(
                     getSsoTokenRequestType,

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -35,11 +35,9 @@ import {
     stsCredentialChangedRequestType,
     getMfaCodeRequestType,
     profileChangedRequestType,
-    UpdateProfileParams,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
-    decryptObjectWithKey,
     encryptIamResultWithKey,
     EncryptionInitialization,
     encryptObjectWithKey,
@@ -308,15 +306,7 @@ export const standalone = (props: RuntimeProps) => {
 
         const identityManagement: IdentityManagement = {
             onListProfiles: handler => lspConnection.onRequest(listProfilesRequestType, handler),
-            onUpdateProfile: handler =>
-                lspConnection.onRequest(
-                    updateProfileRequestType,
-                    async (params: UpdateProfileParams | string, token: CancellationToken) => {
-                        const decrypted: UpdateProfileParams =
-                            typeof params === 'string' ? await decryptObjectWithKey(params, encryptionKey!) : params
-                        return await handler(decrypted, token)
-                    }
-                ),
+            onUpdateProfile: handler => lspConnection.onRequest(updateProfileRequestType, handler),
             onGetSsoToken: handler =>
                 lspConnection.onRequest(
                     getSsoTokenRequestType,

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -34,6 +34,7 @@ import {
     ShowOpenDialogRequestType,
     stsCredentialChangedRequestType,
     getMfaCodeRequestType,
+    profileChangedRequestType,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -332,6 +333,7 @@ export const standalone = (props: RuntimeProps) => {
             onInvalidateStsCredential: handler => lspConnection.onRequest(invalidateStsCredentialRequestType, handler),
             sendSsoTokenChanged: params => lspConnection.sendNotification(ssoTokenChangedRequestType, params),
             sendStsCredentialChanged: params => lspConnection.sendNotification(stsCredentialChangedRequestType, params),
+            sendProfileChanged: params => lspConnection.sendNotification(profileChangedRequestType, params),
             sendGetMfaCode: params => lspConnection.sendRequest(getMfaCodeRequestType, params),
         }
 

--- a/runtimes/server-interface/identity-management.ts
+++ b/runtimes/server-interface/identity-management.ts
@@ -16,6 +16,7 @@ import {
     UpdateProfileParams,
     UpdateProfileResult,
     GetMfaCodeResult,
+    ProfileChangedParams,
 } from '../protocol/identity-management'
 import { RequestHandler } from '../protocol'
 
@@ -53,6 +54,8 @@ export type IdentityManagement = {
     sendSsoTokenChanged: (params: SsoTokenChangedParams) => void
 
     sendStsCredentialChanged: (params: StsCredentialChangedParams) => void
+
+    sendProfileChanged: (params: ProfileChangedParams) => void
 
     sendGetMfaCode: (params: GetMfaCodeParams) => Promise<GetMfaCodeResult>
 }


### PR DESCRIPTION
## Problem
The IAM authentication changes assume that the language server and language client exchange IAM credentials in plaintext through the listProfiles and updateProfile endpoints. Sensitive data, like IAM credentials, should instead be encrypted in-transit to follow best security practices.

## Solution
- Encrypt profiles returned by listProfiles
- Decrypt profiles sent to updateProfile

**This is a breaking change since language clients must decrypt listProfiles responses**

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
