### PR TITLE
feat!: migrate from AWS SDK v2 to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1288,6 +1288,7 @@
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "possible-typed-array-names": "^1.0.0"
@@ -1297,35 +1298,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/aws-sdk": {
-            "version": "2.1692.0",
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "buffer": "4.9.2",
-                "events": "1.1.1",
-                "ieee754": "1.1.13",
-                "jmespath": "0.16.0",
-                "querystring": "0.2.0",
-                "sax": "1.2.1",
-                "url": "0.10.3",
-                "util": "^0.12.4",
-                "uuid": "8.0.0",
-                "xml2js": "0.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/aws-sdk/node_modules/uuid": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-            "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/balanced-match": {
@@ -1449,27 +1421,15 @@
             "license": "ISC",
             "peer": true
         },
-        "node_modules/buffer": {
-            "version": "4.9.2",
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
-            }
-        },
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "dev": true,
             "license": "MIT",
             "peer": true
         },
-        "node_modules/buffer/node_modules/isarray": {
-            "version": "1.0.0",
-            "license": "MIT"
-        },
         "node_modules/call-bind": {
             "version": "1.0.7",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0",
@@ -1860,6 +1820,7 @@
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0",
@@ -1962,6 +1923,7 @@
         },
         "node_modules/es-define-property": {
             "version": "1.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "get-intrinsic": "^1.2.4"
@@ -1972,6 +1934,7 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -1995,13 +1958,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/events": {
-            "version": "1.1.1",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.x"
             }
         },
         "node_modules/expand-template": {
@@ -2097,6 +2053,7 @@
         },
         "node_modules/for-each": {
             "version": "0.3.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-callable": "^1.1.3"
@@ -2128,6 +2085,7 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2207,6 +2165,7 @@
         },
         "node_modules/get-intrinsic": {
             "version": "1.2.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -2294,6 +2253,7 @@
         },
         "node_modules/gopd": {
             "version": "1.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "get-intrinsic": "^1.2.4"
@@ -2315,6 +2275,7 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0"
@@ -2325,6 +2286,7 @@
         },
         "node_modules/has-proto": {
             "version": "1.1.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7"
@@ -2338,6 +2300,7 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2348,6 +2311,7 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
@@ -2367,6 +2331,7 @@
         },
         "node_modules/hasown": {
             "version": "2.0.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -2492,6 +2457,7 @@
         },
         "node_modules/is-arguments": {
             "version": "1.1.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -2525,6 +2491,7 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2568,6 +2535,7 @@
         },
         "node_modules/is-generator-function": {
             "version": "1.0.10",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
@@ -2653,6 +2621,7 @@
         },
         "node_modules/is-typed-array": {
             "version": "1.1.13",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "which-typed-array": "^1.1.14"
@@ -2694,13 +2663,6 @@
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
-            }
-        },
-        "node_modules/jmespath": {
-            "version": "0.16.0",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">= 0.6.0"
             }
         },
         "node_modules/js-tokens": {
@@ -3340,6 +3302,7 @@
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -3473,16 +3436,6 @@
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
-            }
-        },
-        "node_modules/punycode": {
-            "version": "1.3.2",
-            "license": "MIT"
-        },
-        "node_modules/querystring": {
-            "version": "0.2.0",
-            "engines": {
-                "node": ">=0.4.x"
             }
         },
         "node_modules/queue-microtask": {
@@ -3694,10 +3647,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/sax": {
-            "version": "1.2.1",
-            "license": "ISC"
-        },
         "node_modules/semver": {
             "version": "7.7.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -3728,6 +3677,7 @@
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "define-data-property": "^1.1.4",
@@ -4441,16 +4391,9 @@
                 "node": ">=8"
             }
         },
-        "node_modules/url": {
-            "version": "0.10.3",
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "1.3.2",
-                "querystring": "0.2.0"
-            }
-        },
         "node_modules/util": {
             "version": "0.12.5",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -4527,6 +4470,7 @@
         },
         "node_modules/which-typed-array": {
             "version": "1.1.16",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
@@ -4587,24 +4531,6 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "license": "ISC"
-        },
-        "node_modules/xml2js": {
-            "version": "0.6.2",
-            "license": "MIT",
-            "dependencies": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/xmlbuilder": {
-            "version": "11.0.1",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            }
         },
         "node_modules/xtend": {
             "version": "4.0.2",
@@ -4698,7 +4624,6 @@
                 "@opentelemetry/sdk-metrics": "^2.0.1",
                 "@smithy/node-http-handler": "^4.0.4",
                 "ajv": "^8.17.1",
-                "aws-sdk": "^2.1692.0",
                 "hpagent": "^1.2.0",
                 "jose": "^5.9.6",
                 "mac-ca": "^3.1.1",

--- a/runtimes/package.json
+++ b/runtimes/package.json
@@ -41,7 +41,6 @@
         "@opentelemetry/sdk-metrics": "^2.0.1",
         "@smithy/node-http-handler": "^4.0.4",
         "ajv": "^8.17.1",
-        "aws-sdk": "^2.1692.0",
         "hpagent": "^1.2.0",
         "jose": "^5.9.6",
         "mac-ca": "^3.1.1",

--- a/runtimes/runtimes/base-runtime.ts
+++ b/runtimes/runtimes/base-runtime.ts
@@ -72,7 +72,6 @@ import {
     Runtime,
     Telemetry,
     Workspace,
-    SDKClientConstructorV2,
     SDKClientConstructorV3,
     SDKInitializator,
     MessageReader,
@@ -99,8 +98,6 @@ import {
 import { IdentityManagement } from '../server-interface/identity-management'
 import { WebBase64Encoding } from './encoding'
 import { LoggingServer } from './lsp/router/loggingServer'
-import { Service } from 'aws-sdk'
-import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 import { getClientInitializeParamsHandlerFactory } from './util/lspCacheUtil'
 import { newAgent } from './agent'
 import { ShowSaveFileDialogRequestType, CheckDiagnosticsRequestType } from '../protocol/window'
@@ -308,17 +305,8 @@ export const baseRuntime = (connections: { reader: MessageReader; writer: Messag
             },
         }
 
-        const sdkInitializator: SDKInitializator = Object.assign(
-            // Default callable function for v3 clients
-            <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T => new Ctor({ ...current_config }),
-            // Property for v2 clients
-            {
-                v2: <T extends Service, P extends ServiceConfigurationOptions>(
-                    Ctor: SDKClientConstructorV2<T, P>,
-                    current_config: P
-                ): T => new Ctor({ ...current_config }),
-            }
-        )
+        const sdkInitializator: SDKInitializator = <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T =>
+            new Ctor({ ...current_config })
         credentialsProvider.onCredentialsDeleted = lspServer.setCredentialsDeleteHandler
 
         const agent = newAgent()

--- a/runtimes/runtimes/util/standalone/experimentalProxyUtil.test.ts
+++ b/runtimes/runtimes/util/standalone/experimentalProxyUtil.test.ts
@@ -72,14 +72,6 @@ describe('ProxyConfigManager', function () {
         mockFs.restore()
     })
 
-    it('should cache and return same V2 config', () => {
-        const config1 = proxyManager.getV2ProxyConfig()
-        const config2 = proxyManager.getV2ProxyConfig()
-
-        assert.strictEqual(config1, config2)
-        assert.strictEqual(config1.httpOptions?.agent, config2.httpOptions?.agent)
-    })
-
     it('should cache and return same V3 config', () => {
         const config1 = proxyManager.getV3ProxyConfig()
         const config2 = proxyManager.getV3ProxyConfig()
@@ -87,13 +79,11 @@ describe('ProxyConfigManager', function () {
         assert.strictEqual(config1, config2)
     })
 
-    it('should use same agent for V2 and V3 configs', () => {
+    it('should use secure agent for V3 config', () => {
         const getAgentSpy = sinon.spy(proxyManager, 'getSecureAgent')
-        proxyManager.getV2ProxyConfig()
         proxyManager.getV3ProxyConfig()
 
-        assert(getAgentSpy.calledTwice)
-        assert.strictEqual(getAgentSpy.firstCall.returnValue, getAgentSpy.secondCall.returnValue)
+        assert(getAgentSpy.calledOnce)
     })
 
     describe('getProxyUrlFromEnv', () => {

--- a/runtimes/runtimes/util/standalone/experimentalProxyUtil.ts
+++ b/runtimes/runtimes/util/standalone/experimentalProxyUtil.ts
@@ -7,7 +7,6 @@ import { readFileSync } from 'node:fs'
 import * as tls from 'node:tls'
 import { Agent as HttpsAgent } from 'node:https'
 import { X509Certificate } from 'node:crypto'
-import { ConfigurationOptions } from 'aws-sdk'
 import { HttpsProxyAgent } from 'hpagent'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { readMacosCertificates, readLinuxCertificates, readWindowsCertificates } from './certificatesReaders'
@@ -21,7 +20,6 @@ export class ProxyConfigManager {
      * Environment variables for proxy configuration, in order of precedence
      */
     private PROXY_ENV_VARS = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy']
-    private cachedV2Config?: ConfigurationOptions
     private cachedV3Config?: NodeHttpHandler
     private cachedAgent?: HttpsAgent | HttpsProxyAgent
 
@@ -32,18 +30,6 @@ export class ProxyConfigManager {
             this.cachedAgent = this.createSecureAgent()
         }
         return this.cachedAgent
-    }
-
-    public getV2ProxyConfig(): ConfigurationOptions {
-        if (!this.cachedV2Config) {
-            const agent = this.getSecureAgent()
-            this.cachedV2Config = {
-                httpOptions: {
-                    agent: agent,
-                },
-            }
-        }
-        return this.cachedV2Config
     }
 
     public getV3ProxyConfig(): NodeHttpHandler {

--- a/runtimes/runtimes/util/standalone/proxyUtil.ts
+++ b/runtimes/runtimes/util/standalone/proxyUtil.ts
@@ -1,31 +1,7 @@
 import { Workspace } from '../../../server-interface'
 
-import { ConfigurationOptions } from 'aws-sdk'
 import { HttpsProxyAgent } from 'hpagent'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
-
-// proxy configuration for sdk v2 clients
-export const makeProxyConfigv2Standalone = (workspace: Workspace): ConfigurationOptions => {
-    let additionalAwsConfig: ConfigurationOptions = {}
-    const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-
-    if (proxyUrl) {
-        const certs = process.env.AWS_CA_BUNDLE ? [workspace.fs.readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
-
-        const agent = new HttpsProxyAgent({
-            proxy: proxyUrl,
-            ca: certs,
-        })
-
-        additionalAwsConfig = {
-            httpOptions: {
-                agent: agent,
-            },
-        }
-    }
-
-    return additionalAwsConfig
-}
 
 // proxy configuration for sdk v3 clients
 export const makeProxyConfigv3Standalone = (workspace: Workspace): NodeHttpHandler | undefined => {

--- a/runtimes/server-interface/sdk-initializator.ts
+++ b/runtimes/server-interface/sdk-initializator.ts
@@ -1,58 +1,18 @@
-import { Service } from 'aws-sdk'
-import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
-
-// aws sdk v2 clients constructor type
-export type SDKClientConstructorV2<T, P extends ServiceConfigurationOptions> = new (config?: P) => T
 // aws sdk v3 clients constructor type
 export type SDKClientConstructorV3<T, P> = new (...[configuration]: [P] | []) => T
 
 /**
- * SDKInitializator type initializes AWS SDK clients whose constructor and initial configurations are passed as input.
+ * SDKInitializator type initializes AWS SDK v3 clients whose constructor and initial configurations are passed as input.
  * This type serves as a client factory that wraps SDK client constructors, and instantiates them at runtime, allowing additional runtime/environment-specific
- * configurations (e.g. proxy settings) to be injected at runtime. It provides a unified interface
- * for instantiating both AWS SDK v2 and v3 clients, with v3 being the default implementation.
- *
- * @template T - Type parameter for the aws sdk client (v2 or v3)
- * @template P - Type parameter for the configurations options
- *
- * @example
- * // V3 usage (default)
- * const v3Client = sdkInitializator(MySdkV3Client, {
- *     region: 'example_region',
- *     endpoint: 'example_endpoint'
- * });
- *
- * // V2 usage (through .v2 property)
- * const v2Client = sdkInitializator.v2(MySdkV2Client, {
- *     region: 'example_region',
- *     endpoint: 'example_endpoint'
- * });
- */
-export type SDKInitializator = {
-    /**
-     * Creates an instance of the SDK v2 client whose constructor is given as input parameter.
-     *
-     * @template T - Type parameter extending Service base type
-     * @template P - Type parameter extending ServiceConfigurationOptions
-     *
-     * @param {SDKClientConstructorV2<T, P>} Ctor - The constructor function for creating the aws sdk v2 client
-     * @param {P} current_config - The initial configuration options for the client
-     *
-     * @returns {T} An instance of the input sdk v2 client
-     */
-    v2: <T extends Service, P extends ServiceConfigurationOptions>(
-        Ctor: SDKClientConstructorV2<T, P>,
-        current_config: P
-    ) => T
-} /**
- * Creates an instance of the SDK v3 client whose constructor is given as input parameter.
- * This is the default behavior when calling the configurator directly.
+ * configurations (e.g. proxy settings) to be injected at runtime.
  *
  * @template T - Type parameter for the aws sdk v3 client
  * @template P - Type parameter for the configurations options
  *
- * @param {SDKClientConstructorV3<T, P>} Ctor - The constructor function for creating the aws sdk v3 client
- * @param {P} current_config - The initial configuration options for the client
- *
- * @returns {T} An instance of the input sdk v3 client
- */ & (<T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P) => T)
+ * @example
+ * const v3Client = sdkInitializator(MySdkV3Client, {
+ *     region: 'example_region',
+ *     endpoint: 'example_endpoint'
+ * });
+ */
+export type SDKInitializator = <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P) => T

--- a/runtimes/testing/TestFeatures.ts
+++ b/runtimes/testing/TestFeatures.ts
@@ -8,7 +8,6 @@ import {
     Chat,
     Runtime,
     Notification,
-    SDKClientConstructorV2,
     SDKClientConstructorV3,
     SDKInitializator,
     Agent,
@@ -30,8 +29,6 @@ import {
     InitializeParams,
 } from '../protocol'
 import { IdentityManagement } from '../server-interface/identity-management'
-import { Service } from 'aws-sdk'
-import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 
 /**
  * A test helper package to test Server implementations. Accepts a single callback
@@ -82,17 +79,8 @@ export class TestFeatures {
         this.runtime = stubInterface<Runtime>()
         this.identityManagement = stubInterface<IdentityManagement>()
         this.notification = stubInterface<Notification>()
-        this.sdkInitializator = Object.assign(
-            // Default callable function for v3 clients
-            <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T => new Ctor({ ...current_config }),
-            // Property for v2 clients
-            {
-                v2: <T extends Service, P extends ServiceConfigurationOptions>(
-                    Ctor: SDKClientConstructorV2<T, P>,
-                    current_config: P
-                ): T => new Ctor({ ...current_config }),
-            }
-        )
+        this.sdkInitializator = <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T =>
+            new Ctor({ ...current_config })
         this.workspace.getTextDocument.callsFake(async uri => this.documents[uri])
         this.workspace.getAllTextDocuments.callsFake(async () => Object.values(this.documents))
         this.agent = stubInterface<Agent>()


### PR DESCRIPTION
BREAKING CHANGE: removed v2 SDK support, updated to v3-only APIs

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
