### PR TITLE
feat: add diagnostic checking and workspace file opening support

### DIFF
--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -31,11 +31,18 @@ The server runtime implementation acts as a proxy for LSP methods, which means i
 | onInlineCompletion | Yes     | Provide list of inline completion suggestions from the Server                                                                         |
 | onExecuteCommand   | Yes     | Executes a custom command provided by the Server. Servers are advised to document custom commands they support in the package README. |
 
+##### LSP Window
+
+| Description                          | Method                            | Params                         | Method type                                                                                                                     | Response Type   |
+| ------------------------------------ | --------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| Request to check diagnostics for specified files | `aws/checkDiagnostics`         | `CheckDiagnosticsParams`                   | [Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage) Server to Client           | `CheckDiagnosticsResult`    |
+
 ##### LSP Workspace
 
 | Description                          | Method                            | Params                         | Method type                                                                                                                     | Response Type   |
 | ------------------------------------ | --------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | --------------- |
 | Request to select workspace item (folder, file) with the selected items returned | `aws/selectWorkspaceItem`         | `SelectWorkspaceItemParams`                   | [Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage) Server to Client           | `SelectWorkspaceItemResult`    |
+| Request to open a file in the workspace programmatically | `aws/openWorkspaceFile`         | `OpenWorkspaceFileParams`                   | [Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage) Server to Client           | `OpenWorkspaceFileResult`    |
 | Sent notification to open file differences for the new file content. Supports new, updated or removed files. | `aws/openFileDiff`                | `OpenFileDiffParams`                | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) Server to Client          | n/a |
 | Sent notification that file was copied from old to new path using file system operation. | `aws/didCopyFile`                | `CopyFileParams`                | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) Server to Client          | n/a |
 | Sent notification that content was written to file using file system operation. | `aws/didWriteFile`                | `FileParams`                | [Notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage) Server to Client          | n/a |

--- a/runtimes/protocol/window.ts
+++ b/runtimes/protocol/window.ts
@@ -6,6 +6,9 @@ import {
     ShowOpenDialogResult,
     ShowOpenDialogParams,
     SHOW_OPEN_FILE_DIALOG_REQUEST_METHOD,
+    CHECK_DIAGNOSTICS_REQUEST_METHOD,
+    CheckDiagnosticsParams,
+    CheckDiagnosticsResult,
 } from './lsp'
 
 /**
@@ -27,3 +30,11 @@ export const ShowOpenDialogRequestType = new ProtocolRequestType<
     void,
     void
 >(SHOW_OPEN_FILE_DIALOG_REQUEST_METHOD)
+
+export const CheckDiagnosticsRequestType = new ProtocolRequestType<
+    CheckDiagnosticsParams,
+    CheckDiagnosticsResult,
+    never,
+    void,
+    void
+>(CHECK_DIAGNOSTICS_REQUEST_METHOD)

--- a/runtimes/protocol/workspace.ts
+++ b/runtimes/protocol/workspace.ts
@@ -8,6 +8,9 @@ import {
     FileParams,
     OPEN_FILE_DIFF_NOTIFICATION_METHOD,
     OpenFileDiffParams,
+    OPEN_WORKSPACE_FILE_REQUEST_METHOD,
+    OpenWorkspaceFileParams,
+    OpenWorkspaceFileResult,
     ProtocolNotificationType,
     ProtocolRequestType,
     SELECT_WORKSPACE_ITEM_REQUEST_METHOD,
@@ -46,3 +49,11 @@ export const didAppendFileNotificationType = new ProtocolNotificationType<FilePa
 export const didCreateDirectoryNotificationType = new ProtocolNotificationType<FileParams, void>(
     DID_CREATE_DIRECTORY_NOTIFICATION_METHOD
 )
+
+export const openWorkspaceFileRequestType = new ProtocolRequestType<
+    OpenWorkspaceFileParams,
+    OpenWorkspaceFileResult,
+    never,
+    void,
+    void
+>(OPEN_WORKSPACE_FILE_REQUEST_METHOD)

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -102,7 +102,8 @@ import { Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 import { getClientInitializeParamsHandlerFactory } from './util/lspCacheUtil'
 import { newAgent } from './agent'
-import { ShowSaveFileDialogRequestType } from '../protocol/window'
+import { ShowSaveFileDialogRequestType, CheckDiagnosticsRequestType } from '../protocol/window'
+import { openWorkspaceFileRequestType } from '../protocol/workspace'
 import { joinUnixPaths } from './util/pathUtil'
 import { editCompletionRequestType } from '../protocol/editCompletions'
 
@@ -273,6 +274,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
                 onUpdateConfiguration: lspServer.setUpdateConfigurationHandler,
                 selectWorkspaceItem: params => lspConnection.sendRequest(selectWorkspaceItemRequestType.method, params),
                 openFileDiff: params => lspConnection.sendNotification(openFileDiffNotificationType.method, params),
+                openWorkspaceFile: params => lspConnection.sendRequest(openWorkspaceFileRequestType.method, params),
             },
             window: {
                 showMessage: params => lspConnection.sendNotification(ShowMessageNotification.method, params),
@@ -280,6 +282,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
                 showDocument: params => lspConnection.sendRequest(ShowDocumentRequest.method, params),
                 showSaveFileDialog: params => lspConnection.sendRequest(ShowSaveFileDialogRequestType.method, params),
                 showOpenDialog: params => lspConnection.sendRequest(ShowOpenDialogRequestType.method, params),
+                checkDiagnostics: params => lspConnection.sendRequest(CheckDiagnosticsRequestType.method, params),
             },
             publishDiagnostics: params => lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),
             sendProgress: <P>(type: ProgressType<P>, token: ProgressToken, value: P) => {

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -34,6 +34,8 @@ import {
     ShowOpenDialogRequestType,
     stsCredentialChangedRequestType,
     getMfaCodeRequestType,
+    CheckDiagnosticsParams,
+    OpenWorkspaceFileParams,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -91,7 +93,8 @@ import { getTelemetryLspServer } from './util/telemetryLspServer'
 import { getClientInitializeParamsHandlerFactory } from './util/lspCacheUtil'
 import { makeProxyConfigv2Standalone, makeProxyConfigv3Standalone } from './util/standalone/proxyUtil'
 import { newAgent } from './agent'
-import { ShowSaveFileDialogRequestType } from '../protocol/window'
+import { ShowSaveFileDialogRequestType, CheckDiagnosticsRequestType } from '../protocol/window'
+import { openWorkspaceFileRequestType } from '../protocol/workspace'
 import { getTelemetryReasonDesc } from './util/shared'
 import { writeSync } from 'fs'
 import { format } from 'util'
@@ -400,6 +403,8 @@ export const standalone = (props: RuntimeProps) => {
                     selectWorkspaceItem: params =>
                         lspConnection.sendRequest(selectWorkspaceItemRequestType.method, params),
                     openFileDiff: params => lspConnection.sendNotification(openFileDiffNotificationType.method, params),
+                    openWorkspaceFile: (params: OpenWorkspaceFileParams) =>
+                        lspConnection.sendRequest(openWorkspaceFileRequestType.method, params),
                 },
                 window: {
                     showMessage: params => lspConnection.sendNotification(ShowMessageNotification.method, params),
@@ -409,6 +414,8 @@ export const standalone = (props: RuntimeProps) => {
                         lspConnection.sendRequest(ShowSaveFileDialogRequestType.method, params),
                     showOpenDialog: (params: ShowOpenDialogParams) =>
                         lspConnection.sendRequest(ShowOpenDialogRequestType.method, params),
+                    checkDiagnostics: (params: CheckDiagnosticsParams) =>
+                        lspConnection.sendRequest(CheckDiagnosticsRequestType.method, params),
                 },
                 publishDiagnostics: params =>
                     lspConnection.sendNotification(PublishDiagnosticsNotification.method, params),

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -61,6 +61,10 @@ import {
     ShowSaveFileDialogResult,
     ShowOpenDialogParams,
     ShowOpenDialogResult,
+    CheckDiagnosticsParams,
+    CheckDiagnosticsResult,
+    OpenWorkspaceFileParams,
+    OpenWorkspaceFileResult,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -154,6 +158,7 @@ export type Lsp = {
             handler: RequestHandler<SelectWorkspaceItemParams, SelectWorkspaceItemResult | undefined | null, void>
         ) => void
         openFileDiff: (params: OpenFileDiffParams) => void
+        openWorkspaceFile: (params: OpenWorkspaceFileParams) => Promise<OpenWorkspaceFileResult>
     }
     window: {
         showMessage: (params: ShowMessageParams) => Promise<void>
@@ -161,6 +166,7 @@ export type Lsp = {
         showDocument: (params: ShowDocumentParams) => Promise<ShowDocumentResult>
         showSaveFileDialog: (params: ShowSaveFileDialogParams) => Promise<ShowSaveFileDialogResult>
         showOpenDialog: (params: ShowOpenDialogParams) => Promise<ShowOpenDialogResult>
+        checkDiagnostics: (params: CheckDiagnosticsParams) => Promise<CheckDiagnosticsResult>
     }
     extensions: {
         onInlineCompletionWithReferences: (

--- a/types/window.ts
+++ b/types/window.ts
@@ -29,10 +29,21 @@ export interface ShowOpenDialogResult {
     uris: URI[]
 }
 
+export interface DiagnosticInfo {
+    range: {
+        start: { line: number; character: number }
+        end: { line: number; character: number }
+    }
+    severity?: number
+    message: string
+    source?: string
+    code?: string | number
+}
+
 export interface CheckDiagnosticsParams {
-    filePaths: Record<string, any>
+    filePath: Record<string, DiagnosticInfo[]>
 }
 
 export interface CheckDiagnosticsResult {
-    filePaths: Record<string, any>
+    filePath: Record<string, DiagnosticInfo[]>
 }

--- a/types/window.ts
+++ b/types/window.ts
@@ -2,6 +2,7 @@ import { URI } from 'vscode-languageserver-types'
 
 export const SHOW_SAVE_FILE_DIALOG_REQUEST_METHOD = 'aws/showSaveFileDialog'
 export const SHOW_OPEN_FILE_DIALOG_REQUEST_METHOD = 'aws/showOpenFileDialog'
+export const CHECK_DIAGNOSTICS_REQUEST_METHOD = 'aws/checkDiagnostics'
 export interface ShowSaveFileDialogParams {
     // Using untyped string to avoid locking this too strictly.
     // TODO: Migrate to LanguageKind when it is released in 3.18.0
@@ -26,4 +27,12 @@ export interface ShowOpenDialogParams {
 
 export interface ShowOpenDialogResult {
     uris: URI[]
+}
+
+export interface CheckDiagnosticsParams {
+    filePaths: Record<string, any>
+}
+
+export interface CheckDiagnosticsResult {
+    filePaths: Record<string, any>
 }

--- a/types/window.ts
+++ b/types/window.ts
@@ -41,9 +41,9 @@ export interface DiagnosticInfo {
 }
 
 export interface CheckDiagnosticsParams {
-    filePath: Record<string, DiagnosticInfo[]>
+    fileDiagnostics: Record<string, DiagnosticInfo[]>
 }
 
 export interface CheckDiagnosticsResult {
-    filePath: Record<string, DiagnosticInfo[]>
+    fileDiagnostics: Record<string, DiagnosticInfo[]>
 }

--- a/types/workspace.ts
+++ b/types/workspace.ts
@@ -8,6 +8,7 @@ export const DID_WRITE_FILE_NOTIFICATION_METHOD = 'aws/didWriteFile'
 export const DID_APPEND_FILE_NOTIFICATION_METHOD = 'aws/didAppendFile'
 export const DID_REMOVE_FILE_OR_DIRECTORY_NOTIFICATION_METHOD = 'aws/didRemoveFileOrDirectory'
 export const DID_CREATE_DIRECTORY_NOTIFICATION_METHOD = 'aws/didCreateDirectory'
+export const OPEN_WORKSPACE_FILE_REQUEST_METHOD = 'aws/openWorkspaceFile'
 
 export interface SelectWorkspaceItemParams {
     canSelectFolders: boolean
@@ -37,4 +38,13 @@ export interface CopyFileParams {
 
 export interface FileParams {
     path: string
+}
+
+export interface OpenWorkspaceFileParams {
+    filePath: string
+    makeActive?: boolean
+}
+
+export interface OpenWorkspaceFileResult {
+    success: boolean
 }


### PR DESCRIPTION
## Problem
No protocol support is available for Flare to get specific files' diagnostics information and open certain files's editors in VSC SIde 
## Solution
Add the protocol support
- Add CheckDiagnosticsRequestType for checking file diagnostics
- Add openWorkspaceFileRequestType for opening workspace files
- Update base-runtime and standalone to support new LSP methods
- Add type definitions for CheckDiagnosticsParams/Result and OpenWorkspaceFileParams/Result
- Enable language servers to request diagnostic information from IDEs
- Enable language servers to open files in the workspace programmatically
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
