### PR TITLE
feat: add supplemental context api

### DIFF
--- a/runtimes/protocol/inlineCompletionWithReferences.ts
+++ b/runtimes/protocol/inlineCompletionWithReferences.ts
@@ -33,6 +33,16 @@ interface FileContextParams {
     fileContextOverride?: FileContext
 }
 
+export interface SupplementalContextItem {
+    content: string
+    filePath: string
+    score?: number
+}
+
+export interface GetSupplementalContextParams {
+    filePath: string
+}
+
 export type InlineCompletionWithReferencesParams = InlineCompletionParams &
     PartialResultParams &
     DocumentChangeParams &
@@ -51,3 +61,11 @@ export const logInlineCompletionSessionResultsNotificationType = new ProtocolNot
     LogInlineCompletionSessionResultsParams,
     void
 >('aws/logInlineCompletionSessionResults')
+
+export const getSupplementalContextRequestType = new ProtocolRequestType<
+    GetSupplementalContextParams,
+    SupplementalContextItem[],
+    SupplementalContextItem[],
+    void,
+    void
+>('aws/textDocument/getProjectContext')

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -62,6 +62,7 @@ import {
     listAvailableModelsRequestType,
     subscriptionDetailsNotificationType,
     subscriptionUpgradeNotificationType,
+    getSupplementalContextRequestType,
 } from '../protocol'
 import { createConnection } from 'vscode-languageserver/browser'
 import {
@@ -256,6 +257,7 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
             onCompletion: handler => lspConnection.onCompletion(handler),
             onInlineCompletion: handler => lspConnection.onRequest(inlineCompletionRequestType, handler),
             onEditCompletion: handler => lspConnection.onRequest(editCompletionRequestType, handler),
+            onGetSupplementalContext: handler => lspConnection.onRequest(getSupplementalContextRequestType, handler),
             didChangeConfiguration: lspServer.setDidChangeConfigurationHandler,
             onDidFormatDocument: handler => lspConnection.onDocumentFormatting(handler),
             onDidOpenTextDocument: handler => documentsObserver.callbacks.onDidOpenTextDocument(handler),
@@ -295,6 +297,8 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
                 onInlineCompletionWithReferences: handler =>
                     lspConnection.onRequest(inlineCompletionWithReferencesRequestType, handler),
                 onEditCompletion: handler => lspConnection.onRequest(editCompletionRequestType, handler),
+                onGetSupplementalContext: handler =>
+                    lspConnection.onRequest(getSupplementalContextRequestType, handler),
                 onLogInlineCompletionSessionResults: handler => {
                     lspConnection.onNotification(logInlineCompletionSessionResultsNotificationType, handler)
                 },

--- a/runtimes/runtimes/standalone.ts
+++ b/runtimes/runtimes/standalone.ts
@@ -36,6 +36,7 @@ import {
     getMfaCodeRequestType,
     CheckDiagnosticsParams,
     OpenWorkspaceFileParams,
+    getSupplementalContextRequestType,
 } from '../protocol'
 import { ProposedFeatures, createConnection } from 'vscode-languageserver/node'
 import {
@@ -388,6 +389,8 @@ export const standalone = (props: RuntimeProps) => {
                 onCompletion: handler => lspConnection.onCompletion(handler),
                 onInlineCompletion: handler => lspConnection.onRequest(inlineCompletionRequestType, handler),
                 onEditCompletion: handler => lspConnection.onRequest(editCompletionRequestType, handler),
+                onGetSupplementalContext: handler =>
+                    lspConnection.onRequest(getSupplementalContextRequestType, handler),
                 didChangeConfiguration: lspServer.setDidChangeConfigurationHandler,
                 onDidFormatDocument: handler => lspConnection.onDocumentFormatting(handler),
                 onDidOpenTextDocument: handler => documentsObserver.callbacks.onDidOpenTextDocument(handler),
@@ -443,6 +446,9 @@ export const standalone = (props: RuntimeProps) => {
                     },
                     onDidChangeDependencyPaths(handler) {
                         lspConnection.onNotification(didChangeDependencyPathsNotificationType, handler)
+                    },
+                    onGetSupplementalContext: handler => {
+                        lspConnection.onRequest(getSupplementalContextRequestType, handler)
                     },
                 },
             }

--- a/runtimes/server-interface/lsp.ts
+++ b/runtimes/server-interface/lsp.ts
@@ -65,6 +65,8 @@ import {
     CheckDiagnosticsResult,
     OpenWorkspaceFileParams,
     OpenWorkspaceFileResult,
+    GetSupplementalContextParams,
+    SupplementalContextItem,
 } from '../protocol'
 
 // Re-export whole surface of LSP protocol used in Runtimes.
@@ -129,6 +131,9 @@ export type Lsp = {
             void
         >
     ) => void
+    onGetSupplementalContext: (
+        handler: RequestHandler<GetSupplementalContextParams, SupplementalContextItem[] | undefined | null, void>
+    ) => void
     onCompletion: (
         handler: RequestHandler<CompletionParams, CompletionItem[] | CompletionList | undefined | null, void>
     ) => void
@@ -188,5 +193,8 @@ export type Lsp = {
         ) => void
         onGetConfigurationFromServer: (handler: RequestHandler<GetConfigurationFromServerParams, LSPAny, void>) => void
         onDidChangeDependencyPaths: (handler: NotificationHandler<DidChangeDependencyPathsParams>) => void
+        onGetSupplementalContext: (
+            handler: RequestHandler<GetSupplementalContextParams, SupplementalContextItem[] | undefined | null, void>
+        ) => void
     }
 }


### PR DESCRIPTION
## Problem

Part of the work needed to let VS Code IDE get supplemental context from the language server

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
