### PR TITLE
perf: add sideEffects declaration to all packages

### DIFF
--- a/chat-client-ui-types/package.json
+++ b/chat-client-ui-types/package.json
@@ -17,6 +17,7 @@
     },
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
+    "sideEffects": false,
     "dependencies": {
         "@aws/language-server-runtimes-types": "^0.1.56"
     }

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -9,6 +9,7 @@
     },
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
+    "sideEffects": false,
     "engines": {
         "node": ">=18.0.0"
     },

--- a/types/package.json
+++ b/types/package.json
@@ -17,6 +17,7 @@
     },
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
+    "sideEffects": false,
     "dependencies": {
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-languageserver-types": "^3.17.5"


### PR DESCRIPTION
This commit adds `sideEffects: false` to all packages, allowing Webpack and other bundlers to remove unused code when consumers import from them:
https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
