### PR TITLE
ci: declare workflow-level contents: read on 2 CI workflows

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   license-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/runtimes-ci.yaml
+++ b/.github/workflows/runtimes-ci.yaml
@@ -5,6 +5,9 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
     test:
         name: Test


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.