### PR TITLE
feat: optional pending state for ContextCommand 

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -462,6 +462,7 @@ export interface ContextCommand extends QuickActionCommand {
     label?: 'file' | 'folder' | 'code' | 'image'
     children?: ContextCommandGroup[]
     content?: Uint8Array
+    disabledText?: string
 }
 
 export interface ContextCommandParams {


### PR DESCRIPTION
## Problem
In large workspaces, indexing can take a long time with no indication of status
## Solution
An optional pending flag is added to ContextCommand definition type. This allows a pending state to be indicated before the Context Command is sent to the client. The ui can then interpret this pending flag to grey out and disable the context command 
Should be merged before https://github.com/aws/mynah-ui/pull/421 and https://github.com/aws/language-servers/pull/2060  
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

**This pr is a replacement of the https://github.com/aws/language-server-runtimes/pull/652**

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
