### PR TITLE
feat: support clickable in fileDetails

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -139,6 +139,7 @@ export interface FileDetails {
         total?: number
     }
     visibleName?: string
+    clickable?: boolean
 }
 
 export interface FileList {


### PR DESCRIPTION
## Problem

LSP server should be able to disable clicks for files in file lists.

## Solution

Add `clickable` to `FileDetails`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
