### PR TITLE
feat: editable variable for modify functionality 

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -404,6 +404,9 @@ export interface ButtonClickParams {
     messageId: string
     buttonId: string
     metadata?: Record<string, string>
+    /**
+     * Enables passing edited text content when users interact with edit-related buttons
+     **/
     editedText?: string
 }
 

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -169,6 +169,7 @@ export interface ChatMessage {
     body?: string
     messageId?: string
     canBeVoted?: boolean // requires messageId to be filled to show vote thumbs
+    editable?: boolean
     relatedContent?: {
         title?: string
         content: SourceLink[]
@@ -403,6 +404,7 @@ export interface ButtonClickParams {
     messageId: string
     buttonId: string
     metadata?: Record<string, string>
+    editedText?: string
 }
 
 export interface ButtonClickResult {

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -404,10 +404,6 @@ export interface ButtonClickParams {
     messageId: string
     buttonId: string
     metadata?: Record<string, string>
-    /**
-     * Enables passing edited text content when users interact with edit-related buttons
-     **/
-    editedText?: string
 }
 
 export interface ButtonClickResult {


### PR DESCRIPTION
## Problem
The current chat interface lacks support for editing commands/messages after they have been sent. This limits user experience when users need to modify their chat prompts or correct mistakes without starting a new conversation thread.

## Solution
Added support for message editing by extending the chat type definitions: 
add editable property to ChatMessage and editedText to ButtonClickParams

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
