### PR TITLE
fix: add file context override for inline completion

### DIFF
--- a/runtimes/protocol/inlineCompletionWithReferences.ts
+++ b/runtimes/protocol/inlineCompletionWithReferences.ts
@@ -21,10 +21,23 @@ interface OpenTabParams {
     openTabFilepaths?: string[]
 }
 
+interface FileContext {
+    leftFileContent: string
+    rightFileContent: string
+    filename: string
+    fileUri?: string
+    programmingLanguage: string
+}
+
+interface FileContextParams {
+    fileContextOverride?: FileContext
+}
+
 export type InlineCompletionWithReferencesParams = InlineCompletionParams &
     PartialResultParams &
     DocumentChangeParams &
-    OpenTabParams
+    OpenTabParams &
+    FileContextParams
 
 export const inlineCompletionWithReferencesRequestType = new ProtocolRequestType<
     InlineCompletionWithReferencesParams,


### PR DESCRIPTION
## Problem

Support of inline completion in JL Notebook is gone since the language server migration. 
https://github.com/aws/aws-toolkit-vscode/pull/7086

## Solution

Let the IDE provide the file context. 

There is a technical limitations of the language server that it cannot find or construct the `vscode.NotebookDocument`, `vscode.NotebookCell`. The `workspace.getTextDocument` does not work with JL Notebook as it gets a URI in the format of "`vscode-notebook-cell:/../A1.ipynb#W2sZmlsZQ%3D%3D`". The language server does not have the cell number, cell state, cursor position, etc of the current cell.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
