### PR TITLE
chore(runtimes): fix test failures under macOS and Node.js 22

### DIFF
--- a/.github/workflows/runtimes-ci.yaml
+++ b/.github/workflows/runtimes-ci.yaml
@@ -41,3 +41,20 @@ jobs:
             - name: Test
               run: |
                   npm run test
+    test-mac:
+        name: Test (macOS)
+        runs-on: macos-latest
+        steps:
+            - name: Sync Code
+              uses: actions/checkout@v4
+            - name: Set up Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+            - name: Build
+              run: |
+                  npm ci
+                  npm run compile
+            - name: Test
+              run: |
+                  npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -545,6 +545,47 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
         "node_modules/@jsdevtools/ono": {
             "version": "7.1.3",
             "dev": true,
@@ -590,6 +631,8 @@
         },
         "node_modules/@opentelemetry/api": {
             "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8.0.0"
@@ -599,6 +642,7 @@
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
             "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api": "^1.3.0"
             },
@@ -607,9 +651,10 @@
             }
         },
         "node_modules/@opentelemetry/core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-            "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+            "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -624,6 +669,7 @@
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.200.0.tgz",
             "integrity": "sha512-KfWw49htbGGp9s8N4KI8EQ9XuqKJ0VG+yVYVYFiCYSjEV32qpQ5qZ9UZBzOZ6xRb+E16SXOSCT3RkqBVSABZ+g==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api-logs": "0.200.0",
                 "@opentelemetry/core": "2.0.0",
@@ -638,10 +684,26 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
         "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.200.0.tgz",
             "integrity": "sha512-5BiR6i8yHc9+qW7F6LqkuUnIzVNA7lt0qRxIKcKT+gq3eGUPHZ3DY29sfxI3tkvnwMgtnHDMNze5DdxW39HsAw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "2.0.0",
                 "@opentelemetry/otlp-exporter-base": "0.200.0",
@@ -654,6 +716,21 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
@@ -692,6 +769,7 @@
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.200.0.tgz",
             "integrity": "sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "2.0.0",
                 "@opentelemetry/otlp-transformer": "0.200.0"
@@ -703,10 +781,26 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
         "node_modules/@opentelemetry/otlp-transformer": {
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.200.0.tgz",
             "integrity": "sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api-logs": "0.200.0",
                 "@opentelemetry/core": "2.0.0",
@@ -721,6 +815,21 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
@@ -771,25 +880,11 @@
                 "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-            "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
         "node_modules/@opentelemetry/sdk-logs": {
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
             "integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api-logs": "0.200.0",
                 "@opentelemetry/core": "2.0.0",
@@ -800,6 +895,21 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
@@ -834,25 +944,11 @@
                 "@opentelemetry/api": ">=1.9.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-            "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
         "node_modules/@opentelemetry/sdk-trace-base": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
             "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "2.0.0",
                 "@opentelemetry/resources": "2.0.0",
@@ -863,6 +959,21 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
@@ -882,9 +993,9 @@
             }
         },
         "node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.30.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
-            "integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
+            "version": "1.36.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
+            "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
@@ -892,22 +1003,32 @@
         },
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/base64": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.1",
@@ -916,22 +1037,32 @@
         },
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/pool": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@sinonjs/commons": {
@@ -1055,6 +1186,34 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/chai": {
             "version": "5.0.1",
             "dev": true,
@@ -1120,6 +1279,8 @@
         },
         "node_modules/@types/proxyquire": {
             "version": "1.3.31",
+            "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.31.tgz",
+            "integrity": "sha512-uALowNG2TSM1HNPMMOR0AJwv4aPYPhqB0xlEhkeRTMuto5hjoSPZkvgu1nbPUkz3gEPAHv4sy4DmKsurZiEfRQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -1144,6 +1305,32 @@
             "version": "8.1.5",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/acorn": {
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
         },
         "node_modules/ajv": {
             "version": "8.17.1",
@@ -1254,6 +1441,13 @@
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/argparse": {
             "version": "2.0.1",
@@ -1781,6 +1975,13 @@
                 "cosmiconfig": ">=9",
                 "typescript": ">=5"
             }
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -2892,7 +3093,9 @@
             }
         },
         "node_modules/long": {
-            "version": "5.2.4",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
             "license": "Apache-2.0"
         },
         "node_modules/mac-ca": {
@@ -2916,8 +3119,7 @@
         "node_modules/make-error": {
             "version": "1.3.6",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/meow": {
             "version": "12.1.1",
@@ -3433,10 +3635,11 @@
             "license": "MIT"
         },
         "node_modules/protobufjs": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-            "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
             "hasInstallScript": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -3457,6 +3660,8 @@
         },
         "node_modules/proxyquire": {
             "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+            "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4464,6 +4669,13 @@
             "version": "1.0.2",
             "license": "MIT"
         },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/vscode-jsonrpc": {
             "version": "8.2.0",
             "license": "MIT",
@@ -4722,12 +4934,22 @@
                 "node-forge": "^1.3.1",
                 "prettier": "3.5.3",
                 "sinon": "^20.0.0",
-                "ts-mocha": "^11.1.0",
+                "ts-node": "^10.9.2",
                 "ts-sinon": "^2.0.2",
                 "typescript": "^5.8.3"
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "runtimes/node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "runtimes/node_modules/jose": {
@@ -4737,6 +4959,60 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "runtimes/node_modules/ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "runtimes/node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "types": {

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -22,7 +22,7 @@
         "prepub:copyFiles": "shx cp ../.npmignore CHANGELOG.md ../LICENSE ../NOTICE README.md ../SECURITY.md package.json out/",
         "prepub": "npm run clean && npm run test && npm run compile && npm run prepub:copyFiles",
         "pub": "cd out && npm publish",
-        "test:unit": "ts-mocha -b './**/*.test.ts'",
+        "test:unit": "mocha -r ts-node/register './**/*.test.ts' --timeout 10000 --exit",
         "test": "npm run test:unit",
         "preversion": "npm run test",
         "version": "npm run compile && git add -A .",
@@ -45,12 +45,12 @@
         "hpagent": "^1.2.0",
         "jose": "^5.9.6",
         "mac-ca": "^3.1.1",
+        "registry-js": "^1.16.1",
         "rxjs": "^7.8.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-protocol": "^3.17.5",
         "vscode-uri": "^3.1.0",
-        "win-ca": "^3.5.1",
-        "registry-js": "^1.16.1"
+        "win-ca": "^3.5.1"
     },
     "devDependencies": {
         "@types/mocha": "^10.0.9",
@@ -65,7 +65,7 @@
         "node-forge": "^1.3.1",
         "prettier": "3.5.3",
         "sinon": "^20.0.0",
-        "ts-mocha": "^11.1.0",
+        "ts-node": "^10.9.2",
         "ts-sinon": "^2.0.2",
         "typescript": "^5.8.3"
     },

--- a/runtimes/runtimes/auth/auth.test.ts
+++ b/runtimes/runtimes/auth/auth.test.ts
@@ -120,6 +120,11 @@ describe('Auth', () => {
         clearHandlers()
     })
 
+    afterEach(() => {
+        serverConnection.dispose()
+        clientConnection.dispose()
+    })
+
     it('Handles IAM credentials', async () => {
         const updateRequest: UpdateCredentialsParams = {
             data: iamCredentials,

--- a/runtimes/runtimes/lsp/router/initializeUtils.test.ts
+++ b/runtimes/runtimes/lsp/router/initializeUtils.test.ts
@@ -1,8 +1,8 @@
 import { URI } from 'vscode-uri'
 import * as path from 'path'
 import os from 'os'
-import assert = require('assert')
-import sinon = require('sinon')
+import assert from 'assert'
+import sinon from 'sinon'
 import { InitializeParams, WorkspaceFolder } from 'vscode-languageserver-protocol'
 import { getWorkspaceFoldersFromInit } from './initializeUtils'
 import { RemoteConsole } from 'vscode-languageserver'

--- a/runtimes/runtimes/webworker.test.ts
+++ b/runtimes/runtimes/webworker.test.ts
@@ -2,14 +2,16 @@ import sinon, { stubInterface } from 'ts-sinon'
 import { RuntimeProps } from './runtime'
 import * as vscodeLanguageServer from 'vscode-languageserver/node'
 import assert from 'assert'
-import proxyquire from 'proxyquire'
 import { Features } from '../server-interface/server'
+import * as browserModule from 'vscode-languageserver/browser'
 
 describe('webworker', () => {
     let stubServer: sinon.SinonStub
     let props: RuntimeProps
     let stubConnection: sinon.SinonStubbedInstance<vscodeLanguageServer.Connection> & vscodeLanguageServer.Connection
     let webworker: (props: RuntimeProps) => void
+    let mockReader: any
+    let mockWriter: any
 
     beforeEach(() => {
         stubServer = sinon.stub()
@@ -22,15 +24,30 @@ describe('webworker', () => {
         stubConnection.console = stubInterface<vscodeLanguageServer.RemoteConsole>()
         stubConnection.telemetry = stubInterface<vscodeLanguageServer.Telemetry>()
         stubConnection.workspace = stubInterface<vscodeLanguageServer.RemoteWorkspace>()
-        ;(global as any).self = sinon.stub()
-        ;({ webworker } = proxyquire('./webworker', {
-            'vscode-languageserver/browser': {
-                BrowserMessageReader: sinon.stub(),
-                BrowserMessageWriter: sinon.stub(),
-                createConnection: () => stubConnection,
-                '@global': true,
-            },
-        }))
+
+        // Set up global self for webworker environment
+        const mockSelf = {
+            postMessage: sinon.stub(),
+            onmessage: null,
+            addEventListener: sinon.stub(),
+            removeEventListener: sinon.stub(),
+        } as any
+        ;(global as any).self = mockSelf
+
+        // Mock the browser message reader/writer instances
+        mockReader = stubInterface()
+        mockWriter = stubInterface()
+
+        // Stub the constructors to return our mocked instances
+        sinon.stub(browserModule, 'BrowserMessageReader').returns(mockReader)
+        sinon.stub(browserModule, 'BrowserMessageWriter').returns(mockWriter)
+
+        // Most importantly, mock createConnection to return our stubbed connection
+        sinon.stub(browserModule, 'createConnection').returns(stubConnection)
+
+        // Now import the actual webworker module - the stubs will be used when it constructs reader/writer/connection
+        const webworkerModule = require('./webworker')
+        webworker = webworkerModule.webworker
     })
 
     afterEach(() => {


### PR DESCRIPTION
This commit fixes test failures observed under macOS and Node.js 22 and adds a CI job to run the tests in an environment that uses both.

## Problem

The test suite was experiencing critical issues on macOS with Node.js 22:

1. **Test Process Hanging**: Tests would hang indefinitely after reporting results due to a broken child process exit handler in `ts-mocha`.
2. **Resource Leaks**: Some tests weren't properly disposing of LSP connections, contributing to hanging issues.
3. **Platform-Specific Failures**: The webworker test was failing due to `proxyquire` incompatibility with Node.js 22's ES module handling.

## Solution

### 1. Test Runner Replacement
- **Replaced ts-mocha with direct mocha + ts-node/register + --exit flag**
- Eliminates the problematic child process handling in ts-mocha
- Ensures clean process termination while maintaining identical functionality

### 2. Resource Cleanup Improvements
- **Auth Tests**: Added proper `afterEach` cleanup to dispose LSP connections

### 3. Node.js 22 Compatibility
- **Webworker Tests**: Replaced `proxyquire` (incompatible with Node.js 22 ES modules) with direct sinon stubbing

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
