### PR TITLE
chore: bump protobufjs from 7.5.5 to 7.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "overrides": {
         "cross-spawn": "^7.0.6",
         "prebuild-install": "^7.0.0",
-        "protobufjs": "^7.5.5",
+        "protobufjs": "^7.5.6",
         "node-forge": "^1.4.0"
     },
     "typesVersions": {


### PR DESCRIPTION
- Bumping protobufjs from 7.5.5 to 7.5.6 to fix https://github.com/aws/language-server-runtimes/security/dependabot
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
