### PR TITLE
fix: skip PAC URLs in macOS proxy detection

### DIFF
--- a/runtimes/runtimes/util/standalone/getProxySettings/getMacProxySettings.ts
+++ b/runtimes/runtimes/util/standalone/getProxySettings/getMacProxySettings.ts
@@ -35,8 +35,10 @@ export function getMacSystemProxy(): ProxyConfig | undefined {
 
     // Honor PAC URL first if configured
     if (settings.ProxyAutoConfigEnable === '1' && settings.ProxyAutoConfigURLString) {
-        console.debug(`Using PAC URL: ${settings.ProxyAutoConfigURLString}`)
-        return { proxyUrl: settings.ProxyAutoConfigURLString, noProxy }
+        console.debug(`PAC URL detected: ${settings.ProxyAutoConfigURLString}`)
+        // TODO: Parse PAC file to get actual proxy
+        // For now, skip PAC and fall through to manual proxy settings
+        console.warn('PAC file support not yet implemented, falling back to manual proxy settings')
     }
 
     // Otherwise pick the first enabled protocol


### PR DESCRIPTION
## Problem
PAC (Proxy Auto-Configuration) file URLs were being returned directly as proxy URLs, causing the HTTP agent to attempt CONNECT requests to PAC file servers instead of parsing the PAC file to determine the actual proxy configuration. This resulted in "Bad response: 501/400" errors when enterprises used PAC files for proxy configuration.

 - `501` "Not Implemented": The PAC file server doesn't support the CONNECT method at all (like Python's http.server in the bug report)

- `400` "Bad Request": The PAC file server recognizes CONNECT but considers it malformed or inappropriate for that endpoint

Issues: 
- https://github.com/aws/aws-toolkit-vscode/issues/7900
- https://github.com/aws/aws-toolkit-vscode/issues/7878


## Solution

Modified `getMacSystemProxy()` to skip PAC URLs when detected and fall back to manual HTTP/HTTPS proxy settings. This prevents PAC file URLs from being incorrectly used as direct proxy servers while PAC file parsing is not yet implemented

TODO:
- Implement a PAC parser (This is a significant feature requiring JavaScript evaluation and HTTP fetching, which is why it's currently marked as a TODO)

## Testing


1. Created a simple PAC file server:

    ```
      # Created local.pac with content:
      function FindProxyForURL(url, host) {
          return "PROXY localhost:8080";
      }
    ```

    ```
     # Served using Python:
     python3 -m http.server 8082
   ```

    

2. Configured system to use PAC file:

    ```
      sudo networksetup -setautoproxyurl "Wi-Fi" "http://localhost:8082/local.pac"
      sudo networksetup -setautoproxystate "Wi-Fi" on
   ```

    

Test Results:

    With PAC Configuration:
        AWS extension incorrectly tried to use PAC file URL as proxy
        
       
<img width="505" height="161" alt="Screenshot 2025-08-18 at 1 05 49 PM" src="https://github.com/user-attachments/assets/f9d70581-7f34-41c0-83a7-f0324701d288" />


    Without PAC:
        Successfully connected
        
<img width="1624" height="971" alt="Screenshot 2025-08-18 at 1 41 38 PM" src="https://github.com/user-attachments/assets/34db6523-e3ed-4afd-8276-b3c117c5855e" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
